### PR TITLE
[HOTFIX] Update Statutes end to end test so that v3/statutes intercept works

### DIFF
--- a/solution/ui/e2e/cypress/e2e/statutes.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/statutes.spec.cy.js
@@ -4,7 +4,7 @@ describe("Statute Table", () => {
             req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
         });
 
-        cy.intercept(`**/v3/statutes`, {
+        cy.intercept(`**/v3/statutes**`, {
             fixture: "statutes.json",
         }).as("statutes");
     });
@@ -38,7 +38,7 @@ describe("Statute Table", () => {
     });
 
     it("displays as a list at widths narrower than 1024px", () => {
-        cy.viewport(1023, 768);
+        cy.viewport(1023, 1000);
         cy.visit("/statutes");
         cy.get("#statuteTable").should("not.exist");
         cy.get("#statuteList").should("be.visible");

--- a/solution/ui/regulations/eregs-component-lib/package-lock.json
+++ b/solution/ui/regulations/eregs-component-lib/package-lock.json
@@ -396,7 +396,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -412,7 +411,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -428,7 +426,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -444,7 +441,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -460,7 +456,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -476,7 +471,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -492,7 +486,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -508,7 +501,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -524,7 +516,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -540,7 +531,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -556,7 +546,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -572,7 +561,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -588,7 +576,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -604,7 +591,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -620,7 +606,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -636,7 +621,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -652,7 +636,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -668,7 +651,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -684,7 +666,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -700,7 +681,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -716,7 +696,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -732,7 +711,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1267,7 +1245,6 @@
       "version": "0.17.17",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.17.tgz",
       "integrity": "sha512-/jUywtAymR8jR4qsa2RujlAF7Krpt5VWi72Q2yuLD4e/hvtNcFQ0I1j8m/bxq238pf3/0KO5yuXNpuLx8BE1KA==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -2168,7 +2145,6 @@
       "version": "3.24.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.24.0.tgz",
       "integrity": "sha512-OgraHOIg2YpHQTjl0/ymWfFNBEyPucB7lmhXrQUh38qNOegxLapSPFs9sNr0qKR75awW41D93XafoR2QfhBdUQ==",
-      "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -2510,7 +2486,6 @@
       "version": "4.3.9",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
       "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
-      "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",
         "postcss": "^8.4.23",


### PR DESCRIPTION
Resolves deployment issue where intercept for Statutes e2e test was not written correctly and was not working.

**Description**

Currently our `dev` and `val` environments do not have statute data -- the `v3/statutes` endpoint returns an empty array.  This is being worked on in another story.

However, our Cypress end to end tests generally intercept API calls and use fixtures/mock data instead of actual data.  So the empty array response from the `v3/statutes` endpoint should not have been an issue.

**This pull request changes:**

- adds a double asterisk glob matcher in the `v3/statutes` intercept URL so that the fixture of mock data is returned instead of real data.

**Steps to manually verify this change:**

1. Run e2e tests locally.  Watch the Statutes test and step through it when it is done, making sure the rendered table contains fixture data and not actual API response data.

