### PR TITLE
EREGCSC-1882-db_not_being_removed_on_remove_experiment

### DIFF
--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -65,12 +65,7 @@ jobs:
           npm install serverless -g
           npm install
           # remove the database if its there. 
-          if aws rds describe-db-instances --db-instance-identifier eregs >/dev/null 2>&1; then
-            serverless invoke --config ./serverless-experimental.yml --function drop_database --stage dev${PR}
-            echo "database dropped successfully"
-          else
-            echo "database for dev${PR} was not found"
-          fi
+          serverless invoke --config ./serverless-experimental.yml --function drop_database --stage dev${PR}
           ~/work/cmcs-eregulations/cmcs-eregulations/.github/workflows/delete_cloudformation_stacks.sh cmcs-eregs-site-dev${PR} $PR "./serverless-experimental.yml"
           popd
       # Remove the static assets

--- a/solution/backend/cmcs_regulations/settings.py
+++ b/solution/backend/cmcs_regulations/settings.py
@@ -140,7 +140,15 @@ DATABASES = {
         'HOST': os.environ.get('DB_HOST', 'db'),
         'PORT': os.environ.get('DB_PORT', '5432'),
         'NAME': os.environ.get('DB_NAME', 'eregs'),
-    }
+    },
+    'postgres': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'USER': os.environ.get('DB_USER', 'eregs'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', 'sgere'),
+        'HOST': os.environ.get('DB_HOST', 'db'),
+        'PORT': os.environ.get('DB_PORT', '5432'),
+        'NAME': "postgres",
+    },
 }
 
 

--- a/solution/backend/dropdb.py
+++ b/solution/backend/dropdb.py
@@ -4,18 +4,16 @@ import os
 
 def handler(event, context):
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cmcs_regulations.settings")
-    import django
     django.setup()
 
-    from django.db import connection
     connection.ensure_connection()
-    try:
-        if not connection.is_usable():
-            raise Exception("database is unreachable")
-    except Exception as e:
-        print(e)
-
-    with connection.cursor() as cursor:
-        cursor.execute(f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{os.environ.get('STAGE', '')}'")
-        cursor.execute(f"DROP DATABASE {os.environ.get('STAGE', '')}")
-    print(f"Database {os.environ.get('STAGE', '')} has been removed")
+    if not connection.is_usable():
+        print("database is unreachable")
+    else:
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{os.environ.get('STAGE', '')}'")
+                cursor.execute(f"DROP DATABASE {os.environ.get('STAGE', '')}")
+                print(f"Database {os.environ.get('STAGE', '')} has been removed")
+        except Exception as e:
+            print(f"An error occurred while deleting the database: {str(e)}")

--- a/solution/backend/dropdb.py
+++ b/solution/backend/dropdb.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
-
+import django
+from django.db import connection
 
 def handler(event, context):
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cmcs_regulations.settings")

--- a/solution/backend/dropdb.py
+++ b/solution/backend/dropdb.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
+
 import os
+
 import django
-from django.db import connection
-from django.db.utils import OperationalError
+from django.db import connections
+from django.db.utils import ProgrammingError
 
 
 def handler(event, context):
@@ -10,17 +12,20 @@ def handler(event, context):
     django.setup()
 
     try:
+        connection = connections["postgres"]
+        connection.connect()
         connection.ensure_connection()
-    except OperationalError as e:
-        print(f"Failed to delete the database: {str(e)}")
-        quit()
-
-    if not connection.is_usable():
-        raise Exception("Database is unreachable")
-
-    with connection.cursor() as cursor:
-        db_name = os.environ.get('STAGE', '')
-        query = f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}'"
-        cursor.execute(query)
-        cursor.execute(f"DROP DATABASE {db_name}")
-        print(f"Database {db_name} has been removed")
+        if not connection.is_usable():
+            raise Exception("database connection is not usable")
+    except Exception as e:
+        raise Exception(f"Failed to connect to the database: {str(e)}")
+    
+    try:
+        with connection.cursor() as cursor:
+            db_name = os.environ.get('STAGE', '')
+            query = f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}'"
+            cursor.execute(query)
+            cursor.execute(f"DROP DATABASE {db_name}")
+            print(f"Database {db_name} has been removed")
+    except ProgrammingError as e:
+        print(f"Database was not deleted, most likely because it does not exist: {str(e)}")

--- a/solution/backend/dropdb.py
+++ b/solution/backend/dropdb.py
@@ -19,7 +19,7 @@ def handler(event, context):
             raise Exception("database connection is not usable")
     except Exception as e:
         raise Exception(f"Failed to connect to the database: {str(e)}")
-    
+
     try:
         with connection.cursor() as cursor:
             db_name = os.environ.get('STAGE', '')

--- a/solution/backend/dropdb.py
+++ b/solution/backend/dropdb.py
@@ -9,8 +9,11 @@ def handler(event, context):
 
     from django.db import connection
     connection.ensure_connection()
-    if not connection.is_usable():
-        raise Exception("database is unreachable")
+    try:
+        if not connection.is_usable():
+            raise Exception("database is unreachable")
+    except Exception as e:
+        print(e)
 
     with connection.cursor() as cursor:
         cursor.execute(f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{os.environ.get('STAGE', '')}'")

--- a/solution/backend/dropdb.py
+++ b/solution/backend/dropdb.py
@@ -3,6 +3,7 @@ import os
 import django
 from django.db import connection
 
+
 def handler(event, context):
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cmcs_regulations.settings")
     django.setup()
@@ -13,8 +14,10 @@ def handler(event, context):
     else:
         try:
             with connection.cursor() as cursor:
-                cursor.execute(f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{os.environ.get('STAGE', '')}'")
-                cursor.execute(f"DROP DATABASE {os.environ.get('STAGE', '')}")
-                print(f"Database {os.environ.get('STAGE', '')} has been removed")
+                db_name = os.environ.get('STAGE', '')
+                query = f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}'"
+                cursor.execute(query)
+                cursor.execute(f"DROP DATABASE {db_name}")
+                print(f"Database {db_name} has been removed")
         except Exception as e:
             print(f"An error occurred while deleting the database: {str(e)}")

--- a/solution/backend/dropdb.py
+++ b/solution/backend/dropdb.py
@@ -2,22 +2,25 @@
 import os
 import django
 from django.db import connection
+from django.db.utils import OperationalError
 
 
 def handler(event, context):
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cmcs_regulations.settings")
     django.setup()
 
-    connection.ensure_connection()
+    try:
+        connection.ensure_connection()
+    except OperationalError as e:
+        print(f"Failed to delete the database: {str(e)}")
+        quit()
+
     if not connection.is_usable():
-        print("database is unreachable")
-    else:
-        try:
-            with connection.cursor() as cursor:
-                db_name = os.environ.get('STAGE', '')
-                query = f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}'"
-                cursor.execute(query)
-                cursor.execute(f"DROP DATABASE {db_name}")
-                print(f"Database {db_name} has been removed")
-        except Exception as e:
-            print(f"An error occurred while deleting the database: {str(e)}")
+        raise Exception("Database is unreachable")
+
+    with connection.cursor() as cursor:
+        db_name = os.environ.get('STAGE', '')
+        query = f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}'"
+        cursor.execute(query)
+        cursor.execute(f"DROP DATABASE {db_name}")
+        print(f"Database {db_name} has been removed")


### PR DESCRIPTION
Resolves #EREGCSC-1882

**Description-**
DB not being removed on remove_experimental action

**This pull request changes...**
dropdb.py to not fail the entire removal just because the database is not there.
- expected change 2

**Steps to manually verify this change...**

1. create a pull request
2. close the pull request check that db is cleaned up properly. 
Connect to the database:
psql -h <hostname> -p 3306 -U <username> -d <databasename>  
(Note to find the hostname, username, database name. Go look at the lambda function configuration and use those values)
run \l 
You should see a list like this

![Screen Shot 2023-05-29 at 12 04 56 PM](https://github.com/Enterprise-CMCS/cmcs-eregulations/assets/7727136/a57f3324-857f-4252-a2da-bb55eb82985f)


Notice the database name dev829. 

Now close this pull request

You will notice your database connection is lost because you had signed into dev829 that is no longer there. You can sign in again with the dbname dev830 which is still open and do \l 
Notice dev829 is no longer there. 
![Screen Shot 2023-05-29 at 12 22 38 PM](https://github.com/Enterprise-CMCS/cmcs-eregulations/assets/7727136/cf82feaf-c8a3-4701-9a5b-da068fd07009)

Now reopen the ticket and check see if db is there. 

Delete the database and close the ticket to see if it continues to properly clean up the stack. 

Check cloudformation stack ensure that it has been properly removed

