### PR TITLE
Fix negative lookahead to include CFR in ignored list

### DIFF
--- a/solution/backend/regulations/templatetags/link_statutes.py
+++ b/solution/backend/regulations/templatetags/link_statutes.py
@@ -113,8 +113,9 @@ def replace_sections(match, link_conversions):
 # This pattern matches USC citations such as "42 U.S.C. 1901(a)", "42 U.S.C. 1901(a) or (b)",
 # "42 U.S.C. 1901(a) and 1902(b)" and more variations, similar to STATUTE_REF_PATTERN.
 # Negative lookahead ensures "42 U.S.C. 1234 and 41 U.S.C. 4567" doesn't register "1234" and "41" as two sections in one ref.
-USC_PATTERN = r"\s*u.?\s*s.?\s*c.?\s*"
-USC_REF_PATTERN = rf"(\d+){USC_PATTERN}((?:{SECTION_PATTERN}{AND_OR_PATTERN}(?!\d+{USC_PATTERN}))+)"
+USC_PATTERN = r"u.?\s*s.?\s*c.?"
+IGNORE_PATTERN = rf"\d+\s*(?:{USC_PATTERN}|c.?\s*f.?\s*r.?)\s*"
+USC_REF_PATTERN = rf"(\d+)\s*{USC_PATTERN}\s*((?:{SECTION_PATTERN}{AND_OR_PATTERN}(?!{IGNORE_PATTERN}))+)"
 USC_REF_REGEX = re.compile(USC_REF_PATTERN, re.IGNORECASE)
 
 

--- a/solution/backend/regulations/tests/fixtures/section_link_tests.json
+++ b/solution/backend/regulations/tests/fixtures/section_link_tests.json
@@ -108,5 +108,10 @@
         "testing": "proper word boundaries",
         "input": "intersection 123(a) of the act. intersects 123(a). intersect 123(a). And it intersects. 123(a) of the act states that.",
         "expected": "intersection 123(a) of the act. intersects 123(a). intersect 123(a). And it intersects. 123(a) of the act states that."
+    },
+    {
+        "testing": "negative lookahead for USC matching",
+        "input": "5 U.S.C. 552(a) and 6 U.S.C. 12(a) test. 5 U.S.C. 552(a) and 1 CFR part 51. 5 U.S.C. 552(a) and 12(b) test test test.",
+        "expected": "5 U.S.C. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title5-section552&num=0&edition=prelim#substructure-location_a\">552(a)</a> and 6 U.S.C. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title6-section12&num=0&edition=prelim#substructure-location_a\">12(a)</a> test. 5 U.S.C. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title5-section552&num=0&edition=prelim#substructure-location_a\">552(a)</a> and 1 CFR part 51. 5 U.S.C. <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title5-section552&num=0&edition=prelim#substructure-location_a\">552(a)</a> and <a target=\"_blank\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title5-section12&num=0&edition=prelim#substructure-location_b\">12(b)</a> test test test."
     }
 ]


### PR DESCRIPTION
Resolves #n/a

**Description-**

Quick fix so no JIRA ticket for this. "5 U.S.C. 552(a) and 1 CFR part 51" would match "552(a)" and "1" as sections of title 5. This was a failure of the negative lookahead which was only looking for additional U.S.C. sections.

**This pull request changes...**

- "1" no longer matches and is not linked
- Tests are updated to check for this 

**Steps to manually verify this change...**

1. Run unit tests
2. Visit `/42/460/Subpart-E/2023-06-05/#460-72-e` and see that "5 U.S.C. 552(a) and 1 CFR part 51" is matching correctly

