### PR TITLE
Bump the time limit for loading supp content

### DIFF
--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -57,7 +57,7 @@ functions:
     environment:
       SUPPLEMENTARY_CONTENT_PATH: /var/task/guidance
     handler: populate_content.handler
-    timeout: 60
+    timeout: 300
 
 
 resources:


### PR DESCRIPTION
again, It takes roughly 3 min on a lambda, making the timeout 5 min.