### PR TITLE
EREGCSC-2032 -- Implement ruff rules G, S W, ASYNC.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.272
+    rev: v0.0.28
     hooks:
       - id: ruff
   - repo: https://github.com/zricethezav/gitleaks

--- a/solution/backend/pyproject.toml
+++ b/solution/backend/pyproject.toml
@@ -3,11 +3,11 @@ DJANGO_SETTINGS_MODULE = "cmcs_regulations.settings.test_settings"
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F"]
+select = ["E", "F", "G", "S", "W", "ASYNC"]
 ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["E", "F"]
+fixable = ["E", "F", "W"]
 unfixable = []
 
 # Exclude a variety of commonly ignored directories.

--- a/solution/backend/regulations/admin.py
+++ b/solution/backend/regulations/admin.py
@@ -1,5 +1,4 @@
 import re
-from xml.dom import minidom
 
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
@@ -10,6 +9,7 @@ from django.urls import path, reverse
 
 import requests
 from solo.admin import SingletonModelAdmin
+from defusedxml.minidom import parse
 
 from .models import (
     SiteConfiguration,
@@ -155,7 +155,7 @@ class StatuteLinkConverterAdmin(admin.ModelAdmin):
 
     def parse_toc(self, text):
         try:
-            dom = minidom.parseString(text)
+            dom = parse(text)
         except Exception as e:
             raise ValidationError(f"invalid XML detected: {str(e)}")
 
@@ -209,7 +209,7 @@ class StatuteLinkConverterAdmin(admin.ModelAdmin):
         except ValidationError:
             raise ValidationError(f"{url} is not a valid URL." if url else "you must enter a URL.")
 
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         response.raise_for_status()
         conversions, matches, failures = self.import_conversions(response.text, url, act)
         if conversions or failures:

--- a/solution/backend/regulations/templatetags/citation.py
+++ b/solution/backend/regulations/templatetags/citation.py
@@ -16,7 +16,7 @@ def citation(citation, autoescape=True):
         citation = conditional_escape(citation)
     citation = linkify(citation)
 
-    return mark_safe(citation)  # nosec
+    return mark_safe(citation)  # nosec # noqa: S308
 
 
 def linkify(citation):

--- a/solution/backend/resources/admin.py
+++ b/solution/backend/resources/admin.py
@@ -87,7 +87,7 @@ class LocationAdmin(BaseAdmin):
                                           args=(child.id,)), str(child))
                                  for child in obj.resources.all()])
         if display_text:
-            return mark_safe(display_text)
+            return mark_safe(display_text)  # noqa: S308
         return "-"
 
     def get_queryset(self, request):
@@ -305,7 +305,7 @@ class ResourceForm(forms.ModelForm):
     bulk_locations = forms.CharField(
                         widget=forms.Textarea,
                         required=False,
-                        help_text=mark_safe("Add a list of locations separated by a comma.  " +
+                        help_text=mark_safe("Add a list of locations separated by a comma.  " +  # noqa: S308
                                             "ex. 42 430.10, 42 430 Subpart B, 45 18.150 " +
                                             "<a href='https://docs.google.com/document/d/1HKjg5pUQn" +
                                             "RP98i9xbGy0fPiGq_0a6p2PRXhwuDbmiek/edit#' " +
@@ -368,7 +368,7 @@ class ResourceForm(forms.ModelForm):
                                           args=(res['id'],)), res['type'] + " " + str(res['name']))
                                  for res in resources)
         if display_text:
-            return mark_safe(display_text)
+            return mark_safe(display_text)  # noqa: S308
         return "-"
 
     def clean(self):
@@ -438,7 +438,7 @@ class SupplementalContentAdmin(AbstractResourceAdmin):
                                   reverse('admin:{}_{}_change'.format("resources", "supplementalcontent"),
                                           args=(obj.id,)), obj.name)
         if display_text:
-            return mark_safe(display_text)
+            return mark_safe(display_text)  # noqa: S308
         return "-"
 
     def add_content(self, reader):

--- a/solution/static-assets/requirements.txt
+++ b/solution/static-assets/requirements.txt
@@ -19,3 +19,4 @@ ruff
 pytest
 pytest-django==4.5
 pre-commit
+defusedxml


### PR DESCRIPTION
Resolves # EREGCS-2032 and EREGCSC-2026

**Description-**

Adding the following rules for RUFF
G - Flake8 log formatting
S - Flake8 bandiit
W - Warning
ASYNC- flake8-async (ASYNC)

G, W, ASYNC have zero impact on our code so they are simply just added.
S looks over security vulnerabilities.  Some were related to xml parsing, some are worried about sql injection.  Ignores have been put on our marksafe since those inputs are determined by the backend not the user.  Also put a block on the remove lambda for prod.  Making a future ticket to remove the lambda from prod since we would never be running this in the production environment.

**This pull request changes...**

- Running ruff will not produce any errors with the new rules.  All other funcitonality is the same.

**Steps to manually verify this change...**

1. Verify that ruff runs correctly.

