### PR TITLE
EREGCSC-1957 -- Statute switcher list [CLEAN]

### DIFF
--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -4,26 +4,7 @@
 {% block title %}About This Tool | Medicaid & CHIP eRegulations{% endblock %}
 
 {% block header %}
-    <header id="header" class="sticky">
-        <header-component
-            home-url="{% url 'homepage' %}"
-        >
-            <jump-to
-                slot="jump-to"
-                api-url="{{ API_BASE }}"
-                home-url="{% url 'homepage' %}"
-            ></jump-to>
-            <header-links
-                slot="links"
-                about-url="{% url 'about' %}"
-                resources-url="{% url 'resources' %}"
-            ></header-links>
-            <header-search
-                slot="search"
-                search-url="{% url 'search' %}"
-            ></header-search>
-        </header-component>
-    </header>
+    {% include "regulations/partials/header.html" %}
 {% endblock %}
 
 {% block body %}

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -20,24 +20,7 @@ Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
 {% endblock %}
 
 {% block header %}
-<header id="header" class="sticky">
-    <header-component home-url="{% url 'homepage' %}">
-        <jump-to
-            slot="jump-to"
-            api-url="{{ API_BASE }}"
-            home-url="{% url 'homepage' %}"
-        ></jump-to>
-        <header-links
-            slot="links"
-            about-url="{% url 'about' %}"
-            resources-url="{% url 'resources' %}"
-        ></header-links>
-        <header-search
-            slot="search"
-            search-url="{% url 'search' %}"
-        ></header-search>
-    </header-component>
-</header>
+    {% include "regulations/partials/header.html" %}
 {% endblock %}
 
 {% block body %}

--- a/solution/backend/regulations/templates/regulations/partials/header.html
+++ b/solution/backend/regulations/templates/regulations/partials/header.html
@@ -1,0 +1,19 @@
+<header id="header" class="sticky">
+    <header-component home-url="{% url 'homepage' %}">
+        <jump-to
+            slot="jump-to"
+            api-url="{{ API_BASE }}"
+            home-url="{% url 'homepage' %}"
+        ></jump-to>
+        <header-links
+            slot="links"
+            about-url="{% url 'about' %}"
+            resources-url="{% url 'resources' %}"
+            statutes-url="{% url 'statutes' %}"
+        ></header-links>
+        <header-search
+            slot="search"
+            search-url="{% url 'search' %}"
+        ></header-search>
+    </header-component>
+</header>

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -9,28 +9,7 @@
 {% endblock %}
 
 {% block header %}
-    <header id="header" class="sticky">
-        <header-component
-            home-url="{% url 'homepage' %}"
-        >
-            <jump-to
-                slot="jump-to"
-                part="{{ part }}"
-                title="{{ title }}"
-                api-url="{{ API_BASE }}"
-                home-url="{% url 'homepage' %}"
-            ></jump-to>
-            <header-links
-                slot="links"
-                about-url="{% url 'about' %}"
-                resources-url="{% url 'resources' %}"
-            ></header-links>
-            <header-search
-                slot="search"
-                search-url="{% url 'search' %}"
-            ></header-search>
-        </header-component>
-    </header>
+    {% include "regulations/partials/header.html" %}
 {% endblock %}
 
 {% block body %}

--- a/solution/backend/regulations/templates/regulations/regulation_landing.html
+++ b/solution/backend/regulations/templates/regulations/regulation_landing.html
@@ -6,28 +6,7 @@
 {% endblock %}
 
 {% block header %}
-    <header id="header" class="sticky">
-        <header-component
-            home-url="{% url 'homepage' %}"
-        >
-            <jump-to
-                slot="jump-to"
-                part="{{ part }}"
-                title="{{ title }}"
-                api-url="{{ API_BASE }}"
-                home-url="{% url 'homepage' %}"
-            ></jump-to>
-            <header-links
-                slot="links"
-                about-url="{% url 'about' %}"
-                resources-url="{% url 'resources' %}"
-            ></header-links>
-            <header-search
-                slot="search"
-                search-url="{% url 'search' %}"
-            ></header-search>
-        </header-component>
-    </header>
+    {% include "regulations/partials/header.html" %}
 {% endblock %}
 
 {% block body %}

--- a/solution/backend/regulations/templates/regulations/resources.html
+++ b/solution/backend/regulations/templates/regulations/resources.html
@@ -25,6 +25,7 @@
     data-resources-url="{% url 'resources' %}"
     data-search-url="{% url 'search' %}"
     data-host="{{ host }}"
+    data-statutes-url="{% url 'statutes' %}"
 ></div>
 {% endblock %}
 

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -27,6 +27,7 @@
     data-resources-url="{% url 'resources' %}"
     data-search-url="{% url 'search' %}"
     data-host="{{ host }}"
+    data-statutes-url="{% url 'statutes' %}"
 ></div>
 {% endblock %}
 

--- a/solution/backend/regulations/urls.py
+++ b/solution/backend/regulations/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
     path('supplemental_content/<id>/', SupplementalContentView.as_view(), name='supplemental_content'),
     path('cache/', CacheView.as_view(), name='cache'),
     path('resources/', ResourcesView.as_view(), name='resources'),
-    path('statutes/', StatuteView.as_view(), name='statues'),
+    path('statutes/', StatuteView.as_view(), name='statutes'),
     path("v3/", include([
         path("statutes", StatuteLinkConverterViewSet.as_view({
             "get": "list",

--- a/solution/ui/e2e/cypress/e2e/api.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/api.spec.cy.js
@@ -84,7 +84,7 @@ describe("Synonyms endpoint special character testing", () => {
 });
 
 // https://ahmed-alsaab.medium.com/cypress-api-schema-validation-with-ajv-ec61348374f7
-describe("Schema validation spike", () => {
+describe("Schema validation", () => {
     describe("Search.gov Resources", () => {
         it("gets successful response and expected schema from v3/resources/search", () => {
             cy.getSearchGovResources(SEARCH_TERM).then((response) => {

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -29,15 +29,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
             .its("status")
             .should("equal", 404);
         cy.visit("/404", { failOnStatusCode: false });
-        cy.get("div.flash-banner").should("be.visible");
-
-        cy.get("div.flash-banner .greeting")
-            .invoke("text")
-            // remove the space char
-            .invoke("replace", /\u00a0/g, " ")
-            .should("eq", "We welcome questions and suggestions — ");
-
-        cy.get("div.flash-banner a").should("have.text", "give us feedback.");
+        cy.checkFlashBanner();
     });
 
     it("shows feedback form in modal when clicking feedback link in flash banner", () => {
@@ -47,35 +39,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
             .its("status")
             .should("equal", 404);
         cy.visit("/404", { failOnStatusCode: false });
-        // modal doesn't exist
-        cy.get("div.blocking-modal-content").should("not.be.visible");
-        // click link
-        cy.get("div.flash-banner a")
-            .should("have.text", "give us feedback.")
-            .click({ force: true });
-        // modal exists
-        cy.get("div.blocking-modal-content").should("be.visible");
-        // make sure background is right color etc
-        cy.get("div.blocking-modal").should(
-            "have.css",
-            "background-color",
-            "rgba(0, 0, 0, 0.8)"
-        );
-        // a11y
-        cy.injectAxe();
-        cy.checkAccessibility();
-        // query iframe source to make sure it's google forms
-        cy.get(".blocking-modal-content iframe#iframeEl")
-            .should("have.attr", "src")
-            .then((src) => {
-                expect(src.includes("docs.google.com/forms")).to.be.true;
-            });
-        // click close
-        cy.get("button.close-modal")
-            .should("be.visible")
-            .click({ force: true });
-        // modal doesn't exist again
-        cy.get("div.blocking-modal-content").should("not.be.visible");
+        cy.checkBlockingModal();
     });
 
     it("error-page - jumps to a regulation Part using the jump-to select", () => {
@@ -84,35 +48,19 @@ describe("Error page", { scrollBehavior: "center" }, () => {
             .its("status")
             .should("equal", 404);
         cy.visit("/404", { failOnStatusCode: false });
-        cy.get("#jumpToTitle").select("45", { force: true }).then(() => {
-          cy.get("#jumpToPart").should("be.visible").select("95");
-        });
-        cy.get("#jumpBtn").click({ force: true });
-
-        cy.url().should("eq", Cypress.config().baseUrl + "/45/95/#95");
+        cy.jumpToRegulationPart({ title: "45", part: "95" });
     });
 
-    it("NEW -- error-page - jumps to a regulation Part section using the section number text input", () => {
+    it("error-page - jumps to a regulation Part section using the section number text input", () => {
         cy.viewport("macbook-15");
         cy.request({ url: "/404", failOnStatusCode: false })
             .its("status")
             .should("equal", 404);
         cy.visit("/404", { failOnStatusCode: false });
-        cy.get("#jumpToTitle").select("42")
-        cy.get("#jumpToPart").should("be.visible").select("433");
-        cy.get("#jumpToSection").type("40");
-        cy.get("#jumpBtn").click({ force: true });
-
-        cy.url().then((urlString) => {
-            expect(
-                Cypress.minimatch(
-                    urlString,
-                    Cypress.config().baseUrl + "/42/433/Subpart-A/*/#433-40",
-                    {
-                        matchBase: false,
-                    }
-                )
-            ).to.be.true;
+        cy.jumpToRegulationPartSection({
+            title: "42",
+            part: "433",
+            section: "40",
         });
     });
 
@@ -122,8 +70,6 @@ describe("Error page", { scrollBehavior: "center" }, () => {
             .its("status")
             .should("equal", 404);
         cy.visit("/404", { failOnStatusCode: false });
-        cy.contains("Medicaid & CHIP eRegulations").click();
-
-        cy.url().should("eq", Cypress.config().baseUrl + "/");
+        cy.goHome();
     });
 });

--- a/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
@@ -54,14 +54,7 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
     it("has a flash banner at the top with a link to a feedback survey", () => {
         cy.viewport("macbook-15");
         cy.visit("/");
-        cy.get("div.flash-banner").should("be.visible");
-
-        cy.get("div.flash-banner .greeting")
-            .invoke("text")
-            // remove the space char
-            .invoke("replace", /\u00a0/g, " ")
-            .should("eq", "We welcome questions and suggestions — ");
-        cy.get("div.flash-banner a").should("have.text", "give us feedback.");
+        cy.checkFlashBanner();
     });
 
     it.skip("hides the flash banner when scrolling down", () => {
@@ -84,35 +77,7 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
         // feedback link is in banner
         cy.viewport("macbook-15");
         cy.visit("/");
-        // modal doesn't exist
-        cy.get("div.blocking-modal-content").should("not.be.visible");
-        // click link
-        cy.get("div.flash-banner a")
-            .should("have.text", "give us feedback.")
-            .click({ force: true });
-        // modal exists
-        cy.get("div.blocking-modal-content").should("be.visible");
-        // make sure background is right color etc
-        cy.get("div.blocking-modal").should(
-            "have.css",
-            "background-color",
-            "rgba(0, 0, 0, 0.8)"
-        );
-        // a11y
-        cy.injectAxe();
-        cy.checkAccessibility();
-        // query iframe source to make sure it's google forms
-        cy.get(".blocking-modal-content iframe#iframeEl")
-            .should("have.attr", "src")
-            .then((src) => {
-                expect(src.includes("docs.google.com/forms")).to.be.true;
-            });
-        // click close
-        cy.get("button.close-modal")
-            .should("be.visible")
-            .click({ force: true });
-        // modal doesn't exist again
-        cy.get("div.blocking-modal-content").should("not.be.visible");
+        cy.checkBlockingModal();
     });
 
     it("Does not allow selection of Part till Title is selected in Jump To", () => {
@@ -137,33 +102,16 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
     it("jumps to a regulation Part using the jump-to select", () => {
         cy.viewport("macbook-15");
         cy.visit("/");
-        cy.get("#jumpToTitle")
-            .select("45", { force: true })
-            .then(() => {
-                cy.get("#jumpToPart").should("be.visible").select("95");
-            });
-        cy.get("#jumpBtn").click({ force: true });
-        cy.url().should("eq", Cypress.config().baseUrl + "/45/95/#95");
+        cy.jumpToRegulationPart({ title: "45", part: "95" });
     });
 
     it("jumps to a regulation Part section using the section number text input", () => {
         cy.viewport("macbook-15");
         cy.visit("/");
-        cy.get("#jumpToTitle").select("42");
-        cy.get("#jumpToPart").should("be.visible").select("433");
-        cy.get("#jumpToSection").type("40");
-        cy.get("#jumpBtn").click({ force: true });
-
-        cy.url().then((urlString) => {
-            expect(
-                Cypress.minimatch(
-                    urlString,
-                    Cypress.config().baseUrl + "/42/433/Subpart-A/*/#433-40",
-                    {
-                        matchBase: false,
-                    }
-                )
-            ).to.be.true;
+        cy.jumpToRegulationPartSection({
+            title: "42",
+            part: "433",
+            section: "40",
         });
     });
 
@@ -191,9 +139,7 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
     it("allows a user to go back to the homepage by clicking the top left link", () => {
         cy.viewport("macbook-15");
         cy.visit("/42/430/");
-        cy.contains("Medicaid & CHIP eRegulations").click();
-
-        cy.url().should("eq", Cypress.config().baseUrl + "/");
+        cy.goHome();
     });
 
     it("has the correct descriptive text", () => {

--- a/solution/ui/e2e/cypress/e2e/resources.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/resources.spec.cy.js
@@ -13,61 +13,23 @@ describe("Resources page", () => {
         it("goes to resources page from homepage", () => {
             cy.viewport("macbook-15");
             cy.visit("/");
-            cy.get("button.more__button")
-                .should("not.be.visible");
-
-            cy.get("header .header--links .links--container > ul.links__list li:first-child a")
-                .should("be.visible")
-                .should("have.text", "Resources")
-                .click({ force: true });
-
+            cy.clickHeaderLink({ page: "Resources", screen: "wide" });
             cy.url().should("include", "/resources");
         });
 
-        it("is styled correctly when at Resources page", () => {
-            cy.viewport("macbook-15");
-            cy.visit("/");
-            cy.get("header .header--links .links--container > ul.links__list li:first-child a")
-                .should("be.visible")
-                .should("have.attr", "class")
-                .and("not.match", /active/);
-
-            cy.get("header .header--links .links--container > ul.links__list li:first-child a")
-                .click({ force: true });
-
-            cy.get("header .header--links .links--container > ul.links__list li:first-child a")
-                .should("be.visible")
-                .should("have.text", "Resources")
-                .should("have.attr", "class")
-                .and("match", /active/);
-            ;
-        });
-
-        it("is nested in a dropdown menu on narrow screen widths", () => {
+        it("resources link nested in a dropdown menu on narrow screen widths", () => {
             cy.viewport("iphone-x");
             cy.visit("/");
-            cy.get("header .header--links .links--container > ul.links__list")
-                .should("not.be.visible")
-
-            cy.get(".more--dropdown-menu")
-                .should("not.be.visible");
-
-            cy.get("button.more__button")
-                .should("be.visible")
-                .click({ force: true });
-
-            cy.get(".more--dropdown-menu")
-                .should("be.visible");
-
-            cy.get(".more--dropdown-menu > ul.links__list li:first-child a")
-                .should("be.visible")
-                .should("have.text", "Resources")
-                .click({ force: true });
-
+            cy.clickHeaderLink({ page: "Resources", screen: "narrow" });
             cy.url().should("include", "/resources");
-
         });
 
+        it("goes to another SPA page from the resources page", () => {
+            cy.viewport("macbook-15");
+            cy.visit("/resources");
+            cy.clickHeaderLink({ page: "Statutes", screen: "wide" });
+            cy.url().should("include", "/statutes");
+        });
     });
 
     describe("Loading and Empty States", () => {

--- a/solution/ui/e2e/cypress/e2e/statutes.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/statutes.spec.cy.js
@@ -5,15 +5,69 @@ describe("Statute Table", () => {
         });
 
         cy.intercept(`**/v3/statutes`, {
-            fixture: "statutes.json"
+            fixture: "statutes.json",
         }).as("statutes");
     });
 
-    it("checks a11y for search page", () => {
+    it("goes to statutes page from homepage and has SSA Title 19 selected by default", () => {
         cy.viewport("macbook-15");
-        cy.visit("/statutes", { timeout: 60000 });
-        cy.wait("@statutes");
+        cy.visit("/");
+        cy.clickHeaderLink({ page: "Statutes", screen: "wide" });
+        cy.url().should("include", "/statutes/");
+
+        cy.get("h1").contains("Statute Reference");
+        cy.get("h2").contains("Look up statute text in online sources");
+
+        cy.get("a[data-testid=ssa-XIX-19]").should(
+            "have.class",
+            "titles-list__link--active"
+        );
+        cy.get("a[data-testid=ssa-XI-11]").should(
+            "not.have.class",
+            "titles-list__link--active"
+        );
+    });
+
+    it("displays as a table at widths 1024px wide and greater", () => {
+        cy.viewport(1024, 768);
+        cy.visit("/statutes");
+        cy.get("#statuteTable").should("be.visible");
+        cy.get("#statuteList").should("not.exist");
         cy.injectAxe();
         cy.checkAccessibility();
+    });
+
+    it("displays as a list at widths narrower than 1024px", () => {
+        cy.viewport(1023, 768);
+        cy.visit("/statutes");
+        cy.get("#statuteTable").should("not.exist");
+        cy.get("#statuteList").should("be.visible");
+        cy.injectAxe();
+        cy.checkAccessibility();
+    });
+
+    it("statutes link nested in a dropdown menu on mobile screen widths", () => {
+        cy.viewport("iphone-x");
+        cy.visit("/");
+        cy.clickHeaderLink({ page: "Statutes", screen: "narrow" });
+        cy.url().should("include", "/statutes/");
+    });
+
+    it("loads the correct act and title when the URL is changed", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/statutes");
+
+        cy.clickStatuteLink({ act: "ssa", titleRoman: "XXI", title: "21" });
+        cy.url().should("include", "/statutes?act=ssa&title=21");
+
+        cy.clickStatuteLink({ act: "ssa", titleRoman: "XI", title: "11" });
+        cy.url().should("include", "/statutes?act=ssa&title=11");
+    });
+
+    it("goes to another SPA page from the statutes page", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/statutes");
+        cy.clickHeaderLink({ page: "Resources", screen: "wide" });
+        cy.url().should("include", "/resources");
     });
 });

--- a/solution/ui/e2e/cypress/support/common-commands/header.js
+++ b/solution/ui/e2e/cypress/support/common-commands/header.js
@@ -1,0 +1,98 @@
+// Flash Banner/Blocking Modal
+export const checkFlashBanner = () => {
+    cy.get("div.flash-banner").should("be.visible");
+
+    cy.get("div.flash-banner .greeting")
+        .invoke("text")
+        // remove the space char
+        .invoke("replace", /\u00a0/g, " ")
+        .should("eq", "We welcome questions and suggestions — ");
+
+    cy.get("div.flash-banner a").should("have.text", "give us feedback.");
+};
+
+export const checkBlockingModal = () => {
+    // modal doesn't exist
+    cy.get("div.blocking-modal-content").should("not.be.visible");
+    // click link
+    cy.get("div.flash-banner a")
+        .should("have.text", "give us feedback.")
+        .click({ force: true });
+    // modal exists
+    cy.get("div.blocking-modal-content").should("be.visible");
+    // make sure background is right color etc
+    cy.get("div.blocking-modal").should(
+        "have.css",
+        "background-color",
+        "rgba(0, 0, 0, 0.8)"
+    );
+    // a11y
+    cy.injectAxe();
+    cy.checkAccessibility();
+    // query iframe source to make sure it's google forms
+    cy.get(".blocking-modal-content iframe#iframeEl")
+        .should("have.attr", "src")
+        .then((src) => {
+            expect(src.includes("docs.google.com/forms")).to.be.true;
+        });
+    // click close
+    cy.get("button.close-modal").should("be.visible").click({ force: true });
+    // modal doesn't exist again
+    cy.get("div.blocking-modal-content").should("not.be.visible");
+};
+
+export const goHome = () => {
+    cy.contains("Medicaid & CHIP eRegulations").click();
+    cy.url().should("eq", Cypress.config().baseUrl + "/");
+};
+
+export const clickHeaderLink = ({ page = "Resources", screen = "wide" }) => {
+    const listLocation =
+        screen === "wide"
+            ? "header .header--links .links--container"
+            : ".more--dropdown-menu";
+
+    if (screen === "wide") {
+        cy.get("button.more__button").should("not.be.visible");
+
+        // not styled as selected
+        cy.get(
+            `${listLocation} > ul.links__list li a[data-testid=${page.toLowerCase()}]`
+        )
+            .should("be.visible")
+            .should("have.attr", "class")
+            .and("not.match", /active/);
+
+        // click
+        cy.get(
+            `${listLocation} > ul.links__list li a[data-testid=${page.toLowerCase()}]`
+        )
+            .should("be.visible")
+            .should("have.text", page)
+            .click({ force: true });
+
+        // styled as selected
+        cy.get(
+            `${listLocation} > ul.links__list li a[data-testid=${page.toLowerCase()}]`
+        )
+            .should("be.visible")
+            .should("have.text", page)
+            .should("have.attr", "class")
+            .and("match", /active/);
+    } else {
+        cy.get(`${listLocation} > ul.links__list`).should("not.be.visible");
+
+        cy.get(".more--dropdown-menu").should("not.be.visible");
+
+        cy.get("button.more__button")
+            .should("be.visible")
+            .click({ force: true });
+
+        cy.get(".more--dropdown-menu").should("be.visible");
+
+        cy.get(`${listLocation} > ul.links__list li a[data-testid=${page.toLowerCase()}]`)
+            .should("be.visible")
+            .should("have.text", page)
+            .click({ force: true });
+    }
+};

--- a/solution/ui/e2e/cypress/support/common-commands/jumpTo.js
+++ b/solution/ui/e2e/cypress/support/common-commands/jumpTo.js
@@ -1,0 +1,33 @@
+// Jump To
+export const jumpToRegulationPart = ({ title, part }) => {
+    cy.get("#jumpToTitle")
+        .select(title, { force: true })
+        .then(() => {
+            cy.get("#jumpToPart").should("be.visible").select(part);
+        });
+    cy.get("#jumpBtn").click({ force: true });
+    cy.url().should(
+        "eq",
+        Cypress.config().baseUrl + `/${title}/${part}/#${part}`
+    );
+};
+
+export const jumpToRegulationPartSection = ({ title, part, section }) => {
+    cy.get("#jumpToTitle").select(title);
+    cy.get("#jumpToPart").should("be.visible").select(part);
+    cy.get("#jumpToSection").type(section);
+    cy.get("#jumpBtn").click({ force: true });
+
+    cy.url().then((urlString) => {
+        expect(
+            Cypress.minimatch(
+                urlString,
+                Cypress.config().baseUrl +
+                    `/${title}/${part}/Subpart-A/*/#${part}-${section}`,
+                {
+                    matchBase: false,
+                }
+            )
+        ).to.be.true;
+    });
+};

--- a/solution/ui/e2e/cypress/support/common-commands/statutes.js
+++ b/solution/ui/e2e/cypress/support/common-commands/statutes.js
@@ -1,0 +1,6 @@
+export const clickStatuteLink = ({ act, title, titleRoman }) => {
+    const testId = `ssa-${titleRoman}-${title}`;
+    cy.get(`a[data-testid=${act}-${titleRoman}-${title}]`).click({
+        force: true,
+    });
+};

--- a/solution/ui/e2e/cypress/support/e2e.js
+++ b/solution/ui/e2e/cypress/support/e2e.js
@@ -28,11 +28,20 @@ import "cypress-axe";
 import "cypress-plugin-tab";
 
 import { getResources, getSearchGovResources } from "./api-request-commands";
+import { checkBlockingModal, checkFlashBanner, clickHeaderLink, goHome } from"./common-commands/header";
+import { jumpToRegulationPart, jumpToRegulationPartSection } from "./common-commands/jumpTo";
+import { clickStatuteLink } from "./common-commands/statutes";
 import { validateSchema } from "./validate-schema-command";
 
+Cypress.Commands.add("checkBlockingModal", checkBlockingModal);
+Cypress.Commands.add("checkFlashBanner", checkFlashBanner);
+Cypress.Commands.add("clickHeaderLink", clickHeaderLink);
+Cypress.Commands.add("clickStatuteLink", clickStatuteLink);
 Cypress.Commands.add("getResources", getResources);
 Cypress.Commands.add("getSearchGovResources", getSearchGovResources);
-
+Cypress.Commands.add("goHome", goHome);
+Cypress.Commands.add("jumpToRegulationPart", jumpToRegulationPart);
+Cypress.Commands.add("jumpToRegulationPartSection", jumpToRegulationPartSection);
 Cypress.Commands.add("validateSchema", validateSchema);
 
 // Print cypress-axe violations to the terminal

--- a/solution/ui/regulations/alias.js
+++ b/solution/ui/regulations/alias.js
@@ -1,13 +1,15 @@
-import {resolve} from 'path'
+import { resolve } from "path";
 
-const r = (p) => resolve(__dirname, p)
+const r = (p) => resolve(__dirname, p);
 
-export const aliases = {
-    "utilities": r('./utilities'),
-    "legacy": r("../../regulations"),
-    "sharedComponents": r("../eregs-component-lib/src/components/shared-components"),
-    "eregsComponentLib": r("../regulations/eregs-component-lib"),
-    "vite": r("../regulations/eregs-vite/src"),
+export default {
     "@": r("src"),
-  }
-
+    cypress: r("../e2e/cypress"),
+    eregsComponentLib: r("../regulations/eregs-component-lib"),
+    legacy: r("../../regulations"),
+    sharedComponents: r(
+        "../eregs-component-lib/src/components/shared-components"
+    ),
+    utilities: r("./utilities"),
+    vite: r("../regulations/eregs-vite/src"),
+};

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -204,6 +204,8 @@ $eds-xs-max: $eds-width-sm - 1; // 779px
 $eds-sm-max: $eds-width-md - 1; // 1023px
 $eds-md-max: $eds-width-lg - 1; // 1199px
 
+$eds-width-header-links: 1240px;
+
 // Uses CMS Design System + a larger screen size
 
 // Custom maxes

--- a/solution/ui/regulations/css/scss/partials/_header.scss
+++ b/solution/ui/regulations/css/scss/partials/_header.scss
@@ -137,7 +137,6 @@ header {
             display: flex;
             justify-content: flex-end;
             align-items: center;
-            width: 480px;
             order: 3;
             padding-right: 20px;
 
@@ -169,7 +168,7 @@ header {
                 }
 
                 .links--container {
-                    @include custom-max(($eds-width-lg - 1) / 1px) {
+                    @include custom-max(($eds-width-header-links - 1) / 1px) {
                         display: flex;
                         height: 36px;
                         padding: 0 8px;
@@ -188,7 +187,7 @@ header {
                         align-items: center;
                         padding: 0 12px;
 
-                        @include custom-min($eds-width-lg / 1px) {
+                        @include custom-min($eds-width-header-links / 1px) {
                             display: none;
                         }
 
@@ -217,7 +216,7 @@ header {
                         -webkit-box-shadow: 0px 0px 12px rgba(0, 0, 0, 0.25);
                         -moz-box-shadow: 0px 0px 12px rgba(0, 0, 0, 0.25);
 
-                        @include custom-min($eds-width-lg / 1px) {
+                        @include custom-min($eds-width-header-links / 1px) {
                             display: none;
                         }
 
@@ -234,7 +233,7 @@ header {
                             padding: 20px 30px;
 
                             li {
-                                &:first-child {
+                                &:not(:last-child) {
                                     margin-bottom: 12px;
                                 }
 
@@ -250,7 +249,7 @@ header {
                         &.links__list--wide {
                             padding: 0 12px;
 
-                            @include custom-max(($eds-width-lg - 1) / 1px) {
+                            @include custom-max(($eds-width-header-links - 1) / 1px) {
                                 display: none;
                             }
 

--- a/solution/ui/regulations/css/scss/partials/_statutes.scss
+++ b/solution/ui/regulations/css/scss/partials/_statutes.scss
@@ -20,14 +20,85 @@
         }
 
         .content {
+            display: flex;
+            flex-direction: row;
             padding-top: 30px;
             padding-bottom: 30px;
+
+            @include custom-max(($eds-width-md - 1) / 1px) {
+                flex-direction: column;
+            }
+
+            .content__selector {
+                flex: 0 0 200px;
+                margin-right: 25px;
+
+                h3 {
+                    font-size: 1.5rem;
+                    line-height: 36px;
+                    margin: 0 0 16px;
+                }
+
+                h4 {
+                    margin: 0 0 12px;
+
+                    &.acts-item__heading {
+                        color: $mid_blue;
+                        transition: none;
+
+                        &--active {
+                            color: $dark_gray;
+                        }
+                    }
+                }
+
+                .selector__parent {
+                    @include screen-eds-md {
+                        position: sticky;
+                        top: $header_height;
+                    }
+                }
+
+                .titles-list__link {
+                    text-decoration: none;
+                    transition: none;
+
+                    &:hover,
+                    &:focus,
+                    &--active {
+                        color: $dark_gray;
+                        border-bottom: 1px solid $dark_gray;
+                    }
+
+                    &--loading {
+                        pointer-events: none;
+                    }
+                }
+
+                ul {
+                    list-style-type: none;
+
+                    &.acts__list {
+                        padding-left: 0;
+                    }
+
+                    &.titles__list {
+                        margin: 0;
+                    }
+                }
+            }
 
             .table__parent {
                 padding: 0.75rem;
                 border: 1px solid $table_border_color;
                 border-radius: 4px;
+                width: 100%;
 
+                &.loading {
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                }
                 .table__caption {
                     padding-bottom: 1.5rem;
                     color: $primary_text_color;

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.test.js
@@ -1,0 +1,82 @@
+import flushPromises from "flush-promises";
+import { render, screen } from "@testing-library/vue";
+import { describe, it, expect } from "vitest";
+
+import StatuteSelector from "./StatuteSelector.vue";
+
+describe("Statute Table Selector", () => {
+    describe("SSA table type", () => {
+        it(`Creates a snapshot of the Statute Selector with default props`, async () => {
+            const wrapper = render(StatuteSelector, {
+                stubs: { "RouterLink": true },
+            });
+
+            await flushPromises();
+
+            const activeLink = screen.getByTestId("ssa-XIX-19");
+            expect(
+                activeLink.classList.contains("titles-list__link--active")
+            ).toBe(true);
+            expect(
+                activeLink.classList.contains("titles-list__link--loading")
+            ).toBe(false);
+
+            const inactiveLink = screen.getByTestId("ssa-XXI-21");
+            expect(
+                inactiveLink.classList.contains("titles-list__link--active")
+            ).toBe(false);
+            expect(
+                inactiveLink.classList.contains("titles-list__link--loading")
+            ).toBe(false);
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        it(`Creates a snapshot of the Statute Selector with a loading prop`, async () => {
+            const wrapper = render(StatuteSelector, {
+                stubs: { "RouterLink": true },
+                props: {
+                    loading: true,
+                },
+            });
+
+            await flushPromises();
+
+            const activeLink = screen.getByTestId("ssa-XIX-19");
+            expect(
+                activeLink.classList.contains("titles-list__link--loading")
+            ).toBe(true);
+
+            const inactiveLink = screen.getByTestId("ssa-XXI-21");
+            expect(
+                inactiveLink.classList.contains("titles-list__link--active")
+            ).toBe(false);
+
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        it(`Creates a snapshot of the Statute Selector when act and title props passed in to component`, async () => {
+            const wrapper = render(StatuteSelector, {
+                stubs: { "RouterLink": true },
+                props: {
+                    selectedAct: "ssa",
+                    selectedTitle: "21",
+                },
+            });
+
+            await flushPromises();
+
+            const activeLink = screen.getByTestId("ssa-XXI-21");
+            expect(
+                activeLink.classList.contains("titles-list__link--active")
+            ).toBe(true);
+
+            const inactiveLink = screen.getByTestId("ssa-XIX-19");
+            expect(
+                inactiveLink.classList.contains("titles-list__link--active")
+            ).toBe(false);
+
+            expect(wrapper).toMatchSnapshot();
+        });
+    });
+});

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.vue
@@ -64,7 +64,7 @@ const isTitleActive = ({ act, title }) =>
                                 },
                             }"
                         >
-                            Title {{ title.titleRoman }} [{{ title.title }}]
+                            Title {{ title.titleRoman }}
                         </RouterLink>
                     </h4>
                 </li>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.vue
@@ -1,0 +1,74 @@
+<script setup>
+import { titleSelectorList } from "./schemas/listSchemas";
+
+const props = defineProps({
+    loading: {
+        type: Boolean,
+        required: false,
+        default: false,
+    },
+    selectedAct: {
+        type: String,
+        required: false,
+        default: "ssa",
+    },
+    selectedTitle: {
+        type: String,
+        required: false,
+        default: "19",
+    },
+});
+
+const isActActive = ({ act }) => act === props.selectedAct;
+const isTitleActive = ({ act, title }) =>
+    act === props.selectedAct && title === props.selectedTitle;
+</script>
+
+<template>
+    <ul class="acts__list">
+        <li
+            v-for="(value, key, i) in titleSelectorList"
+            :key="`${key}-${i}`"
+            class="acts-list__item"
+        >
+            <h4
+                class="acts-item__heading"
+                :class="{
+                    'acts-item__heading--active': isActActive({ act: key }),
+                }"
+            >
+                {{ value.name }}
+            </h4>
+            <ul class="titles__list">
+                <li
+                    v-for="(title, j) in value.titles"
+                    :key="`${title.title}-${j}`"
+                    class="titles-list__item"
+                >
+                    <h4>
+                        <RouterLink
+                            class="titles-list__link"
+                            :data-testid="`${key}-${title.titleRoman}-${title.title}`"
+                            :class="{
+                                'titles-list__link--active': isTitleActive({
+                                    act: key,
+                                    title: title.title,
+                                }),
+                                'titles-list__link--loading': loading,
+                            }"
+                            :to="{
+                                name: 'statutes',
+                                query: {
+                                    act: key,
+                                    title: title.title,
+                                },
+                            }"
+                        >
+                            Title {{ title.titleRoman }} [{{ title.title }}]
+                        </RouterLink>
+                    </h4>
+                </li>
+            </ul>
+        </li>
+    </ul>
+</template>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteTable.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteTable.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from "vue";
 
 import { acaSchema, ssaSchema } from "./schemas/tableSchemas";
-import { DISPLAY_TYPES, TABLE_TYPES } from "./utils/enums";
+import { ACT_TYPES, DISPLAY_TYPES } from "./utils/enums";
 
 import BodyCell from "./table-elements/BodyCell.vue";
 import HeaderCell from "./table-elements/HeaderCell.vue";
@@ -19,7 +19,8 @@ const props = defineProps({
         default: () => [],
     },
     tableType: {
-        validator: (value) => TABLE_TYPES.includes(value),
+        validator: (value) =>
+            ACT_TYPES.map((act) => Object.keys(act)[0]).includes(value),
         required: false,
         default: "ssa",
     },

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/TableCaption.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/TableCaption.vue
@@ -1,0 +1,45 @@
+<script setup></script>
+
+<template>
+    <div class="table__caption">
+        This table shows U.S. Code sections enacted by the Social Security Act.
+        See also:
+        <a
+            target="_blank"
+            rel="noopener noreferrer"
+            class="external"
+            href="https://uscode.house.gov/view.xhtml?req=granuleid%3AUSC-prelim-title42-chapter7&amp;saved=%7CZ3JhbnVsZWlkOlVTQy1wcmVsaW0tdGl0bGU0Mi1jaGFwdGVyNy1mcm9udA%3D%3D%7C%7C%7C0%7Cfalse%7Cprelim&amp;edition=prelim"
+            >full table of contents and text for 42 U.S.C. Chapter 7 (Social
+            Security)</a
+        >.<br />
+        Learn about these sources:
+        <a
+            href="https://uscode.house.gov/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="external"
+            >US Code House.gov</a
+        >,
+        <a
+            href="https://www.govinfo.gov/app/collection/comps/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="external"
+            >Statute Compilation</a
+        >,
+        <a
+            href="https://www.govinfo.gov/app/collection/uscode"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="external"
+            >US Code Annual</a
+        >,
+        <a
+            href="https://www.ssa.gov/OP_Home/ssact/ssact.htm"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="external"
+            >SSA.gov Compilation</a
+        >.
+    </div>
+</template>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/__snapshots__/StatuteSelector.test.js.snap
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/__snapshots__/StatuteSelector.test.js.snap
@@ -1,0 +1,610 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Statute Selector when act and title props passed in to component 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <ul
+        class="acts__list"
+      >
+        <li
+          class="acts-list__item"
+        >
+          <h4
+            class="acts-item__heading acts-item__heading--active"
+          >
+             Social Security Act 
+          </h4>
+          <ul
+            class="titles__list"
+          >
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link"
+                  data-testid="ssa-XI-11"
+                  to="[object Object]"
+                >
+                   Title XI [11] 
+                </routerlink-stub>
+              </h4>
+            </li>
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link"
+                  data-testid="ssa-XVIII-18"
+                  to="[object Object]"
+                >
+                   Title XVIII [18] 
+                </routerlink-stub>
+              </h4>
+            </li>
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link"
+                  data-testid="ssa-XIX-19"
+                  to="[object Object]"
+                >
+                   Title XIX [19] 
+                </routerlink-stub>
+              </h4>
+            </li>
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link titles-list__link--active"
+                  data-testid="ssa-XXI-21"
+                  to="[object Object]"
+                >
+                   Title XXI [21] 
+                </routerlink-stub>
+              </h4>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </body>,
+  "container": <div>
+    <ul
+      class="acts__list"
+    >
+      <li
+        class="acts-list__item"
+      >
+        <h4
+          class="acts-item__heading acts-item__heading--active"
+        >
+           Social Security Act 
+        </h4>
+        <ul
+          class="titles__list"
+        >
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link"
+                data-testid="ssa-XI-11"
+                to="[object Object]"
+              >
+                 Title XI [11] 
+              </routerlink-stub>
+            </h4>
+          </li>
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link"
+                data-testid="ssa-XVIII-18"
+                to="[object Object]"
+              >
+                 Title XVIII [18] 
+              </routerlink-stub>
+            </h4>
+          </li>
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link"
+                data-testid="ssa-XIX-19"
+                to="[object Object]"
+              >
+                 Title XIX [19] 
+              </routerlink-stub>
+            </h4>
+          </li>
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link titles-list__link--active"
+                data-testid="ssa-XXI-21"
+                to="[object Object]"
+              >
+                 Title XXI [21] 
+              </routerlink-stub>
+            </h4>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Statute Selector with a loading prop 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <ul
+        class="acts__list"
+      >
+        <li
+          class="acts-list__item"
+        >
+          <h4
+            class="acts-item__heading acts-item__heading--active"
+          >
+             Social Security Act 
+          </h4>
+          <ul
+            class="titles__list"
+          >
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link titles-list__link--loading"
+                  data-testid="ssa-XI-11"
+                  to="[object Object]"
+                >
+                   Title XI [11] 
+                </routerlink-stub>
+              </h4>
+            </li>
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link titles-list__link--loading"
+                  data-testid="ssa-XVIII-18"
+                  to="[object Object]"
+                >
+                   Title XVIII [18] 
+                </routerlink-stub>
+              </h4>
+            </li>
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link titles-list__link--active titles-list__link--loading"
+                  data-testid="ssa-XIX-19"
+                  to="[object Object]"
+                >
+                   Title XIX [19] 
+                </routerlink-stub>
+              </h4>
+            </li>
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link titles-list__link--loading"
+                  data-testid="ssa-XXI-21"
+                  to="[object Object]"
+                >
+                   Title XXI [21] 
+                </routerlink-stub>
+              </h4>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </body>,
+  "container": <div>
+    <ul
+      class="acts__list"
+    >
+      <li
+        class="acts-list__item"
+      >
+        <h4
+          class="acts-item__heading acts-item__heading--active"
+        >
+           Social Security Act 
+        </h4>
+        <ul
+          class="titles__list"
+        >
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link titles-list__link--loading"
+                data-testid="ssa-XI-11"
+                to="[object Object]"
+              >
+                 Title XI [11] 
+              </routerlink-stub>
+            </h4>
+          </li>
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link titles-list__link--loading"
+                data-testid="ssa-XVIII-18"
+                to="[object Object]"
+              >
+                 Title XVIII [18] 
+              </routerlink-stub>
+            </h4>
+          </li>
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link titles-list__link--active titles-list__link--loading"
+                data-testid="ssa-XIX-19"
+                to="[object Object]"
+              >
+                 Title XIX [19] 
+              </routerlink-stub>
+            </h4>
+          </li>
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link titles-list__link--loading"
+                data-testid="ssa-XXI-21"
+                to="[object Object]"
+              >
+                 Title XXI [21] 
+              </routerlink-stub>
+            </h4>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Statute Selector with default props 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <ul
+        class="acts__list"
+      >
+        <li
+          class="acts-list__item"
+        >
+          <h4
+            class="acts-item__heading acts-item__heading--active"
+          >
+             Social Security Act 
+          </h4>
+          <ul
+            class="titles__list"
+          >
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link"
+                  data-testid="ssa-XI-11"
+                  to="[object Object]"
+                >
+                   Title XI [11] 
+                </routerlink-stub>
+              </h4>
+            </li>
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link"
+                  data-testid="ssa-XVIII-18"
+                  to="[object Object]"
+                >
+                   Title XVIII [18] 
+                </routerlink-stub>
+              </h4>
+            </li>
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link titles-list__link--active"
+                  data-testid="ssa-XIX-19"
+                  to="[object Object]"
+                >
+                   Title XIX [19] 
+                </routerlink-stub>
+              </h4>
+            </li>
+            <li
+              class="titles-list__item"
+            >
+              <h4>
+                <routerlink-stub
+                  class="titles-list__link"
+                  data-testid="ssa-XXI-21"
+                  to="[object Object]"
+                >
+                   Title XXI [21] 
+                </routerlink-stub>
+              </h4>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </body>,
+  "container": <div>
+    <ul
+      class="acts__list"
+    >
+      <li
+        class="acts-list__item"
+      >
+        <h4
+          class="acts-item__heading acts-item__heading--active"
+        >
+           Social Security Act 
+        </h4>
+        <ul
+          class="titles__list"
+        >
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link"
+                data-testid="ssa-XI-11"
+                to="[object Object]"
+              >
+                 Title XI [11] 
+              </routerlink-stub>
+            </h4>
+          </li>
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link"
+                data-testid="ssa-XVIII-18"
+                to="[object Object]"
+              >
+                 Title XVIII [18] 
+              </routerlink-stub>
+            </h4>
+          </li>
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link titles-list__link--active"
+                data-testid="ssa-XIX-19"
+                to="[object Object]"
+              >
+                 Title XIX [19] 
+              </routerlink-stub>
+            </h4>
+          </li>
+          <li
+            class="titles-list__item"
+          >
+            <h4>
+              <routerlink-stub
+                class="titles-list__link"
+                data-testid="ssa-XXI-21"
+                to="[object Object]"
+              >
+                 Title XXI [21] 
+              </routerlink-stub>
+            </h4>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/__snapshots__/StatuteSelector.test.js.snap
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/__snapshots__/StatuteSelector.test.js.snap
@@ -27,7 +27,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XI-11"
                   to="[object Object]"
                 >
-                   Title XI [11] 
+                   Title XI 
                 </routerlink-stub>
               </h4>
             </li>
@@ -40,7 +40,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XVIII-18"
                   to="[object Object]"
                 >
-                   Title XVIII [18] 
+                   Title XVIII 
                 </routerlink-stub>
               </h4>
             </li>
@@ -53,7 +53,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XIX-19"
                   to="[object Object]"
                 >
-                   Title XIX [19] 
+                   Title XIX 
                 </routerlink-stub>
               </h4>
             </li>
@@ -66,7 +66,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XXI-21"
                   to="[object Object]"
                 >
-                   Title XXI [21] 
+                   Title XXI 
                 </routerlink-stub>
               </h4>
             </li>
@@ -99,7 +99,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XI-11"
                 to="[object Object]"
               >
-                 Title XI [11] 
+                 Title XI 
               </routerlink-stub>
             </h4>
           </li>
@@ -112,7 +112,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XVIII-18"
                 to="[object Object]"
               >
-                 Title XVIII [18] 
+                 Title XVIII 
               </routerlink-stub>
             </h4>
           </li>
@@ -125,7 +125,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XIX-19"
                 to="[object Object]"
               >
-                 Title XIX [19] 
+                 Title XIX 
               </routerlink-stub>
             </h4>
           </li>
@@ -138,7 +138,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XXI-21"
                 to="[object Object]"
               >
-                 Title XXI [21] 
+                 Title XXI 
               </routerlink-stub>
             </h4>
           </li>
@@ -230,7 +230,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XI-11"
                   to="[object Object]"
                 >
-                   Title XI [11] 
+                   Title XI 
                 </routerlink-stub>
               </h4>
             </li>
@@ -243,7 +243,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XVIII-18"
                   to="[object Object]"
                 >
-                   Title XVIII [18] 
+                   Title XVIII 
                 </routerlink-stub>
               </h4>
             </li>
@@ -256,7 +256,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XIX-19"
                   to="[object Object]"
                 >
-                   Title XIX [19] 
+                   Title XIX 
                 </routerlink-stub>
               </h4>
             </li>
@@ -269,7 +269,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XXI-21"
                   to="[object Object]"
                 >
-                   Title XXI [21] 
+                   Title XXI 
                 </routerlink-stub>
               </h4>
             </li>
@@ -302,7 +302,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XI-11"
                 to="[object Object]"
               >
-                 Title XI [11] 
+                 Title XI 
               </routerlink-stub>
             </h4>
           </li>
@@ -315,7 +315,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XVIII-18"
                 to="[object Object]"
               >
-                 Title XVIII [18] 
+                 Title XVIII 
               </routerlink-stub>
             </h4>
           </li>
@@ -328,7 +328,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XIX-19"
                 to="[object Object]"
               >
-                 Title XIX [19] 
+                 Title XIX 
               </routerlink-stub>
             </h4>
           </li>
@@ -341,7 +341,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XXI-21"
                 to="[object Object]"
               >
-                 Title XXI [21] 
+                 Title XXI 
               </routerlink-stub>
             </h4>
           </li>
@@ -433,7 +433,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XI-11"
                   to="[object Object]"
                 >
-                   Title XI [11] 
+                   Title XI 
                 </routerlink-stub>
               </h4>
             </li>
@@ -446,7 +446,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XVIII-18"
                   to="[object Object]"
                 >
-                   Title XVIII [18] 
+                   Title XVIII 
                 </routerlink-stub>
               </h4>
             </li>
@@ -459,7 +459,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XIX-19"
                   to="[object Object]"
                 >
-                   Title XIX [19] 
+                   Title XIX 
                 </routerlink-stub>
               </h4>
             </li>
@@ -472,7 +472,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                   data-testid="ssa-XXI-21"
                   to="[object Object]"
                 >
-                   Title XXI [21] 
+                   Title XXI 
                 </routerlink-stub>
               </h4>
             </li>
@@ -505,7 +505,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XI-11"
                 to="[object Object]"
               >
-                 Title XI [11] 
+                 Title XI 
               </routerlink-stub>
             </h4>
           </li>
@@ -518,7 +518,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XVIII-18"
                 to="[object Object]"
               >
-                 Title XVIII [18] 
+                 Title XVIII 
               </routerlink-stub>
             </h4>
           </li>
@@ -531,7 +531,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XIX-19"
                 to="[object Object]"
               >
-                 Title XIX [19] 
+                 Title XIX 
               </routerlink-stub>
             </h4>
           </li>
@@ -544,7 +544,7 @@ exports[`Statute Table Selector > SSA table type > Creates a snapshot of the Sta
                 data-testid="ssa-XXI-21"
                 to="[object Object]"
               >
-                 Title XXI [21] 
+                 Title XXI 
               </routerlink-stub>
             </h4>
           </li>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/listSchemas.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/listSchemas.js
@@ -1,0 +1,25 @@
+const titleSelectorList = {
+    ssa: {
+        name: "Social Security Act",
+        titles: [
+            {
+                title: "11",
+                titleRoman: "XI",
+            },
+            {
+                title: "18",
+                titleRoman: "XVIII",
+            },
+            {
+                title: "19",
+                titleRoman: "XIX",
+            },
+            {
+                title: "21",
+                titleRoman: "XXI",
+            },
+        ],
+    },
+};
+
+export { titleSelectorList };

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/BodyCell.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/BodyCell.test.js
@@ -1,0 +1,25 @@
+import flushPromises from "flush-promises";
+import { render } from "@testing-library/vue";
+import { describe, it, expect } from "vitest";
+
+import { ssaSchema } from "../schemas/tableSchemas";
+import statutesFixture from "cypress/fixtures/statutes.json";
+
+import BodyCell from "./BodyCell.vue";
+
+describe("Statute Table Body Cell", () => {
+    describe("SSA table type", () => {
+        ssaSchema.forEach((column, index) => {
+            it(`Creates a snapshot of a body cell for column ${index + 1}`, async () => {
+                const wrapper = render(BodyCell, {
+                    props: {
+                        cellData: column,
+                        statute: statutesFixture[0],
+                    },
+                });
+                await flushPromises();
+                expect(wrapper).toMatchSnapshot();
+            });
+        });
+    });
+});

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.test.js
@@ -1,0 +1,24 @@
+import flushPromises from "flush-promises";
+import { render } from "@testing-library/vue";
+import { describe, it, expect } from "vitest";
+
+import { ssaSchema } from "../schemas/tableSchemas";
+
+import HeaderCell from "./HeaderCell.vue";
+
+describe("Statute Table Header Cell", () => {
+    describe("SSA table header", () => {
+        ssaSchema.forEach((column, index) => {
+            it(`Creates a snapshot of header cell for column ${index + 1}`, async () => {
+                const wrapper = render(HeaderCell, {
+                    props: {
+                        cellData: column.header,
+                        displayType: "table",
+                    },
+                });
+                await flushPromises();
+                expect(wrapper).toMatchSnapshot();
+            });
+        });
+    });
+});

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.vue
@@ -23,12 +23,12 @@ const props = defineProps({
         }"
     >
         <div class="cell__title">
-            {{ cellData.title }}
+            {{ props.cellData.title }}
         </div>
         <template v-if="cellData.subtitles">
             <div
                 v-for="(subtitle, i) in cellData.subtitles"
-                :key="`${displayType}-subtitle-${i}`"
+                :key="`${props.displayType}-subtitle-${i}`"
                 class="cell__subtitle"
             >
                 {{ subtitle }}

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/BodyCell.test.js.snap
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/BodyCell.test.js.snap
@@ -1,0 +1,460 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 1 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <td
+        class="row__cell row__cell--body row__cell--primary"
+      >
+        <div
+          class="cell__title"
+        >
+           SSA Section 1101 
+        </div>
+        <div
+          class="cell__usc-label"
+        >
+           42 U.S.C. 1301 
+        </div>
+        <div
+          class="cell__name"
+        >
+           Definitions 
+        </div>
+      </td>
+    </div>
+  </body>,
+  "container": <div>
+    <td
+      class="row__cell row__cell--body row__cell--primary"
+    >
+      <div
+        class="cell__title"
+      >
+         SSA Section 1101 
+      </div>
+      <div
+        class="cell__usc-label"
+      >
+         42 U.S.C. 1301 
+      </div>
+      <div
+        class="cell__name"
+      >
+         Definitions 
+      </div>
+    </td>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 2 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <td
+        class="row__cell row__cell--body row__cell--secondary"
+      >
+        <a
+          class="external"
+          href="https://uscode.house.gov/view.xhtml?hl=false&edition=prelim&req=granuleid%3AUSC-prelim-title42-section1301"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          1301
+        </a>
+      </td>
+    </div>
+  </body>,
+  "container": <div>
+    <td
+      class="row__cell row__cell--body row__cell--secondary"
+    >
+      <a
+        class="external"
+        href="https://uscode.house.gov/view.xhtml?hl=false&edition=prelim&req=granuleid%3AUSC-prelim-title42-section1301"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        1301
+      </a>
+    </td>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 3 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <td
+        class="row__cell row__cell--body row__cell--secondary"
+      >
+        <a
+          class="pdf"
+          href="https://www.govinfo.gov/content/pkg/COMPS-8763/pdf/COMPS-8763.pdf"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Title XI
+        </a>
+      </td>
+    </div>
+  </body>,
+  "container": <div>
+    <td
+      class="row__cell row__cell--body row__cell--secondary"
+    >
+      <a
+        class="pdf"
+        href="https://www.govinfo.gov/content/pkg/COMPS-8763/pdf/COMPS-8763.pdf"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Title XI
+      </a>
+    </td>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 4 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <td
+        class="row__cell row__cell--body row__cell--secondary"
+      >
+        <a
+          class="pdf"
+          href="https://www.govinfo.gov/link/uscode/42/1301"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          1301
+        </a>
+      </td>
+    </div>
+  </body>,
+  "container": <div>
+    <td
+      class="row__cell row__cell--body row__cell--secondary"
+    >
+      <a
+        class="pdf"
+        href="https://www.govinfo.gov/link/uscode/42/1301"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        1301
+      </a>
+    </td>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 5 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <td
+        class="row__cell row__cell--body row__cell--secondary"
+      >
+        <a
+          class="external"
+          href="https://www.ssa.gov/OP_Home/ssact/title11/1101.htm"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          1101
+        </a>
+      </td>
+    </div>
+  </body>,
+  "container": <div>
+    <td
+      class="row__cell row__cell--body row__cell--secondary"
+    >
+      <a
+        class="external"
+        href="https://www.ssa.gov/OP_Home/ssact/title11/1101.htm"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        1101
+      </a>
+    </td>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/HeaderCell.test.js.snap
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/HeaderCell.test.js.snap
@@ -1,0 +1,498 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 1 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <th
+        class="row__cell row__cell--header row__cell--primary"
+      >
+        <div
+          class="cell__title"
+        >
+           Statute Citation 
+        </div>
+        <!---->
+      </th>
+    </div>
+  </body>,
+  "container": <div>
+    <th
+      class="row__cell row__cell--header row__cell--primary"
+    >
+      <div
+        class="cell__title"
+      >
+         Statute Citation 
+      </div>
+      <!---->
+    </th>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 2 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <th
+        class="row__cell row__cell--header row__cell--secondary"
+      >
+        <div
+          class="cell__title"
+        >
+           US Code House.gov 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           Web Page 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           Effective Jul 2023 
+        </div>
+      </th>
+    </div>
+  </body>,
+  "container": <div>
+    <th
+      class="row__cell row__cell--header row__cell--secondary"
+    >
+      <div
+        class="cell__title"
+      >
+         US Code House.gov 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         Web Page 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         Effective Jul 2023 
+      </div>
+    </th>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 3 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <th
+        class="row__cell row__cell--header row__cell--secondary"
+      >
+        <div
+          class="cell__title"
+        >
+           Statute Compilation 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           PDF Document 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           Amended Dec 2022 
+        </div>
+      </th>
+    </div>
+  </body>,
+  "container": <div>
+    <th
+      class="row__cell row__cell--header row__cell--secondary"
+    >
+      <div
+        class="cell__title"
+      >
+         Statute Compilation 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         PDF Document 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         Amended Dec 2022 
+      </div>
+    </th>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 4 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <th
+        class="row__cell row__cell--header row__cell--secondary"
+      >
+        <div
+          class="cell__title"
+        >
+           US Code Annual 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           PDF Document 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           Effective Jan 2022 
+        </div>
+      </th>
+    </div>
+  </body>,
+  "container": <div>
+    <th
+      class="row__cell row__cell--header row__cell--secondary"
+    >
+      <div
+        class="cell__title"
+      >
+         US Code Annual 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         PDF Document 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         Effective Jan 2022 
+      </div>
+    </th>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 5 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <th
+        class="row__cell row__cell--header row__cell--secondary"
+      >
+        <div
+          class="cell__title"
+        >
+           SSA.gov Compilation 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           Web Page 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           Amended Dec 2019 
+        </div>
+      </th>
+    </div>
+  </body>,
+  "container": <div>
+    <th
+      class="row__cell row__cell--header row__cell--secondary"
+    >
+      <div
+        class="cell__title"
+      >
+         SSA.gov Compilation 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         Web Page 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         Amended Dec 2019 
+      </div>
+    </th>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/enums.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/enums.js
@@ -1,7 +1,7 @@
+const ACT_TYPES = [
+    { aca: "Affordable Care Act" },
+    { ssa: "Social Security Act" },
+];
 const DISPLAY_TYPES = ["table", "list"];
-const TABLE_TYPES = ["aca", "ssa"];
 
-export {
-    DISPLAY_TYPES,
-    TABLE_TYPES,
-};
+export { ACT_TYPES, DISPLAY_TYPES };

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/urlMethods.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/urlMethods.test.js
@@ -1,0 +1,52 @@
+import {
+    houseGovUrl,
+    usCodeUrl,
+    statuteCompilationUrl,
+    ssaGovUrl,
+} from "./urlMethods";
+
+import statutesFixture from "cypress/fixtures/statutes.json";
+
+import { describe, it, expect } from "vitest";
+
+describe("Statute Table URL methods", () => {
+    describe("houseGovUrl", () => {
+        it("returns expected URL string", async () => {
+            const statuteItem = statutesFixture[0];
+            const computedUrl = houseGovUrl(statuteItem);
+            expect(computedUrl).toEqual(
+                "https://uscode.house.gov/view.xhtml?hl=false&edition=prelim&req=granuleid%3AUSC-prelim-title42-section1301"
+            );
+        });
+    });
+
+    describe("statuteCompilationUrl", () => {
+        it("returns expected URL string", async () => {
+            const statuteItem = statutesFixture[0];
+            const computedUrl = statuteCompilationUrl(statuteItem);
+            expect(computedUrl).toEqual(
+                "https://www.govinfo.gov/content/pkg/COMPS-8763/pdf/COMPS-8763.pdf"
+            );
+        });
+    });
+
+    describe("ssaGovUrl", () => {
+        it("returns expected URL string", async () => {
+            const statuteItem = statutesFixture[0];
+            const computedUrl = ssaGovUrl(statuteItem);
+            expect(computedUrl).toEqual(
+                "https://www.ssa.gov/OP_Home/ssact/title11/1101.htm"
+            );
+        });
+    });
+
+    describe("usCodeUrl", () => {
+        it("returns expected URL string", async () => {
+            const statuteItem = statutesFixture[0];
+            const computedUrl = usCodeUrl(statuteItem);
+            expect(computedUrl).toEqual(
+                "https://www.govinfo.gov/link/uscode/42/1301"
+            );
+        });
+    });
+});

--- a/solution/ui/regulations/eregs-vite/package-lock.json
+++ b/solution/ui/regulations/eregs-vite/package-lock.json
@@ -11,7 +11,7 @@
         "localforage": "^1.10.0",
         "lodash": "^4.17.21",
         "vue": "^2.7.10",
-        "vue-router": "^3.2.0",
+        "vue-router": "^3.6.5",
         "vue-template-compiler": "^2.7.0",
         "vuetify": "^2.6.10"
       },
@@ -1216,9 +1216,9 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.2.0.tgz",
-      "integrity": "sha512-khkrcUIzMcI1rDcNtqkvLwfRFzB97GmJEsPAQdj7t/VvpGhmXLOkUfhc+Ah8CvpSXGXwuWuQO+x8Sy/xDhXZIA=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
+      "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ=="
     },
     "node_modules/vue-template-compiler": {
       "version": "2.7.10",
@@ -1960,9 +1960,9 @@
       }
     },
     "vue-router": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.2.0.tgz",
-      "integrity": "sha512-khkrcUIzMcI1rDcNtqkvLwfRFzB97GmJEsPAQdj7t/VvpGhmXLOkUfhc+Ah8CvpSXGXwuWuQO+x8Sy/xDhXZIA=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
+      "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ=="
     },
     "vue-template-compiler": {
       "version": "2.7.10",

--- a/solution/ui/regulations/eregs-vite/package.json
+++ b/solution/ui/regulations/eregs-vite/package.json
@@ -12,7 +12,7 @@
     "localforage": "^1.10.0",
     "lodash": "^4.17.21",
     "vue": "^2.7.10",
-    "vue-router": "^3.2.0",
+    "vue-router": "^3.6.5",
     "vue-template-compiler": "^2.7.0",
     "vuetify": "^2.6.10"
   },

--- a/solution/ui/regulations/eregs-vite/src/App.vue
+++ b/solution/ui/regulations/eregs-vite/src/App.vue
@@ -29,6 +29,10 @@ export default {
             type: String,
             default: "",
         },
+        statutesUrl: {
+            type: String,
+            default: "",
+        },
         host: {
             type: String,
             default: "",
@@ -46,6 +50,7 @@ export default {
             :home-url="homeUrl"
             :resources-url="resourcesUrl"
             :search-url="searchUrl"
+            :statutes-url="statutesUrl"
             :host="host"
         />
     </v-app>

--- a/solution/ui/regulations/eregs-vite/src/components/header/HeaderLinks.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/header/HeaderLinks.vue
@@ -13,9 +13,19 @@ const props = defineProps({
         type: String,
         required: true,
     },
+    statutesUrl: {
+        type: String,
+        required: true,
+    },
 });
 
 const links = [
+    {
+        name: "statutes",
+        label: "Statutes",
+        active: window.location.pathname.includes("statutes"),
+        href: props.statutesUrl,
+    },
     {
         name: "resources",
         label: "Resources",
@@ -46,6 +56,7 @@ const closeClick = () => {
         <ul class="links__list links__list--wide">
             <li v-for="(link, index) in links" :key="index">
                 <a
+                    :data-testid="link.name"
                     class="header--links__anchor"
                     :class="{ active: link.active }"
                     :href="link.href"
@@ -67,6 +78,7 @@ const closeClick = () => {
             <ul class="links__list links__list--dropdown">
                 <li v-for="(link, index) in links" :key="index">
                     <a
+                        :data-testid="link.name"
                         class="header--links__anchor"
                         :class="{ active: link.active }"
                         :href="link.href"

--- a/solution/ui/regulations/eregs-vite/src/views/Resources.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Resources.vue
@@ -16,6 +16,7 @@
                     <HeaderLinks
                         :about-url="aboutUrl"
                         :resources-url="resourcesUrl"
+                        :statutes-url="statutesUrl"
                     />
                 </template>
                 <template #search>
@@ -225,6 +226,10 @@ export default {
         searchUrl: {
             type: String,
             default: "/search/",
+        },
+        statutesUrl: {
+            type: String,
+            default: "/statutes/",
         },
         host: {
             type: String,

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -16,6 +16,7 @@
                     <HeaderLinks
                         :about-url="aboutUrl"
                         :resources-url="resourcesUrl"
+                        :statutes-url="statutesUrl"
                     />
                 </template>
                 <template #search>
@@ -218,6 +219,10 @@ export default {
         searchUrl: {
             type: String,
             default: "/search/",
+        },
+        statutesUrl: {
+            type: String,
+            default: "/statutes/",
         },
     },
 

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -1,13 +1,17 @@
 <script setup>
-import { computed, onMounted, onUnmounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { useRoute } from "vue-router/composables";
 
+import { ACT_TYPES } from "eregsComponentLib/src/components/shared-components/Statutes/utils/enums";
 import { getStatutes } from "utilities/api";
 
 import BlockingModal from "eregsComponentLib/src/components/BlockingModal.vue";
 import FlashBanner from "eregsComponentLib/src/components/FlashBanner.vue";
 import IFrameContainer from "eregsComponentLib/src/components/IFrameContainer.vue";
 import SimpleSpinner from "eregsComponentLib/src/components/SimpleSpinner.vue";
+import StatuteSelector from "eregsComponentLib/src/components/shared-components/Statutes/StatuteSelector.vue";
 import StatuteTable from "eregsComponentLib/src/components/shared-components/Statutes/StatuteTable.vue";
+import TableCaption from "eregsComponentLib/src/components/shared-components/Statutes/TableCaption.vue";
 
 import Banner from "@/components/Banner.vue";
 import HeaderComponent from "@/components/header/HeaderComponent.vue";
@@ -38,14 +42,29 @@ const props = defineProps({
     },
 });
 
-// Get statutes
+// get route query params
+const $route = useRoute();
+
+// validate query params to make sure they're in the enum?
+const queryParams = ref({
+    act: $route?.query?.act ?? "ssa",
+    title: $route?.query?.title ?? "19",
+});
+
+// Statutes -- state and fetch method
 const statutes = ref({
     results: [],
     loading: true,
 });
 const getStatutesArray = async () => {
+    statutes.value.loading = true;
+
     try {
-        const statutesArray = await getStatutes({ apiUrl: props.apiUrl });
+        const statutesArray = await getStatutes({
+            act: ACT_TYPES[queryParams.value.act],
+            apiUrl: props.apiUrl,
+            title: queryParams.value.title,
+        });
         statutes.value.results = statutesArray;
     } catch (error) {
         console.error(error);
@@ -54,6 +73,26 @@ const getStatutesArray = async () => {
     }
 };
 
+// watch query params and fetch statutes
+watch(
+    () => $route.query,
+    (newParams, oldParams) => {
+        console.log("watch route", newParams, oldParams);
+        queryParams.value = {
+            act: newParams.act,
+            title: newParams.title,
+        };
+    }
+);
+
+watch(
+    () => queryParams.value,
+    async (newParams, oldParams) => {
+        await getStatutesArray();
+    }
+);
+
+// Watch layout
 const windowWidth = ref(window.innerWidth);
 const isNarrow = computed(() => windowWidth.value < 1024);
 
@@ -117,48 +156,29 @@ getStatutesArray();
             </Banner>
             <div id="main-content" class="statute__container">
                 <div class="content" :style="{ marginLeft: bannerLeftMargin }">
-                    <div class="table__parent">
+                    <div class="content__selector">
+                        <div class="selector__parent">
+                            <h3>Included Statute</h3>
+                            <StatuteSelector
+                                :loading="statutes.loading"
+                                :selected-act="queryParams.act"
+                                :selected-title="queryParams.title"
+                            />
+                        </div>
+                    </div>
+                    <div
+                        class="table__parent"
+                        :class="{ loading: statutes.loading }"
+                    >
                         <SimpleSpinner
                             v-if="statutes.loading"
                             class="table__spinner"
                         />
                         <template v-else>
-                            <div class="table__caption">
-                                In selected Social Security Act titles (XI, XVI,
-                                XVIII, XIX, XXI), find equivalent US Code
-                                citations and read the text in your choice of
-                                government website. Coming up soon: more
-                                navigation options and additional statutes.<br />
-                                Learn more about these sources:
-                                <a
-                                    class="external"
-                                    href="https://uscode.house.gov/"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    >US Code House.gov</a
-                                >,
-                                <a
-                                    class="external"
-                                    href="https://www.govinfo.gov/app/collection/comps/"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    >Statute Compilation</a
-                                >,
-                                <a
-                                    class="external"
-                                    href="https://www.govinfo.gov/app/collection/uscode"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    >US Code Annual</a
-                                >,
-                                <a
-                                    class="external"
-                                    href="https://www.ssa.gov/OP_Home/ssact/ssact.htm"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    >SSA.gov Compilation</a
-                                >.
-                            </div>
+                            <TableCaption
+                                :selected-act="ACT_TYPES[queryParams.act]"
+                                :selected-title="queryParams.title"
+                            />
                             <StatuteTable
                                 :display-type="isNarrow ? 'list' : 'table'"
                                 :filtered-statutes="statutes.results"

--- a/solution/ui/regulations/utilities/api.js
+++ b/solution/ui/regulations/utilities/api.js
@@ -300,7 +300,9 @@ const getCategories = async (apiUrl) => {
  * @returns {string} - date in `MMM DD, YYYY` format or "N/A" if no date available
  */
 const getLastParserSuccessDate = async (apiURL, { title = "42" }) => {
-    const result = await httpApiGetLegacy(`${apiURL}ecfr_parser_result/${title}`);
+    const result = await httpApiGetLegacy(
+        `${apiURL}ecfr_parser_result/${title}`
+    );
     return result.end ? niceDate(result.end.split("T")[0]) : "N/A";
 };
 
@@ -322,7 +324,8 @@ const getTOC = async ({ title, apiUrl }) => {
 const getSectionsForPart = async (title, part) =>
     httpApiGet(`title/${title}/part/${part}/version/latest/sections`);
 
-const getSubpartTOC = async (apiURL, title, part, subPart) => httpApiGetLegacy(
+const getSubpartTOC = async (apiURL, title, part, subPart) =>
+    httpApiGetLegacy(
         `${apiURL}title/${title}/part/${part}/version/latest/subpart/${subPart}/toc`
     );
 
@@ -480,7 +483,7 @@ const getSupplementalContent = async ({
     sortMethod = "newest",
     frGrouping = true,
     builtLocationString = "",
-    apiUrl = ""
+    apiUrl = "",
 }) => {
     const queryString = q ? `&q=${encodeURIComponent(q)}` : "";
     let sString = "";
@@ -517,11 +520,11 @@ const getSupplementalContent = async ({
     sString = `${sString}&location_details=${locationDetails}`;
     sString = `${sString}&start=${start}&max_results=${maxResults}${queryString}`;
     sString = `${sString}&sort=${sortMethod}`;
-    sString = `${sString}&paginate=${paginate}&page_size=${pageSize}&page=${page}`;  
+    sString = `${sString}&paginate=${paginate}&page_size=${pageSize}&page=${page}`;
     sString = `${sString}&fr_grouping=${frGrouping}`;
 
     let response = "";
-    
+
     if (apiUrl) {
         response = await httpApiGetLegacy(`${apiUrl}resources/?${sString}`);
     } else {
@@ -588,19 +591,24 @@ const getParts = async (title, apiUrl) => {
 };
 
 /**
- * @param {string} [act] - Act on which to filter.  Ex: `Social Security Act`
+ * @param {string} [act=Social Security Act] - Act on which to filter.
  * @param {string} [apiUrl] - API base url passed in from Django template
+ * @param {string} [title=19] - Act title number as digits.
  *
  * @returns {Promise <Array<{section: string, title: number, usc: string, act: string, name: string, statute_title: string, source_url: string}>} - Promise that contains array of part objects for provided title when fulfilled
  */
-const getStatutes = async ({ act, apiUrl }) => {
-    const actString = act ? `?act=${encodeURIComponent(act)}` : "";
-
+const getStatutes = async ({
+    act = "Social Security Act",
+    apiUrl,
+    title = "19",
+}) => {
     if (apiUrl) {
-        return httpApiGetLegacy(`${apiUrl}statutes${actString}`);
+        return httpApiGetLegacy(
+            `${apiUrl}statutes?act=${encodeURIComponent(act)}&title=${title}`
+        );
     }
 
-    return httpApiGet(`statutes${actString}`);
+    return httpApiGet(`statutes?act=${encodeURIComponent(act)}&title=${title}`);
 };
 
 export {

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -496,9 +496,7 @@ const getCurrentPageResultsRange = ({ count, page = 1, pageSize }) => {
 
     const firstInRange = minInRange + 1;
     const lastInRange =
-        maxInRange > count
-            ? (count % pageSize) + minInRange
-            : maxInRange;
+        maxInRange > count ? (count % pageSize) + minInRange : maxInRange;
 
     return [firstInRange, lastInRange];
 };
@@ -736,6 +734,40 @@ function trapFocus(element) {
     };
 }
 
+/**
+ * Convert digit to roman numeral.
+ * Adapted from: https://blog.stevenlevithan.com/archives/javascript-roman-numeral-converter#comment-823972
+ *
+ * @param {number} num - number to convert
+ * @returns {string} - roman numeral
+ */
+const romanize = (num) => {
+    var romansObj = {
+        M: 1000,
+        CM: 900,
+        D: 500,
+        CD: 400,
+        C: 100,
+        XC: 90,
+        L: 50,
+        XL: 40,
+        X: 10,
+        IX: 9,
+        V: 5,
+        IV: 4,
+        I: 1,
+    };
+
+    return Object.keys(romansObj).reduce(
+        function (acc, roman) {
+            acc.str += roman.repeat(acc.num / romansObj[roman]);
+            acc.num %= romansObj[roman];
+            return acc;
+        },
+        { str: "", num: num }
+    ).str;
+};
+
 export {
     addMarks,
     addQueryParams,
@@ -772,6 +804,7 @@ export {
     removeFragmentParams,
     removeNulls,
     removeQueryParams,
+    romanize,
     scrollToElement,
     stripQuotes,
     swallowError,

--- a/solution/ui/regulations/utilities/utils.test.js
+++ b/solution/ui/regulations/utilities/utils.test.js
@@ -1,0 +1,22 @@
+import { getCurrentPageResultsRange, romanize } from "utilities/utils.js";
+
+import { describe, it, expect } from "vitest";
+
+describe("Utilities.js", () => {
+    it("getCurrentPageResultsRange properly gets the current page results range", async () => {
+        let obj = { count: 100, page: 1, pageSize: 25 };
+        let results = getCurrentPageResultsRange(obj);
+        expect(results).toStrictEqual([1, 25]);
+
+        obj = { count: 100, page: 2, pageSize: 25 };
+        results = getCurrentPageResultsRange(obj);
+        expect(results).toStrictEqual([26, 50]);
+    });
+
+    it("romanize properly converts numbers to roman numerals", async () => {
+        expect(romanize(1)).toBe("I");
+        expect(romanize(2)).toBe("II");
+        expect(romanize(21)).toBe("XXI");
+        expect(romanize(1936)).toBe("MCMXXXVI");
+    });
+});

--- a/solution/ui/regulations/vitest.config.ts
+++ b/solution/ui/regulations/vitest.config.ts
@@ -1,6 +1,6 @@
 import vue from "@vitejs/plugin-vue2";
 import { defineConfig } from "vite";
-import { aliases } from './alias.js'
+import aliases from './alias.js'
 
 // This is for vue2.  When we make the transition to 3 this must change.
 


### PR DESCRIPTION
Resolves [EREGCSC-1957](https://jiraent.cms.gov/browse/EREGCSC-1957) and [EREGCSC-1923](https://jiraent.cms.gov/browse/EREGCSC-1923)

**Description**

This pull request includes all work done in the `1923-statute-tune-up` branch.  The [pull request for that story](1923-statute-tune-up) was approved, but closed without merging to `main` because additional stories related to the statute table were not yet ready. 

This pull request that you are reading right now will contain all work from 1923 as well as new work for 1957.

New features and functionality specific to this pull request:

- Adds list of SSA Titles that, when clicked, will refine the table to only display rows from that title.  The default title selection is SSA Title XIX / 19.

**This pull request changes:**

- Adds a `StatuteSelector` component to control which act and title is displayed on the Statutes page
- Styles `StatuteSelector` to match [Figma](https://www.figma.com/proto/mXCFChrIR50gbFAvXV0kgB/statute-to-USC-conversion?type=design&node-id=60-618&scaling=min-zoom&page-id=60%3A617)
- Adds Vitest tests for `StatuteSelector` component and extends existing Cypress end to end tests for the Statutes page
- Updates the table caption based on Slack conversation with Britta

**Steps to manually verify this change:**

1. Visit [experimental deployment](https://lyehc1jclf.execute-api.us-east-1.amazonaws.com/dev901) and make sure it looks like the Figma doc and matches the behavior notes (except the horizontal scrolling behavior, which is not implemented)
2. Make sure all Vitest and Cypress tests pass

