### PR TITLE
EREGCSC-1913 - update the ticket to not test links for section histor…

### DIFF
--- a/solution/ui/e2e/cypress/e2e/api.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/api.spec.cy.js
@@ -35,7 +35,8 @@ const API_ENDPOINTS_V3 = [
     `/v3/resources/search?q=${SEARCH_TERM}`,
     `/v3/resources/supplemental_content`,
     `${SYNONYMS_ENDPOINT}${SYNONYM}`,
-    `/v3/title/${TITLE}/part/${PART}/history/section/${SECTION}`,
+    // Seems to time out and will be addressed in https://jiraent.cms.gov/browse/EREGCSC-1917
+    //`/v3/title/${TITLE}/part/${PART}/history/section/${SECTION}`,
     `/v3/title/${TITLE}/part/${PART}/version/${VERSION}`,
     `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/section/${SECTION}`,
     `/v3/title/${TITLE}/part/${PART}/version/${VERSION}/sections`,


### PR DESCRIPTION

 update the ticket to not test links for section history
Resolves #1913

**Description-**
Tests are failing because the section history endpoint is flakey and sometimes times out

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

run tests and see that it passes. 

