### PR TITLE
EREGCSC-1941 -- Fix Firefox / macOS Venture bug in Jump To

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_jump_to.scss
+++ b/solution/ui/regulations/css/scss/partials/_jump_to.scss
@@ -96,11 +96,7 @@ form .jump-to-input {
 
     input#jumpToSection {
         margin-right: 10px;
-        width: 80px;
-
-        @include custom-max(($eds-width-md - 1) / 1px) {
-            width: 70px;
-        }
+        width: 70px;
 
         @include custom-max(($eds-width-sm - 1) / 1px) {
             width: 60px;


### PR DESCRIPTION
Resolves [EREGCSC-1941](https://jiraent.cms.gov/browse/EREGCSC-1941)

**Description:**

On Firefox, and specifically on macOS Venture, the Jump To in the header breaks and overflows onto the next line between 1024px and 1034px screen widths

**This pull request changes:**

- Trims Jump To's section `input` by 10px at screen widths greater than 780px

**Steps to manually verify this change:**

1. Open Firefox on your macOS Venture machine
2. Reproduce the bug on the `prod` site at [https://regulations-pilot.cms.gov/](https://regulations-pilot.cms.gov/)
3. Visit the experimental deployment for this PR on the same machine and attempt to reproduce the bug

