### PR TITLE
[HOTFIX] Null source_url in statute response item causing console/rendering error

### DIFF
--- a/solution/ui/e2e/cypress/fixtures/statutes.json
+++ b/solution/ui/e2e/cypress/fixtures/statutes.json
@@ -17,7 +17,7 @@
         "name": "Rules and regulations.",
         "statute_title": 11,
         "statute_title_roman": "XI",
-        "source_url": "https://www.govinfo.gov/content/pkg/COMPS-8763/uslm/COMPS-8763.xml"
+        "source_url": null
     },
     {
         "section": "1103",

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/BodyCell.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/BodyCell.test.js
@@ -10,7 +10,9 @@ import BodyCell from "./BodyCell.vue";
 describe("Statute Table Body Cell", () => {
     describe("SSA table type", () => {
         ssaSchema.forEach((column, index) => {
-            it(`Creates a snapshot of a body cell for column ${index + 1}`, async () => {
+            it(`Creates a snapshot of a body cell for column ${
+                index + 1
+            }`, async () => {
                 const wrapper = render(BodyCell, {
                     props: {
                         cellData: column,
@@ -20,17 +22,23 @@ describe("Statute Table Body Cell", () => {
                 await flushPromises();
                 expect(wrapper).toMatchSnapshot();
             });
+        });
 
-            it(`Creates a snapshot of a body cell for column ${index + 1} with a null source_url`, async () => {
-                const wrapper = render(BodyCell, {
-                    props: {
-                        cellData: column,
-                        statute: statutesFixture[1],
-                    },
-                });
-                await flushPromises();
-                expect(wrapper).toMatchSnapshot();
+        it("displays 'None' in Statute Compilation BodyCell when source_url is null", async () => {
+            const statuteCompilationCellSchema = ssaSchema[2];
+
+            const wrapper = render(BodyCell, {
+                props: {
+                    cellData: statuteCompilationCellSchema,
+                    statute: statutesFixture[1],
+                },
             });
+            await flushPromises();
+
+            const nullCell = wrapper.getByTestId("1302-none").textContent;
+            expect(nullCell).toEqual("None");
+
+            expect(wrapper).toMatchSnapshot();
         });
     });
 });

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/BodyCell.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/BodyCell.test.js
@@ -20,6 +20,17 @@ describe("Statute Table Body Cell", () => {
                 await flushPromises();
                 expect(wrapper).toMatchSnapshot();
             });
+
+            it(`Creates a snapshot of a body cell for column ${index + 1} with a null source_url`, async () => {
+                const wrapper = render(BodyCell, {
+                    props: {
+                        cellData: column,
+                        statute: statutesFixture[1],
+                    },
+                });
+                await flushPromises();
+                expect(wrapper).toMatchSnapshot();
+            });
         });
     });
 });

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/BodyCell.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/BodyCell.vue
@@ -32,12 +32,14 @@ const props = defineProps({
         </template>
         <template v-else>
             <a
+                v-if="cellData.body.url(statute)"
                 :class="cellData.body.type"
                 :href="cellData.body.url(statute)"
                 target="_blank"
                 rel="noopener noreferrer"
                 >{{ cellData.body.text(statute) }}</a
             >
+            <span v-else>None</span>
         </template>
     </td>
 </template>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/BodyCell.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/BodyCell.vue
@@ -39,7 +39,7 @@ const props = defineProps({
                 rel="noopener noreferrer"
                 >{{ cellData.body.text(statute) }}</a
             >
-            <span v-else>None</span>
+            <span v-else :data-testid="statute.usc + '-none'">None</span>
         </template>
     </td>
 </template>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/BodyCell.test.js.snap
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/BodyCell.test.js.snap
@@ -103,109 +103,6 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
 }
 `;
 
-exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 1 with a null source_url 1`] = `
-{
-  "baseElement": <body>
-    <div>
-      <td
-        class="row__cell row__cell--body row__cell--primary"
-      >
-        <div
-          class="cell__title"
-        >
-           SSA Section 1102 
-        </div>
-        <div
-          class="cell__usc-label"
-        >
-           42 U.S.C. 1302 
-        </div>
-        <div
-          class="cell__name"
-        >
-           Rules and regulations. 
-        </div>
-      </td>
-    </div>
-  </body>,
-  "container": <div>
-    <td
-      class="row__cell row__cell--body row__cell--primary"
-    >
-      <div
-        class="cell__title"
-      >
-         SSA Section 1102 
-      </div>
-      <div
-        class="cell__usc-label"
-      >
-         42 U.S.C. 1302 
-      </div>
-      <div
-        class="cell__name"
-      >
-         Rules and regulations. 
-      </div>
-    </td>
-  </div>,
-  "debug": [Function],
-  "emitted": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "html": [Function],
-  "isUnmounted": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "unmount": [Function],
-  "updateProps": [Function],
-}
-`;
-
 exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 2 1`] = `
 {
   "baseElement": <body>
@@ -235,95 +132,6 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
         target="_blank"
       >
         1301
-      </a>
-    </td>
-  </div>,
-  "debug": [Function],
-  "emitted": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "html": [Function],
-  "isUnmounted": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "unmount": [Function],
-  "updateProps": [Function],
-}
-`;
-
-exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 2 with a null source_url 1`] = `
-{
-  "baseElement": <body>
-    <div>
-      <td
-        class="row__cell row__cell--body row__cell--secondary"
-      >
-        <a
-          class="external"
-          href="https://uscode.house.gov/view.xhtml?hl=false&edition=prelim&req=granuleid%3AUSC-prelim-title42-section1302"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          1302
-        </a>
-      </td>
-    </div>
-  </body>,
-  "container": <div>
-    <td
-      class="row__cell row__cell--body row__cell--secondary"
-    >
-      <a
-        class="external"
-        href="https://uscode.house.gov/view.xhtml?hl=false&edition=prelim&req=granuleid%3AUSC-prelim-title42-section1302"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        1302
       </a>
     </td>
   </div>,
@@ -473,85 +281,6 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
 }
 `;
 
-exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 3 with a null source_url 1`] = `
-{
-  "baseElement": <body>
-    <div>
-      <td
-        class="row__cell row__cell--body row__cell--secondary"
-      >
-        <span>
-          None
-        </span>
-      </td>
-    </div>
-  </body>,
-  "container": <div>
-    <td
-      class="row__cell row__cell--body row__cell--secondary"
-    >
-      <span>
-        None
-      </span>
-    </td>
-  </div>,
-  "debug": [Function],
-  "emitted": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "html": [Function],
-  "isUnmounted": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "unmount": [Function],
-  "updateProps": [Function],
-}
-`;
-
 exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 4 1`] = `
 {
   "baseElement": <body>
@@ -581,95 +310,6 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
         target="_blank"
       >
         1301
-      </a>
-    </td>
-  </div>,
-  "debug": [Function],
-  "emitted": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "html": [Function],
-  "isUnmounted": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "unmount": [Function],
-  "updateProps": [Function],
-}
-`;
-
-exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 4 with a null source_url 1`] = `
-{
-  "baseElement": <body>
-    <div>
-      <td
-        class="row__cell row__cell--body row__cell--secondary"
-      >
-        <a
-          class="pdf"
-          href="https://www.govinfo.gov/link/uscode/42/1302"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          1302
-        </a>
-      </td>
-    </div>
-  </body>,
-  "container": <div>
-    <td
-      class="row__cell row__cell--body row__cell--secondary"
-    >
-      <a
-        class="pdf"
-        href="https://www.govinfo.gov/link/uscode/42/1302"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        1302
       </a>
     </td>
   </div>,
@@ -819,21 +459,18 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
 }
 `;
 
-exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 5 with a null source_url 1`] = `
+exports[`Statute Table Body Cell > SSA table type > displays 'None' in Statute Compilation BodyCell when source_url is null 1`] = `
 {
   "baseElement": <body>
     <div>
       <td
         class="row__cell row__cell--body row__cell--secondary"
       >
-        <a
-          class="external"
-          href="https://www.ssa.gov/OP_Home/ssact/title11/1102.htm"
-          rel="noopener noreferrer"
-          target="_blank"
+        <span
+          data-testid="1302-none"
         >
-          1102
-        </a>
+          None
+        </span>
       </td>
     </div>
   </body>,
@@ -841,14 +478,11 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
     <td
       class="row__cell row__cell--body row__cell--secondary"
     >
-      <a
-        class="external"
-        href="https://www.ssa.gov/OP_Home/ssact/title11/1102.htm"
-        rel="noopener noreferrer"
-        target="_blank"
+      <span
+        data-testid="1302-none"
       >
-        1102
-      </a>
+        None
+      </span>
     </td>
   </div>,
   "debug": [Function],

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/BodyCell.test.js.snap
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/BodyCell.test.js.snap
@@ -103,6 +103,109 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
 }
 `;
 
+exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 1 with a null source_url 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <td
+        class="row__cell row__cell--body row__cell--primary"
+      >
+        <div
+          class="cell__title"
+        >
+           SSA Section 1102 
+        </div>
+        <div
+          class="cell__usc-label"
+        >
+           42 U.S.C. 1302 
+        </div>
+        <div
+          class="cell__name"
+        >
+           Rules and regulations. 
+        </div>
+      </td>
+    </div>
+  </body>,
+  "container": <div>
+    <td
+      class="row__cell row__cell--body row__cell--primary"
+    >
+      <div
+        class="cell__title"
+      >
+         SSA Section 1102 
+      </div>
+      <div
+        class="cell__usc-label"
+      >
+         42 U.S.C. 1302 
+      </div>
+      <div
+        class="cell__name"
+      >
+         Rules and regulations. 
+      </div>
+    </td>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
 exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 2 1`] = `
 {
   "baseElement": <body>
@@ -132,6 +235,95 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
         target="_blank"
       >
         1301
+      </a>
+    </td>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 2 with a null source_url 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <td
+        class="row__cell row__cell--body row__cell--secondary"
+      >
+        <a
+          class="external"
+          href="https://uscode.house.gov/view.xhtml?hl=false&edition=prelim&req=granuleid%3AUSC-prelim-title42-section1302"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          1302
+        </a>
+      </td>
+    </div>
+  </body>,
+  "container": <div>
+    <td
+      class="row__cell row__cell--body row__cell--secondary"
+    >
+      <a
+        class="external"
+        href="https://uscode.house.gov/view.xhtml?hl=false&edition=prelim&req=granuleid%3AUSC-prelim-title42-section1302"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        1302
       </a>
     </td>
   </div>,
@@ -281,6 +473,85 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
 }
 `;
 
+exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 3 with a null source_url 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <td
+        class="row__cell row__cell--body row__cell--secondary"
+      >
+        <span>
+          None
+        </span>
+      </td>
+    </div>
+  </body>,
+  "container": <div>
+    <td
+      class="row__cell row__cell--body row__cell--secondary"
+    >
+      <span>
+        None
+      </span>
+    </td>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
 exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 4 1`] = `
 {
   "baseElement": <body>
@@ -370,6 +641,95 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
 }
 `;
 
+exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 4 with a null source_url 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <td
+        class="row__cell row__cell--body row__cell--secondary"
+      >
+        <a
+          class="pdf"
+          href="https://www.govinfo.gov/link/uscode/42/1302"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          1302
+        </a>
+      </td>
+    </div>
+  </body>,
+  "container": <div>
+    <td
+      class="row__cell row__cell--body row__cell--secondary"
+    >
+      <a
+        class="pdf"
+        href="https://www.govinfo.gov/link/uscode/42/1302"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        1302
+      </a>
+    </td>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
 exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 5 1`] = `
 {
   "baseElement": <body>
@@ -399,6 +759,95 @@ exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body
         target="_blank"
       >
         1101
+      </a>
+    </td>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Body Cell > SSA table type > Creates a snapshot of a body cell for column 5 with a null source_url 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <td
+        class="row__cell row__cell--body row__cell--secondary"
+      >
+        <a
+          class="external"
+          href="https://www.ssa.gov/OP_Home/ssact/title11/1102.htm"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          1102
+        </a>
+      </td>
+    </div>
+  </body>,
+  "container": <div>
+    <td
+      class="row__cell row__cell--body row__cell--secondary"
+    >
+      <a
+        class="external"
+        href="https://www.ssa.gov/OP_Home/ssact/title11/1102.htm"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        1102
       </a>
     </td>
   </div>,

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/urlMethods.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/urlMethods.js
@@ -10,12 +10,15 @@ const houseGovUrl = ({ title, usc }) =>`https://uscode.house.gov/view.xhtml?hl=f
 /**
  * @param {string} souce_url - URL containing COMPS number
  *
- * @returns {string} url - url to GovInfo.gov page displaying Statute Compilation PDF
+ * @returns {string | null} url - url to GovInfo.gov page displaying Statute Compilation PDF
  */
 const statuteCompilationUrl = ({ source_url }) => {
+    if (!source_url) return null;
+
     const compsNumber = source_url
         .split("/")
         .find((str) => str.includes("COMPS"));
+
     return `https://www.govinfo.gov/content/pkg/${compsNumber}/pdf/${compsNumber}.pdf`;
 };
 

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/urlMethods.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/urlMethods.test.js
@@ -21,12 +21,18 @@ describe("Statute Table URL methods", () => {
     });
 
     describe("statuteCompilationUrl", () => {
-        it("returns expected URL string", async () => {
+        it("returns expected URL string if source_url is valid", async () => {
             const statuteItem = statutesFixture[0];
             const computedUrl = statuteCompilationUrl(statuteItem);
             expect(computedUrl).toEqual(
                 "https://www.govinfo.gov/content/pkg/COMPS-8763/pdf/COMPS-8763.pdf"
             );
+        });
+
+        it("returns null if source_url is null", async () => {
+            const statuteItem = statutesFixture[1];
+            const computedUrl = statuteCompilationUrl(statuteItem);
+            expect(computedUrl).toBeNull();
         });
     });
 

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -77,7 +77,6 @@ const getStatutesArray = async () => {
 watch(
     () => $route.query,
     (newParams, oldParams) => {
-        console.log("watch route", newParams, oldParams);
         queryParams.value = {
             act: newParams.act,
             title: newParams.title,


### PR DESCRIPTION
**Description-**

Resolves `prod` issue where some items returned from the `v3/statutes` endpoint have a `null` `source_url` field; this is not being handled appropriately and is throwing an error in the console and not rendering some rows correctly.

**This pull request changes:**

- updates `statuteCompilationUrl` utility method to expect `null` prop and to early return `null` in response
- updates `BodyCell.vue` component to handle `null` response from `statuteCompilationUrl` and render "None" instead of an anchor
- Extends unit tests and snapshot tests to add coverage for new functionality

**Steps to manually verify this change:**

1. All Vitest tests pass
2. All Cypress tests pass

