### PR TITLE
EREGCSC-1974 - Correct make file

### DIFF
--- a/solution/Makefile
+++ b/solution/Makefile
@@ -191,10 +191,10 @@ objects = resources.abstractcategory resources.category resources.subcategory re
 
 local.seed:
 	$(foreach object, $(objects), docker-compose exec regulations python manage.py loaddata $(object).json;) \
-	docker-compose exec regulations python manage.py loaddata search.synonym.json \
+	docker-compose exec regulations python manage.py loaddata search.synonym.json 
 	docker-compose exec regulations python manage.py loaddata regulations.statutelinkconverter.json
 
 local.dump:
 	$(foreach object, $(objects), docker-compose exec regulations python manage.py dumpdata $(object) --indent 4 > ./backend/resources/fixtures/$(object).json;) \
-	docker-compose exec regulations python manage.py dumpdata search.synonym --indent 4 > ./backend/regcore/search/fixtures/search.synonym.json \
+	docker-compose exec regulations python manage.py dumpdata search.synonym --indent 4 > ./backend/regcore/search/fixtures/search.synonym.json
 	docker-compose exec regulations python manage.py dumpdata regulations.statutelinkconverter --indent 4 > ./backend/regulations/fixtures/regulations.statutelinkconverter.json


### PR DESCRIPTION
Resolves # EREGCSC-1974

**Description-**
Make file had back slashes that caused issues.  This corrects it

**This pull request changes...**

- Allows the docker-compose commands to run properly

**Steps to manually verify this change...**

1. On your local, run "make local.seed".  There should be no errors
2. On your local run "make local.dump".  There should be no errors.

