### PR TITLE
Fix: programmatically get Resource Category IDs for "View More Guidance" link

### DIFF
--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -85,7 +85,7 @@ Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
                     <div class="resources__container">
                         <recent-resources
                             api-url={{ API_BASE }}
-                            resource-link='{% url 'resources' %}?resourceCategory=Subregulatory%20Guidance,State%20Medicaid%20Director%20Letter%20%28SMDL%29,State%20Health%20Official%20%28SHO%29%20Letter,CMCS%20Informational%20Bulletin%20%28CIB%29,Frequently%20Asked%20Questions%20%28FAQs%29,State%20Medicaid%20Manual%20%28SMM%29&sort=newest'
+                            resource-link='{% url 'resources' %}'
                             fr-doc-link='{% url 'resources' %}?resourceCategory={{ fr_docs_category_name }}'
                         />
                     </div>

--- a/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
@@ -6,6 +6,9 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
         cy.intercept("/**", (req) => {
             req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
         });
+        cy.intercept("**/v3/resources/categories", {
+            fixture: "categories.json",
+        }).as("categories");
         cy.intercept(
             "**/v3/resources/federal_register_docs?page=1&page_size=3&paginate=true",
             { fixture: "frdocs.json" }
@@ -229,6 +232,7 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
         cy.viewport("macbook-15");
         cy.visit("/");
         cy.get(".resources__container").should("exist");
+        cy.wait("@categories");
         cy.get(".recent-rules-descriptive-text")
             .first()
             .should(($el) => {
@@ -236,11 +240,13 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
                     "Includes 42 CFR 400, 430-460, 600, and 45 CFR 95"
                 );
             });
-        cy.get(".resources__container").contains("View More Guidance").click({ force: true });
+        cy.get(".resources__container")
+            .contains("View More Guidance")
+            .click({ force: true });
         cy.url().should(
             "eq",
             Cypress.config().baseUrl +
-                `/resources/?resourceCategory=Subregulatory%20Guidance,State%20Medicaid%20Director%20Letter%20%28SMDL%29,State%20Health%20Official%20%28SHO%29%20Letter,CMCS%20Informational%20Bulletin%20%28CIB%29,Frequently%20Asked%20Questions%20%28FAQs%29,State%20Medicaid%20Manual%20%28SMM%29&sort=newest`
+                "/resources/?resourceCategory=State%20Medicaid%20Director%20Letter%20%28SMDL%29,State%20Health%20Official%20%28SHO%29%20Letter,CMCS%20Informational%20Bulletin%20%28CIB%29,Frequently%20Asked%20Questions%20%28FAQs%29,Associate%20Regional%20Administrator%20%28ARA%29%20Memo,State%20Medicaid%20Manual%20%28SMM%29&sort=newest"
         );
     });
 
@@ -278,7 +284,9 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
                 });
         });
 
-        cy.get(".resources__container").contains("View More Changes").click({ force: true });
+        cy.get(".resources__container")
+            .contains("View More Changes")
+            .click({ force: true });
         cy.url().should(
             "eq",
             Cypress.config().baseUrl +

--- a/solution/ui/e2e/cypress/fixtures/categories.json
+++ b/solution/ui/e2e/cypress/fixtures/categories.json
@@ -1,0 +1,398 @@
+[
+    {
+        "id": 139,
+        "name": "Topic Briefs and Reports",
+        "description": "",
+        "order": 0,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 19,
+            "name": "Reports and Evaluations",
+            "description": "HHS, CMS, and ASPE policy analysis and research reports",
+            "order": 550,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 7,
+        "name": "State Medicaid Director Letter (SMDL)",
+        "description": "",
+        "order": 100,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 5,
+            "name": "Subregulatory Guidance",
+            "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+            "order": 400,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 12,
+        "name": "SPA Resources",
+        "description": "",
+        "order": 101,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 11,
+            "name": "Implementation Resources",
+            "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+            "order": 500,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 13,
+        "name": "Technical Assistance for States",
+        "description": "",
+        "order": 200,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 11,
+            "name": "Implementation Resources",
+            "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+            "order": 500,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 135,
+        "name": "HHS and CMS Reports to Congress",
+        "description": "",
+        "order": 200,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 19,
+            "name": "Reports and Evaluations",
+            "description": "HHS, CMS, and ASPE policy analysis and research reports",
+            "order": 550,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 3,
+        "name": "Related Statutes",
+        "description": "Statutes that relate to the subject matter of the subpart or section",
+        "order": 200,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "category"
+    },
+    {
+        "id": 6,
+        "name": "State Health Official (SHO) Letter",
+        "description": "",
+        "order": 200,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 5,
+            "name": "Subregulatory Guidance",
+            "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+            "order": 400,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 67,
+        "name": "Proposed and Final Rules",
+        "description": "Federal Register documents with agency policy proposals and decisions",
+        "order": 250,
+        "show_if_empty": false,
+        "is_fr_doc_category": true,
+        "type": "category"
+    },
+    {
+        "id": 9,
+        "name": "CMCS Informational Bulletin (CIB)",
+        "description": "",
+        "order": 300,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 5,
+            "name": "Subregulatory Guidance",
+            "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+            "order": 400,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 14,
+        "name": "Templates",
+        "description": "",
+        "order": 300,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 11,
+            "name": "Implementation Resources",
+            "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+            "order": 500,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 4,
+        "name": "Related Regulations",
+        "description": "Regulations outside the Subpart related to the subject matter",
+        "order": 300,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "category"
+    },
+    {
+        "id": 5,
+        "name": "Subregulatory Guidance",
+        "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+        "order": 400,
+        "show_if_empty": true,
+        "is_fr_doc_category": false,
+        "type": "category"
+    },
+    {
+        "id": 10,
+        "name": "Frequently Asked Questions (FAQs)",
+        "description": "",
+        "order": 400,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 5,
+            "name": "Subregulatory Guidance",
+            "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+            "order": 400,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 138,
+        "name": "Associate Regional Administrator (ARA) Memo",
+        "description": "",
+        "order": 450,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 5,
+            "name": "Subregulatory Guidance",
+            "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+            "order": 400,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 11,
+        "name": "Implementation Resources",
+        "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+        "order": 500,
+        "show_if_empty": true,
+        "is_fr_doc_category": false,
+        "type": "category"
+    },
+    {
+        "id": 15,
+        "name": "Toolkits",
+        "description": "",
+        "order": 500,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 11,
+            "name": "Implementation Resources",
+            "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+            "order": 500,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 8,
+        "name": "State Medicaid Manual (SMM)",
+        "description": "",
+        "order": 500,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 5,
+            "name": "Subregulatory Guidance",
+            "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+            "order": 400,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 133,
+        "name": "Informational Summaries",
+        "description": "Overview pages from HHS and CMS",
+        "order": 520,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "category"
+    },
+    {
+        "id": 25,
+        "name": "OIG Reports",
+        "description": "",
+        "order": 550,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 23,
+            "name": "Oversight Reports",
+            "description": "Reports from HHS Office of Inspector General and U.S. Government Accountability Office",
+            "order": 600,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 19,
+        "name": "Reports and Evaluations",
+        "description": "HHS, CMS, and ASPE policy analysis and research reports",
+        "order": 550,
+        "show_if_empty": true,
+        "is_fr_doc_category": false,
+        "type": "category"
+    },
+    {
+        "id": 16,
+        "name": "Waiver Resources",
+        "description": "",
+        "order": 600,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 11,
+            "name": "Implementation Resources",
+            "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+            "order": 500,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 23,
+        "name": "Oversight Reports",
+        "description": "Reports from HHS Office of Inspector General and U.S. Government Accountability Office",
+        "order": 600,
+        "show_if_empty": true,
+        "is_fr_doc_category": false,
+        "type": "category"
+    },
+    {
+        "id": 24,
+        "name": "GAO Reports",
+        "description": "",
+        "order": 601,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 23,
+            "name": "Oversight Reports",
+            "description": "Reports from HHS Office of Inspector General and U.S. Government Accountability Office",
+            "order": 600,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 134,
+        "name": "Appeals Decisions",
+        "description": "HHS Departmental Appeals Board",
+        "order": 650,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "category"
+    },
+    {
+        "id": 17,
+        "name": "Terms",
+        "description": "Key abbreviations and definitions",
+        "order": 700,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "category"
+    },
+    {
+        "id": 69,
+        "name": "Other Reports",
+        "description": "",
+        "order": 900,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 23,
+            "name": "Oversight Reports",
+            "description": "Reports from HHS Office of Inspector General and U.S. Government Accountability Office",
+            "order": 600,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    },
+    {
+        "id": 68,
+        "name": "Other Resources",
+        "description": "",
+        "order": 900,
+        "show_if_empty": false,
+        "is_fr_doc_category": false,
+        "type": "subcategory",
+        "parent": {
+            "id": 11,
+            "name": "Implementation Resources",
+            "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+            "order": 500,
+            "show_if_empty": true,
+            "is_fr_doc_category": false,
+            "type": ""
+        }
+    }
+]

--- a/solution/ui/regulations/eregs-component-lib/src/components/RecentChangesContainer.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/RecentChangesContainer.vue
@@ -34,7 +34,7 @@ export default {
     },
 
     async created() {
-        if (_isNull(this.categories)) {
+        if (this.type !== "supplemental") {
             this.getRules();
         }
     },
@@ -69,7 +69,7 @@ export default {
 
     watch: {
         async categories(newCats, oldCats) {
-            if (oldCats === null) {
+            if (_isNull(oldCats)) {
                 this.getRules({ categories: newCats });
             }
         },

--- a/solution/ui/regulations/eregs-component-lib/src/components/RecentResources.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/RecentResources.vue
@@ -30,13 +30,26 @@ export default {
                     : []
             )
             .join("");
+
+        this.categoryNames = categoriesResult
+            .flatMap((cat) =>
+                cat.parent?.name === "Subregulatory Guidance" ? cat.name : []
+            )
+            .join(",");
     },
 
     data() {
         return {
             tab: null,
             categories: null,
+            categoryNames: null,
         };
+    },
+
+    computed: {
+        moreGuidanceLink() {
+            return `${this.resourceLink}?resourceCategory=${this.categoryNames}&sort=newest`;
+        },
     },
 
     components: {
@@ -61,7 +74,7 @@ export default {
                     :categories="categories"
                     type="supplemental"
                 ></RecentChangesContainer>
-                <a :href="resourceLink" class="action-btn default-btn link-btn"
+                <a :href="moreGuidanceLink" class="action-btn default-btn link-btn"
                     >View More Guidance</a
                 >
             </v-tab-item>

--- a/solution/ui/regulations/eregs-component-lib/src/components/RecentResources.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/RecentResources.vue
@@ -1,4 +1,6 @@
 <script>
+import { getCategories } from "utilities/api";
+
 import RecentChangesContainer from "./RecentChangesContainer.vue";
 
 export default {
@@ -18,11 +20,25 @@ export default {
             required: true,
         },
     },
+
+    async created() {
+        const categoriesResult = await getCategories(this.apiUrl);
+        this.categories = categoriesResult
+            .flatMap((cat) =>
+                cat.parent?.name === "Subregulatory Guidance"
+                    ? `&categories=${cat.id}`
+                    : []
+            )
+            .join("");
+    },
+
     data() {
         return {
             tab: null,
+            categories: null,
         };
     },
+
     components: {
         RecentChangesContainer,
     },
@@ -42,6 +58,7 @@ export default {
                 </p>
                 <RecentChangesContainer
                     :api-url="apiUrl"
+                    :categories="categories"
                     type="supplemental"
                 ></RecentChangesContainer>
                 <a :href="resourceLink" class="action-btn default-btn link-btn"


### PR DESCRIPTION
Resolves issue where Subregulatory Guidance category names were hard coded in the "View More Guidance" link, resulting in a missing category (ARA Memos) and incomplete results on the Resources page when clicking "View More Guidance."

**Description:**

On the new homepage, the "Recent Subregulatory Guidance" tab shows items that are part of a Subregulatory Guidance subcategory.  Examples of these subcategories include: FAQs, CIBe, SMDLs, etc.

We are already programmatically getting the IDs for each of these subcategories so that the home page will display only items that are part of a Subregulatory Guidance subcategory.

See [this commit](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/844/commits/2b0e32d8f23675afb9bbdf722771123fc0f0c171) for more information on how this was accomplished.

Unfortunately, the "View More Guidance" link at the bottom of the Recent Subregulatory Guidance tab on the homepage is also using hardcoded subcategory names.

This is an issue because `prod` has more Subregulatory Guidance subcategories than our `dev` and `val` environments.  Specifically, it has a subcategory named "Associate Regional Administrator (ARA) Memo".  This subcategory that is unique to the `prod` environment was not included in the hard coded "View More Guidance" link, so when a user clicks the link and is taken to the Resources page, they would not be shown any items that have the ARA memo subcategory.

**This pull request changes:**

- Moves `getCategories` API call that fetches and parses categories up from `<RecentChangesContainer />` to its parent: `<RecentResources />` container component
- programmatically creates `moreGuidanceLink` prop that includes all Subregulatory Guidance subcategories that were fetched from the `getCategories` call.  No more hard coding the URL params for this link
- refactors `<RecentChangesContainer />` a bit to accommodate this new logic/organization

**Steps to manually verify this change:**

1. Make sure all tests pass
2. Make sure homepage works as expected on local and experimental deployment
3. Make sure "View More Guidance" link takes you to the resources page with all Subregulatory Guidance subcategories selected as filter chips
