### PR TITLE
Use make test.local to run cypress on M1 Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,7 @@ local.createadmin: ## Create a local admin account.
 
 test: ## run the cypress e2e suite
 	docker-compose -f docker-compose.yml -f docker-compose.e2e.yml up e2e
+test.local: ## run cypress tests locally without docker
+	cd e2e; \
+		npm install; \
+		npm run cypress:run;

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,2 +1,3 @@
 {
+  "baseUrl" : "http://localhost:8000"
 }

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "e2e",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
Since for now the cypress docker container does not work on M1 Macs
Cypress should be run locally.

`make test.local`

should install the npm dependencies for cypress and then run the test
suite.