### PR TITLE
EREGCSC-2002 Fix statute endpoint ordering

### DIFF
--- a/solution/backend/regulations/tests/fixtures/statute_link_api_test.json
+++ b/solution/backend/regulations/tests/fixtures/statute_link_api_test.json
@@ -1,15 +1,5 @@
 [
     {
-        "section": "11111",
-        "title": 45,
-        "usc": "12345",
-        "act": "Social Security Act",
-        "name": "Something",
-        "statute_title": 1,
-        "statute_title_roman": "I",
-        "source_url": "https://test.gov/test2.xml"
-    },
-    {
         "section": "10211",
         "title": 42,
         "usc": "18201",
@@ -18,6 +8,16 @@
         "statute_title": 10,
         "statute_title_roman": "X",
         "source_url": "https://test.gov/test.xml"
+    },    
+    {
+        "section": "11111",
+        "title": 45,
+        "usc": "12345",
+        "act": "Social Security Act",
+        "name": "Something",
+        "statute_title": 1,
+        "statute_title_roman": "I",
+        "source_url": "https://test.gov/test2.xml"
     },
     {
         "section": "7890",

--- a/solution/backend/regulations/tests/test_statute_links.py
+++ b/solution/backend/regulations/tests/test_statute_links.py
@@ -142,11 +142,13 @@ class StatuteConvertersAPITestCase(APITestCase):
     def setUp(self):
         with open("regulations/tests/fixtures/statute_link_api_test.json", "r") as f:
             self.objects = json.load(f)
-            for i in self.objects:
-                roman = i["statute_title_roman"]
-                del i["statute_title_roman"]
-                StatuteLinkConverter.objects.create(**i)
-                i["statute_title_roman"] = roman
+            # Objects are inserted in reverse order to ensure endpoint ordering is correct
+            for i in range(len(self.objects)-1, -1, -1):
+                obj = self.objects[i]
+                roman = obj["statute_title_roman"]
+                del obj["statute_title_roman"]
+                StatuteLinkConverter.objects.create(**obj)
+                obj["statute_title_roman"] = roman
 
     def test_all_statutes(self):
         response = self.client.get("/v3/statutes")
@@ -156,12 +158,12 @@ class StatuteConvertersAPITestCase(APITestCase):
     def test_aca(self):
         response = self.client.get("/v3/statutes?act=Affordable Care Act")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(response.data, self.objects[1:2])
+        self.assertEqual(response.data, self.objects[0:1])
 
     def test_ssa(self):
         response = self.client.get("/v3/statutes?act=Social Security Act")
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(response.data, self.objects[0:1] + self.objects[2:4])
+        self.assertEqual(response.data, self.objects[1:4])
 
     def test_act_and_title(self):
         response = self.client.get("/v3/statutes?act=Social Security Act&title=3")

--- a/solution/backend/regulations/views/statutes.py
+++ b/solution/backend/regulations/views/statutes.py
@@ -38,7 +38,7 @@ class StatuteLinkConverterViewSet(viewsets.ReadOnlyModelViewSet):
             queryset = queryset.filter(act__iexact=act)
         if title:
             queryset = queryset.filter(statute_title__iexact=title)
-        return queryset
+        return queryset.order_by("act", "statute_title")
 
 
 class ActListSerializer(serializers.Serializer):


### PR DESCRIPTION
Resolves #2002

**Description-**

I forgot to actually do ordering on the statute endpoint. This PR implements it. The tests that I wrote should have caught it, but didn't, so I modified it to insert the test objects in the reverse order so that it is guaranteed to fail if ordering isn't working.

**This pull request changes...**

- Add ordering to statute endpoint
- Update test to check for this

**Steps to manually verify this change...**

1. Check `/v3/statutes` and make sure objects are ordered by act name, then statute title respectively.
2. Run unit tests. If you want proof, go to `backend/regulations/views/statutes.py` and remove `.order_by("act", "statute_title")` on line 41. Then run the test again and it will fail.

