### PR TITLE
HOTFIX: Disable assertion that relies on changing data

### DIFF
--- a/solution/ui/e2e/cypress/e2e/part.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/part.spec.cy.js
@@ -162,9 +162,9 @@ describe("Part View", () => {
         cy.get(
             "#433-8 .reg-history-link-container .tooltip.clicked .tooltip-title"
         ).contains("View § 433.8 Effective In");
-        cy.get(
-            "#433-8 .reg-history-link-container .tooltip.clicked .gov-info-links a:nth-child(1)"
-        ).contains("2021");
+        //cy.get(
+            //"#433-8 .reg-history-link-container .tooltip.clicked .gov-info-links a:nth-child(1)"
+        //).contains("2021");
         cy.get(
             "#433-8 .reg-history-link-container .tooltip.clicked .gov-info-links a:nth-child(1)"
         )


### PR DESCRIPTION
Resolves failing Cypress assertion in `part.spec`

**Description**
We have an assertion that relies on data returned from an actual API call.  That data has changed -- it has been updated and includes a new value in the 0 index position of an array.  We should not assert on data that may change.

**This pull request changes:**

- Comments out assertion that relies on data that may change.

**Steps to manually verify this change:**

1. Make sure Cypress tests pass.

