### PR TITLE
EREGCSC-1940 Link statute refs to full paragraph depth

### DIFF
--- a/solution/backend/regulations/templatetags/link_statutes.py
+++ b/solution/backend/regulations/templatetags/link_statutes.py
@@ -16,9 +16,6 @@ SECTION_ID_PATTERN = r"\d+[a-z]?(?:-+[a-z0-9]+)?"
 # Matches ", and", ", or", "and", "or", "&", and more variations.
 AND_OR_PATTERN = r"(?:,?\s*(?:and|or|\&)?\s*)?"
 
-# Extracts a paragraph identifier (e.g. (a) extracts "a").
-PARAGRAPH_PATTERN = r"\(([a-z0-9]+)\)"
-
 # Matches individual sections, for example "Section 1902(a)(2) and (b)(1)" and its variations.
 SECTION_PATTERN = rf"{SECTION_ID_PATTERN}(?:{AND_OR_PATTERN}\([a-z0-9]+\))*"
 
@@ -28,21 +25,28 @@ SECTION_PATTERN = rf"{SECTION_ID_PATTERN}(?:{AND_OR_PATTERN}\([a-z0-9]+\))*"
 STATUTE_REF_PATTERN = rf"\bsect(?:ion[s]?|s?)\.?\s*((?:{SECTION_PATTERN}{AND_OR_PATTERN})+)"\
                       r"(?:\s*of\s*the\s*([a-z0-9\s]*?(?=\bact\b)))?"
 
+# Matches chains of paragraphs, for example in "Section 1902(a)(1)(C)", "(a)(1)(C)" will match.
+LINKED_PARAGRAPH_PATTERN = r"((?:\([a-z0-9]+\))+)"
+
+# Extracts paragraph identifiers. Running findall() on "(a)(1)(C)" returns ["a", "1", "C"].
+PARAGRAPH_PATTERN = r"\(([a-z0-9]+)\)"
+
 # Regex's are precompiled to improve page load time.
 SECTION_ID_REGEX = re.compile(rf"({SECTION_ID_PATTERN})", re.IGNORECASE)
 SECTION_REGEX = re.compile(rf"({SECTION_PATTERN})", re.IGNORECASE)
 STATUTE_REF_REGEX = re.compile(STATUTE_REF_PATTERN, re.IGNORECASE)
+LINKED_PARAGRAPH_REGEX = re.compile(LINKED_PARAGRAPH_PATTERN, re.IGNORECASE)
 PARAGRAPH_REGEX = re.compile(PARAGRAPH_PATTERN, re.IGNORECASE)
 
 # The act to use if none is specified, for example "section 1902 of the act" defaults to this.
 DEFAULT_ACT = "Social Security Act"
 
 
-# Returns the first paragraph identifier in the section.
-# For example, if the section text is "Section 1902(a)(1)(C) and (b)(2)", this will return "a".
-def extract_paragraph(section_text):
-    match = PARAGRAPH_REGEX.search(section_text)
-    return match.group(1) if match else None
+# Returns a list containing the first paragraph chain in a section ref.
+# For example, if the section text is "Section 1902(a)(1)(C) and (b)(2)", this will return ["a", "1", "C"].
+def extract_paragraphs(section_text):
+    linked_paragraphs = LINKED_PARAGRAPH_REGEX.search(section_text)  # extract the first paragraph chain (e.g. (a)(1)(c)...)
+    return PARAGRAPH_REGEX.findall(linked_paragraphs.group()) if linked_paragraphs else None
 
 
 # This function is run by re.sub() to replace individual section refs with links.
@@ -52,12 +56,12 @@ def replace_section(section, act, link_conversions):
     section = SECTION_ID_REGEX.match(section_text).group()  # extract section
     # only link if section exists within the relevant act
     if act in link_conversions and section in link_conversions[act]:
-        paragraph = extract_paragraph(section_text)
+        paragraphs = extract_paragraphs(section_text)
         conversion = link_conversions[act][section]
         return USCODE_LINK_FORMAT.format(
             conversion["title"],
             conversion["usc"],
-            USCODE_SUBSTRUCT_FORMAT.format(paragraph) if paragraph else "",
+            USCODE_SUBSTRUCT_FORMAT.format("_".join(paragraphs)) if paragraphs else "",
             section_text,
         )
     return section_text

--- a/solution/backend/regulations/tests/fixtures/section_link_tests.json
+++ b/solution/backend/regulations/tests/fixtures/section_link_tests.json
@@ -7,17 +7,17 @@
     {
         "testing": "two links within one statute ref",
         "input": "section 123(a)(1)(C) and 456(b)(2) of the Social Security Act",
-        "expected": "section <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)(1)(C)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_b\">456(b)(2)</a> of the Social Security Act"
+        "expected": "section <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a_1_C\">123(a)(1)(C)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_b_2\">456(b)(2)</a> of the Social Security Act"
     },
     {
         "testing": "multiple comma-separated paragraph refs",
         "input": "section 123(a)(1)(C), (b)(1), and (b)(2) of the act",
-        "expected": "section <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)(1)(C), (b)(1), and (b)(2)</a> of the act"
+        "expected": "section <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a_1_C\">123(a)(1)(C), (b)(1), and (b)(2)</a> of the act"
     },
     {
         "testing": "multiple paragraphs and sections in the same ref",
         "input": "sections 123(a)(1)(C), (b)(1), and (b)(2) and 456(a)(1) and (b)(1) and 456(f) or (g).",
-        "expected": "sections <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)(1)(C), (b)(1), and (b)(2)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_a\">456(a)(1) and (b)(1)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_f\">456(f) or (g)</a>."
+        "expected": "sections <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a_1_C\">123(a)(1)(C), (b)(1), and (b)(2)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_a_1\">456(a)(1) and (b)(1)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title43-sectiondef&num=0&edition=prelim#substructure-location_f\">456(f) or (g)</a>."
     },
     {
         "testing": "all variations of paragraph separation",


### PR DESCRIPTION
Resolves #1940

**Description-**

Now that the house.gov team has fixed the majority of their deeply-nested links, we can more reliably link to paragraphs like 1902(a)(1)(C) and so on.

**This pull request changes...**

- Textual links to deeply-nested substructures will link directly there instead of the top-level paragraph.
- Tests are updated.

**Steps to manually verify this change...**

1. Import statute link converters and verify they are linking to the correct depth
2. Run unit tests for regulations

