### PR TITLE
adding in cloudfront invalidation to prod/val/dev deploys

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -44,6 +44,10 @@ custom:
     DB_NAME: eregs
     USERNAME: eregsuser
     ALLOWED_HOST: '.amazonaws.com'
+  cloudfrontInvalidate:
+    - distributionId: ${cf:cmcs-eregs-static-assets-${self:custom.stage}.CloudFrontDistributionId}
+      items:
+        - "/*"
 
 functions:
   reg_site:
@@ -232,3 +236,4 @@ plugins:
   - serverless-python-requirements
   - serverless-wsgi
   - serverless-go-plugin
+  - serverless-cloudfront-invalidate


### PR DESCRIPTION
Resolves #EREGCSC-1357

**Description-**

Invalidate cloudfront cache when releasing to dev/val/prod

**This pull request changes...**

- added plugin for cloudfront invalidation
- set custom value up so cloudfront invalidation knows the right stack to invalidate

**Steps to manually verify this change...**

release software to dev/val/prod and chack the logs to ensure cloudfront was invalidated (Should be listed at AWS as well)

