### PR TITLE
EREGCSC-1865 - Updated org name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # About
 
-[![Actions Status](https://github.com/CMSgov/cmcs-eregulations/workflows/eCFR%20Parser%20Checks/badge.svg)](https://github.com/CMSgov/cmcs-eregulations/actions)
+[![Actions Status](https://github.com/Enterprise-CMCS/cmcs-eregulations/workflows/eCFR%20Parser%20Checks/badge.svg)](https://github.com/Enterprise-CMCS/cmcs-eregulations/actions)
 
 This is a project for the Center for Medicaid and CHIP Services (CMCS) to meet needs of CMCS and State staff researching regulations and related guidance, building on the [eRegulations](https://eregs.github.io/) open source project.
 
-We have public documentation about our product, design, and research processes in [this repository wiki](https://github.com/CMSgov/cmcs-eregulations/wiki).
+We have public documentation about our product, design, and research processes in [this repository wiki](https://github.com/Enterprise-CMCS/cmcs-eregulations/wiki).
 
 # Prerequisites
 
@@ -19,7 +19,7 @@ We have public documentation about our product, design, and research processes i
 ## Getting the code
 
 ```
-git clone https://github.com/cmsgov/cmcs-eregulations
+git clone https://github.com/Enterprise-CMCS/cmcs-eregulations
 ```
 ## Create your Dockerfile
 


### PR DESCRIPTION
Part of resolving #EREGCSC-1865

**Description**

This repository was previously in the CMSGov organization, and we moved it to the Enterprise-CMCS organization. The old links should auto-redirect, but I updated our links in our readme to reduce any potential confusion.

**Steps to manually verify this change...**

Look at the readme and ensure the links work.