### PR TITLE
EREGCSC-1845 Implement linking directly to SSA paragraphs

### DIFF
--- a/solution/backend/regulations/templatetags/link_statutes.py
+++ b/solution/backend/regulations/templatetags/link_statutes.py
@@ -16,6 +16,9 @@ SECTION_ID_PATTERN = r"\d+[a-z]?(?:-+[a-z0-9]+)?"
 # Matches ", and", ", or", "and", "or", "&", and more variations.
 AND_OR_PATTERN = r"(?:,?\s*(?:and|or|\&)?\s*)?"
 
+# Extracts a paragraph identifier (e.g. (a) extracts "a").
+PARAGRAPH_PATTERN = r"\(([a-z0-9]+)\)"
+
 # Matches individual sections, for example "Section 1902(a)(2) and (b)(1)" and its variations.
 SECTION_PATTERN = rf"{SECTION_ID_PATTERN}(?:{AND_OR_PATTERN}\([a-z0-9]+\))*"
 
@@ -25,28 +28,21 @@ SECTION_PATTERN = rf"{SECTION_ID_PATTERN}(?:{AND_OR_PATTERN}\([a-z0-9]+\))*"
 STATUTE_REF_PATTERN = rf"\bsect(?:ion[s]?|s?)\.?\s*((?:{SECTION_PATTERN}{AND_OR_PATTERN})+)"\
                       r"(?:\s*of\s*the\s*([a-z0-9\s]*?(?=\bact\b)))?"
 
-# Matches chains of paragraphs, for example in "Section 1902(a)(1)(C)", "(a)(1)(C)" will match.
-LINKED_PARAGRAPH_PATTERN = r"((?:\([a-z0-9]+\))+)"
-
-# Extracts paragraph identifiers. Running findall() on "(a)(1)(C)" returns ["a", "1", "C"].
-PARAGRAPH_PATTERN = r"\(([a-z0-9]+)\)"
-
 # Regex's are precompiled to improve page load time.
 SECTION_ID_REGEX = re.compile(rf"({SECTION_ID_PATTERN})", re.IGNORECASE)
 SECTION_REGEX = re.compile(rf"({SECTION_PATTERN})", re.IGNORECASE)
 STATUTE_REF_REGEX = re.compile(STATUTE_REF_PATTERN, re.IGNORECASE)
-LINKED_PARAGRAPH_REGEX = re.compile(LINKED_PARAGRAPH_PATTERN, re.IGNORECASE)
 PARAGRAPH_REGEX = re.compile(PARAGRAPH_PATTERN, re.IGNORECASE)
 
 # The act to use if none is specified, for example "section 1902 of the act" defaults to this.
 DEFAULT_ACT = "Social Security Act"
 
 
-# Returns a list containing the first paragraph chain in a section ref.
-# For example, if the section text is "Section 1902(a)(1)(C) and (b)(2)", this will return ["a", "1", "C"].
-def extract_paragraphs(section_text):
-    linked_paragraphs = LINKED_PARAGRAPH_REGEX.search(section_text)  # extract the first paragraph chain (e.g. (a)(1)(c)...)
-    return PARAGRAPH_REGEX.findall(linked_paragraphs.group()) if linked_paragraphs else None
+# Returns the first paragraph identifier in the section.
+# For example, if the section text is "Section 1902(a)(1)(C) and (b)(2)", this will return "a".
+def extract_paragraph(section_text):
+    match = PARAGRAPH_REGEX.search(section_text)
+    return match.group(1) if match else None
 
 
 # This function is run by re.sub() to replace individual section refs with links.
@@ -56,12 +52,12 @@ def replace_section(section, act, link_conversions):
     section = SECTION_ID_REGEX.match(section_text).group()  # extract section
     # only link if section exists within the relevant act
     if act in link_conversions and section in link_conversions[act]:
-        paragraphs = extract_paragraphs(section_text)
+        paragraph = extract_paragraph(section_text)
         conversion = link_conversions[act][section]
         return USCODE_LINK_FORMAT.format(
             conversion["title"],
             conversion["usc"],
-            USCODE_SUBSTRUCT_FORMAT.format("_".join(paragraphs)) if paragraphs else "",
+            USCODE_SUBSTRUCT_FORMAT.format(paragraph) if paragraph else "",
             section_text,
         )
     return section_text

--- a/solution/backend/regulations/tests/fixtures/section_link_tests.json
+++ b/solution/backend/regulations/tests/fixtures/section_link_tests.json
@@ -1,0 +1,57 @@
+[
+    {
+        "testing": "a single link with no act",
+        "input": "Section 123(a) of the Act",
+        "expected": "Section <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the Act"
+    },
+    {
+        "testing": "two links within one statute ref",
+        "input": "section 123(a)(1)(C) and 456(b)(2) of the Social Security Act",
+        "expected": "section <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)(1)(C)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_b\">456(b)(2)</a> of the Social Security Act"
+    },
+    {
+        "testing": "multiple comma-separated paragraph refs",
+        "input": "section 123(a)(1)(C), (b)(1), and (b)(2) of the act",
+        "expected": "section <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)(1)(C), (b)(1), and (b)(2)</a> of the act"
+    },
+    {
+        "testing": "multiple paragraphs and sections in the same ref",
+        "input": "sections 123(a)(1)(C), (b)(1), and (b)(2) and 456(a)(1) and (b)(1) and 456(f) or (g).",
+        "expected": "sections <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)(1)(C), (b)(1), and (b)(2)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_a\">456(a)(1) and (b)(1)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_f\">456(f) or (g)</a>."
+    },
+    {
+        "testing": "all variations of paragraph separation",
+        "input": "section 123(a), (b), and (c) and (d), or (e) or (f)",
+        "expected": "section <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a), (b), and (c) and (d), or (e) or (f)</a>"
+    },
+    {
+        "testing": "all variations of section separation",
+        "input": "section 123(a), 456(b), and 123(c) and 456(d), or 123(e) or 456(f)",
+        "expected": "section <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_b\">456(b)</a>, and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_c\">123(c)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_d\">456(d)</a>, or <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_e\">123(e)</a> or <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_f\">456(f)</a>"
+    },
+    {
+        "testing": "case-insensitivity",
+        "input": "sEcTiOn 123(A) oF tHe aCt",
+        "expected": "sEcTiOn <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_A\">123(A)</a> oF tHe aCt"
+    },
+    {
+        "testing": "when a section is not found in the referenced act",
+        "input": "Section 1111(a) of the Social Security Act",
+        "expected": "Section 1111(a) of the Social Security Act"
+    },
+    {
+        "testing": "when one section is valid but another is not within the same act",
+        "input": "Section 1111(a) and 123(a) of the Act",
+        "expected": "Section 1111(a) and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the Act"
+    },
+    {
+        "testing": "when the section is valid but referencing the wrong act",
+        "input": "Section 123(a) of the Affordable Care Act",
+        "expected": "Section 123(a) of the Affordable Care Act"
+    },
+    {
+        "testing": "when the section is valid but not in the default act",
+        "input": "section 789 of the act",
+        "expected": "section 789 of the act"
+    }
+]

--- a/solution/backend/regulations/tests/test_statute_links.py
+++ b/solution/backend/regulations/tests/test_statute_links.py
@@ -108,87 +108,8 @@ class LinkStatutesTestCase(SimpleTestCase):
             },
         }
 
-        test_values = [
-            {
-                "testing": "a single link with no act",
-                "input": "Section 123(a) of the Act",
-                "expected": 'Section <a target="_blank" class="external" href="https://uscode.house.gov/view.xhtml?req=granuleid'
-                            ':USC-prelim-title42-sectionabc&num=0&edition=prelim">123(a)</a> of the Act',
-            },
-            {
-                "testing": "two links within one statute ref",
-                "input": "section 123(a)(1)(C) and 456(b)(2) of the Social Security Act",
-                "expected": 'section <a target="_blank" class="external" href="https://uscode.house.gov/view.xhtml?req=granuleid'
-                            ':USC-prelim-title42-sectionabc&num=0&edition=prelim">123(a)(1)(C)</a> and <a target="_blank" class='
-                            '"external" href="https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&nu'
-                            'm=0&edition=prelim">456(b)(2)</a> of the Social Security Act',
-            },
-            {
-                "testing": "multiple comma-separated paragraph refs",
-                "input": "section 123(a)(1)(C), (b)(1), and (b)(2) of the act",
-                "expected": 'section <a target="_blank" class="external" href="https://'
-                            'uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title'
-                            '42-sectionabc&num=0&edition=prelim">123(a)(1)(C), (b)(1), and (b)(2)</a> of the act',
-            },
-            {
-                "testing": "multiple paragraphs and sections in the same ref",
-                "input": "sections 123(a)(1)(C), (b)(1), and (b)(2) and 456(a)(1) and (b)(1) and 456(f) or (g).",
-                "expected": 'sections <a target="_blank" class="external" href="https://uscode.house.gov/view.xhtml?req=granuleid'
-                            ':USC-prelim-title42-sectionabc&num=0&edition=prelim">123(a)(1)(C), (b)(1), and (b)(2)</a> and <a tar'
-                            'get="_blank" class="external" href="https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-tit'
-                            'le43-sectiondef&num=0&edition=prelim">456(a)(1) and (b)(1)</a> and <a target="_blank" class="externa'
-                            'l" href="https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&editi'
-                            'on=prelim">456(f) or (g)</a>.',
-            },
-            {
-                "testing": "all variations of paragraph separation",
-                "input": "section 123(a), (b), and (c) and (d), or (e) or (f)",
-                "expected": 'section <a target="_blank" class="external" href="https://uscode.house.'
-                            'gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&editio'
-                            'n=prelim">123(a), (b), and (c) and (d), or (e) or (f)</a>',
-            },
-            {
-                "testing": "all variations of section separation",
-                "input": "section 123(a), 456(b), and 123(c) and 456(d), or 123(e) or 456(f)",
-                "expected": 'section <a target="_blank" class="external" href="https://uscode.house.gov/view.xhtml?req=granuleid'
-                            ':USC-prelim-title42-sectionabc&num=0&edition=prelim">123(a)</a>, <a target="_blank" class="external'
-                            '" href="https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&editi'
-                            'on=prelim">456(b)</a>, and <a target="_blank" class="external" href="https://uscode.house.gov/view.'
-                            'xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim">123(c)</a> and <a target="_'
-                            'blank" class="external" href="https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-'
-                            'sectiondef&num=0&edition=prelim">456(d)</a>, or <a target="_blank" class="external" href="https://u'
-                            'scode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim">123(e)'
-                            '</a> or <a target="_blank" class="external" href="https://uscode.house.gov/view.xhtml?req=granuleid'
-                            ':USC-prelim-title43-sectiondef&num=0&edition=prelim">456(f)</a>',
-            },
-            {
-                "testing": "case-insensitivity",
-                "input": "sEcTiOn 123(A) oF tHe aCt",
-                "expected": 'sEcTiOn <a target="_blank" class="external" href="https://uscode.house.gov/view.xhtml?req=granuleid'
-                            ':USC-prelim-title42-sectionabc&num=0&edition=prelim">123(A)</a> oF tHe aCt',
-            },
-            {
-                "testing": "when a section is not found in the referenced act",
-                "input": "Section 1111(a) of the Social Security Act",
-                "expected": "Section 1111(a) of the Social Security Act",
-            },
-            {
-                "testing": "when one section is valid but another is not within the same act",
-                "input": "Section 1111(a) and 123(a) of the Act",
-                "expected": 'Section 1111(a) and <a target="_blank" class="external" href="https://uscode.house.gov/view.xhtml?r'
-                            'eq=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim">123(a)</a> of the Act',
-            },
-            {
-                "testing": "when the section is valid but referencing the wrong act",
-                "input": "Section 123(a) of the Affordable Care Act",
-                "expected": "Section 123(a) of the Affordable Care Act",
-            },
-            {
-                "testing": "when the section is valid but not in the default act",
-                "input": "section 789 of the act",
-                "expected": "section 789 of the act",
-            },
-        ]
+        with open("regulations/tests/fixtures/section_link_tests.json", "r") as f:
+            test_values = json.load(f)
 
         for test in test_values:
             template = Template("{% load link_statutes %}{{ paragraph|link_statutes:link_conversions|safe }}")


### PR DESCRIPTION
Resolves #1845

**Description-**

To enhance the regulation reading experience, section links with paragraphs (e.g. 1902(a)) should link to that paragraph directly. Please note that this PR does not support deeply-nested paragraph links, and for now "Section 1902(a)(1)(C)" will link only to paragraph (a). This is due to the unreliable nature of generating links for any reference below the top level of a paragraph. See discussion in Jira for more info.

**This pull request changes...**

- Where a statute ref has a paragraph identifier, `#substructure-location_{paragraph}` is appended to the link.
- Tests are updated with this in mind.
- Test data is moved to a JSON file for better readability.

**Steps to manually verify this change...**

1. Navigate to a part in eRegs that has linked sections e.g. https://miwqeh3jyf.execute-api.us-east-1.amazonaws.com/dev827/42/430/Subpart-B/2017-01-20/#430-25
2. Find a section reference with a paragraph ID, and click to make sure it goes to the correct paragraph-level substructure.
3. Find a section without a paragraph ID and verify that `#substructure-location_...` is missing from the link.
4. Run unit tests to make sure link generation is working properly.

