### PR TITLE
update code to use site_name as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ git clone https://github.com/Enterprise-CMCS/cmcs-eregulations
 
 ```
 cd solution
-cp DockerFile.template DockerFile
+cp Dockerfile.template Dockerfile
 ```
 - Update the dockerfile with correct environment variables values
 ## Running eRegs

--- a/solution/Dockerfile.template
+++ b/solution/Dockerfile.template
@@ -11,6 +11,7 @@ RUN pip install --no-cache-dir --upgrade pip setuptools \
     && pip install -r requirements.txt
 
 ENV SEARCHGOV_KEY=""
+ENV SEARCHGOV_SITE_NAME=""
 
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
 

--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -93,7 +93,7 @@ STATIC_URL = os.environ.get("STATIC_URL", None)
 STATIC_ROOT = os.environ.get("STATIC_ROOT", None)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DEBUG", True)
+DEBUG = os.environ.get("DEBUG", False)
 
 WORKING_DIR = os.environ.get("WORKING_DIR", "/var/lib/eregs")
 TEMPLATES = [

--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -93,7 +93,7 @@ STATIC_URL = os.environ.get("STATIC_URL", None)
 STATIC_ROOT = os.environ.get("STATIC_ROOT", None)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DEBUG", False)
+DEBUG = os.environ.get("DEBUG", True)
 
 WORKING_DIR = os.environ.get("WORKING_DIR", "/var/lib/eregs")
 TEMPLATES = [

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -65,6 +65,7 @@ class ResourceSearchViewSet(viewsets.ModelViewSet):
         if "errors" in gov_results or (gov_results["web"]["total"] == 0 and not gov_results["web"]["results"]):
             raise NotFound("Invalid page")
         results = []
+
         for gov_result in gov_results['web']['results']:
             results.append({
                 'name': gov_result['title'],
@@ -78,9 +79,11 @@ class ResourceSearchViewSet(viewsets.ModelViewSet):
 
     def get_gov_results(self, query, page):
         key = os.environ.get('SEARCHGOV_KEY')
+        site_name = os.environ.get('SEARCHGOV_SITE_NAME')
+
         offset = (page - 1) * self.limit
 
-        rstring = f'https://search.usa.gov/api/v2/search/?affiliate=reg-pilot-cms-test&access_key={key}' \
+        rstring = f'https://search.usa.gov/api/v2/search/?affiliate={site_name}&access_key={key}' \
                   f'&query={urlparse.quote_plus(query)}&limit={self.limit}&offset={offset}'
         gov_results = json.loads(requests.get(rstring).text)
         self.format_gov_results(gov_results)

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -27,6 +27,7 @@ provider:
     CUSTOM_URL: ${ssm:/eregulations/custom_url, ''}
     SURVEY_URL: ${ssm:/eregulations/survey_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
+    SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -30,6 +30,7 @@ provider:
     CUSTOM_URL: ${ssm:/eregulations/custom_url}
     SURVEY_URL: ${ssm:/eregulations/survey_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
+    SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
   tracing:
     apiGateway: true
   vpc:


### PR DESCRIPTION
Resolves #site_name needs to be passed for prod thats different from dev

**Note**
This ticket is a blocker for [EREGCSC-1878](https://jiraent.cms.gov/browse/EREGCSC-1878) . 

**Description-**
We have created a production search.gov site and plan to use the other as a sandbox. The production site has its own key and sitename. The previous pull request did not take into account that on prod, and val the sitename is different
**This pull request changes...**

- expected change 4
-  yml files that set the environment variables in serverless. 
- code to reference the environment variable instead of hard coded site name
- updated Dockerfile template that requires to add the site_name as a environment variable locally

**Steps to manually verify this change...**

1. steps to view and verify change
visit [experimental page](https://q3yulgc3qi.execute-api.us-east-1.amazonaws.com/dev816/search/?q=covid&search.gov) notice that the search returns results.
On val do the same test to ensure it still works before going to prod. 

