### PR TITLE
EREGCSC-1988 Link to citations when section symbol is used instead of the word "section"

### DIFF
--- a/solution/backend/regulations/templatetags/link_statutes.py
+++ b/solution/backend/regulations/templatetags/link_statutes.py
@@ -29,7 +29,7 @@ SECTION_PATTERN = rf"{SECTION_ID_PATTERN}(?:{AND_OR_PATTERN}\([a-z0-9]+\))*"
 # Matches entire statute references, including one or more sections and an optional Act.
 # For example, "Sections 1902(a)(2) and (b)(1) and 1903(b) of the Social Security Act" and its variations.
 # Will also match "Section 1902" if the section is contained within the DEFAULT_ACT. See tests for more complete examples.
-STATUTE_REF_PATTERN = rf"\bsect(?:ion[s]?|s?)\.?\s*((?:{SECTION_PATTERN}{AND_OR_PATTERN})+)"\
+STATUTE_REF_PATTERN = rf"(?:\bsec(?:tions?|t?s?)?|§|&#xA7;)\.?\s*((?:{SECTION_PATTERN}{AND_OR_PATTERN})+)"\
                       r"(?:\s*of\s*the\s*([a-z0-9\s]*?(?=\bact\b)))?"
 
 # Matches chains of paragraphs, for example in "Section 1902(a)(1)(C)", "(a)(1)(C)" will match.

--- a/solution/backend/regulations/tests/fixtures/section_link_tests.json
+++ b/solution/backend/regulations/tests/fixtures/section_link_tests.json
@@ -93,5 +93,20 @@
         "testing": "section refs not starting with a number",
         "input": "42 U.S.C. A1234",
         "expected": "42 U.S.C. A1234"
+    },
+    {
+        "testing": "variations of word 'section'",
+        "input": "Section 123(a) of the Act, sections 123(a), section. 123(a), sections. 123(a), sec. 123(a), secs. 123(a), sec 123(a), secs 123(a), sect. 123(a), sects. 123(a), sects 123(a), sects 123(a)",
+        "expected": "Section <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the Act, sections <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, section. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, sections. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, sec. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, secs. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, sec <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, secs <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, sect. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, sects. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, sects <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>, sects <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a>"
+    },
+    {
+        "testing": "section symbol instead of word 'section'",
+        "input": "§ 123(a) of the Act. §. 123(a) of the Act. &#xA7; 123(a) of the act. &#xA7;. 123(a) of the act.",
+        "expected": "§ <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the Act. §. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the Act. &#xA7; <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the act. &#xA7;. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the act."
+    },
+    {
+        "testing": "proper word boundaries",
+        "input": "intersection 123(a) of the act. intersects 123(a). intersect 123(a). And it intersects. 123(a) of the act states that.",
+        "expected": "intersection 123(a) of the act. intersects 123(a). intersect 123(a). And it intersects. 123(a) of the act states that."
     }
 ]


### PR DESCRIPTION
Resolves #1988

**Description-**

Some statute refs use "§" (or worse, unicode HTML `&#xA7;`) instead of the word "section" and its variations. This PR handles that as well as adds more edge cases.

**This pull request changes...**

- `§ 1903` will now match.
- `Sec. 1903` will also match.
- Additional edge cases should also be covered, with variations in spacing, plurality, and punctuation. 

**Steps to manually verify this change...**

1. Check `/42/431/Subpart-A/2023-01-01/#431-15`. "Sec." ref should be linked.
2. Check `/45/75/Subpart-B/2021-11-15/#75-101-e-1-v`. "§" ref should be linked.
3. Run unit tests.

