### PR TITLE
EREGCSC 1695: Docker upgrade and serverless file cleanup

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -187,38 +187,6 @@ resources:
     # Aurora DB
     # =============================================================================================
 
-    AuroraRDSClusterParameter:
-      Type: AWS::RDS::DBClusterParameterGroup
-      Properties:
-        Description: Parameter group for the Serverless Aurora RDS DB.
-        Family: aurora-postgresql12
-        Parameters:
-          rds.force_ssl: 1
-
-    AuroraRDSInstanceParameter:
-      Type: AWS::RDS::DBParameterGroup
-      Properties:
-        Description: Parameter group for the Serverless Aurora RDS DB.
-        Family: aurora-postgresql12
-        Parameters:
-          shared_preload_libraries: auto_explain,pg_stat_statements,pg_hint_plan,pgaudit
-          log_statement: "ddl"
-          log_connections: 1
-          log_disconnections: 1
-          log_lock_waits: 1
-          log_min_duration_statement: 5000
-          auto_explain.log_min_duration: 5000
-          auto_explain.log_verbose: 1
-          log_rotation_age: 1440
-          log_rotation_size: 102400
-          rds.log_retention_period: 10080
-          random_page_cost: 1
-          track_activity_query_size: 16384
-          idle_in_transaction_session_timeout: 7200000
-          statement_timeout: 7200000
-          search_path: '"$user",public'
-          pgaudit.role: "rds_pgaudit"
-          pgaudit.log: "ALL"
 
     AuroraRDSClusterParameter15:
       Type: AWS::RDS::DBClusterParameterGroup
@@ -253,70 +221,6 @@ resources:
           pgaudit.role: "rds_pgaudit"
           pgaudit.log: "ALL"
 
-    AuroraRDSClusterParameter14:
-      Type: AWS::RDS::DBClusterParameterGroup
-      Properties:
-        Description: Parameter group for the Serverless Aurora RDS DB.
-        Family: aurora-postgresql14
-        Parameters:
-          rds.force_ssl: 1
-
-    AuroraRDSInstanceParameter14:
-      Type: AWS::RDS::DBParameterGroup
-      Properties:
-        Description: Parameter group for the Serverless Aurora RDS DB.
-        Family: aurora-postgresql14
-        Parameters:
-          shared_preload_libraries: auto_explain,pg_stat_statements,pg_hint_plan,pgaudit
-          log_statement: "ddl"
-          log_connections: 1
-          log_disconnections: 1
-          log_lock_waits: 1
-          log_min_duration_statement: 5000
-          auto_explain.log_min_duration: 5000
-          auto_explain.log_verbose: 1
-          log_rotation_age: 1440
-          log_rotation_size: 102400
-          rds.log_retention_period: 10080
-          random_page_cost: 1
-          track_activity_query_size: 16384
-          idle_in_transaction_session_timeout: 7200000
-          statement_timeout: 7200000
-          search_path: '"$user",public'
-          pgaudit.role: "rds_pgaudit"
-          pgaudit.log: "ALL"
-
-    RDSResource:
-      Type: AWS::RDS::DBCluster
-      DeletionPolicy: Retain
-      Properties:
-        MasterUsername: ${self:custom.settings.USERNAME}
-        StorageEncrypted: true
-        MasterUserPassword: ${ssm:/eregulations/db/password}
-        DBSubnetGroupName:
-          Ref: DBSubnetGroup
-        Engine: aurora-postgresql
-        EngineVersion: "12.8"
-        DatabaseName: 'eregs'
-        BackupRetentionPeriod: 3
-        DBClusterParameterGroupName:
-          Ref: AuroraRDSClusterParameter
-        VpcSecurityGroupIds:
-          - !Ref 'DBSecurityGroup'
-    
-    AuroraRDSInstance:
-      Type: AWS::RDS::DBInstance
-      DeletionPolicy: Retain
-      Properties:
-        DBInstanceClass: db.r6g.large
-        StorageEncrypted: true
-        Engine: aurora-postgresql
-        EngineVersion: "12.8"
-        PubliclyAccessible: false
-        DBParameterGroupName:
-          Ref: AuroraRDSInstanceParameter
-        DBClusterIdentifier:
-          Ref: RDSResource
     RDSResource15:
       Type: AWS::RDS::DBCluster
       DeletionPolicy: Retain

--- a/solution/docker-compose.yml
+++ b/solution/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: postgres:12.8
+    image: postgres:15.2
     environment:
       POSTGRES_USER: eregs
       POSTGRES_PASSWORD: sgere


### PR DESCRIPTION
Resolves # EREGCSC-1695

**Description-**

Removes old database from serverless file(postgres 12) and updates docker file to postgres 15
**This pull request changes...**

- Docker file is updated to postgres 15
- Old database is removed from serverless file
- 

**Steps to manually verify this change...**

1. Remove docker container for existing database.  Rebuild it.  Should be posgres 15 
2. Upon deploy serverless will not build a new database for 12.

