### PR TITLE
EREGCSC-2018 Adding django settings module config

### DIFF
--- a/solution/backend/cmcs_regulations/settings/local.py
+++ b/solution/backend/cmcs_regulations/settings/local.py
@@ -3,7 +3,7 @@ import os
 import socket
 
 
-DEBUG = os.environ.get("DEBUG", True)
+DEBUG = os.environ.get("DEBUG", False)
 
 # turns on django toolbar if debug is true
 if DEBUG:

--- a/solution/backend/cmcs_regulations/settings/local.py
+++ b/solution/backend/cmcs_regulations/settings/local.py
@@ -3,7 +3,7 @@ import os
 import socket
 
 
-DEBUG = os.environ.get("DEBUG", False)
+DEBUG = os.environ.get("DEBUG", True)
 
 # turns on django toolbar if debug is true
 if DEBUG:

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -22,6 +22,7 @@ provider:
     HTTP_AUTH_PASSWORD: ${ssm:/eregulations/http/password}
     DJANGO_ADMIN_USERNAME: ${ssm:/eregulations/http/user}
     DJANGO_ADMIN_PASSWORD: ${ssm:/eregulations/http/password}
+    DJANGO_SETTINGS_MODULE: ${ssm:/eregulations/django_settings_module}
     ALLOWED_HOST: '.amazonaws.com'
     STATIC_URL: ${self:custom.settings.static_url}
     CUSTOM_URL: ${ssm:/eregulations/custom_url, ''}

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -24,6 +24,7 @@ provider:
     HTTP_AUTH_PASSWORD: ${ssm:/eregulations/http/password}
     DJANGO_ADMIN_USERNAME: ${ssm:/eregulations/http/user}
     DJANGO_ADMIN_PASSWORD: ${ssm:/eregulations/http/password}
+    DJANGO_SETTINGS_MODULE: ${ssm:/eregulations/django_settings_module}
     ALLOWED_HOST: '.amazonaws.com'
     STATIC_URL: ${self:custom.settings.static_url}
     BASE_URL: ${ssm:/eregulations/base_url}


### PR DESCRIPTION
Resolves # EREGCSC-2018

**Description-**

In order to set up independent settings files per environment an environment variable for django_settings_module needs to be set.

The value of "cmcs_regulations.settings.deploy" is set in each environment and is called in the two serverless files.  This will not change anything about how the application currently behaves since if now envrionment variable is passed in, it defaults to cmcs_regulations.settings.deploy.

**This pull request changes...**

- Adds environment variables to serverless and serverless-experimental
- A new variable located in eregulations/django_settings_module was added in aws for dev, val and prod. 

**Steps to manually verify this change...**

1. The experimental deployment site works correctly
2. Log into aws for dev, val and prod
3. In app store there should be a value for /eregulations/django_settings_module with a value of cmcs_regulations.settings.deploy.
4. In dev go to the lambda for site on 885.
5. The configuration value for the lambda for django_settings_module should be there and set to cmcs_eregulations.settings.deploy

Post deployment validation
1. Dev will work correctly and lambdas have django_settings_module set to cmcs_eregulations.settings.deploy.
2. Same with val
3. After Dev and val are working correctly push to production.
4. Site should be running correctly.

