### PR TITLE
EREGCSC1879- Adding Title to Part name on reg sear

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/components/search/RegResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/search/RegResults.vue
@@ -54,7 +54,7 @@ const createResultLink = (
         <template v-for="(result, i) in results">
             <ResultsItem :key="i">
                 <template #context>
-                    {{ partDocumentTitleLabel(result.part_title) }}
+                    {{result.title}} CFR {{ partDocumentTitleLabel(result.part_title) }}
                 </template>
                 <template #link>
                     <a


### PR DESCRIPTION
Resolves #EREGCSC-1879

**Description-**

Adding title to part name on regulations search
**This pull request changes...**

- On regulations search the part name for each result should have the title name in it.  Ex.  42 CFR Part 441 - Services: Requirements And Limits Applicable To Specific Services
**Steps to manually verify this change...**

1. Make a regulations search
2. Title number cfr should be in the part search results

