### PR TITLE
EREGCSC-2041 -- Set up url and configs for OIDC

### DIFF
--- a/.github/workflows/git-secrets.yaml
+++ b/.github/workflows/git-secrets.yaml
@@ -4,7 +4,7 @@ jobs:
   gitleaks-scan:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run gitlakes docker	    
       uses: docker://zricethezav/gitleaks
       with:

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -72,7 +72,6 @@ OIDC_RP_IDP_SIGN_KEY = os.environ.get("OIDC_RP_IDP_SIGN_KEY", None)
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
     'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
-    # ...
 )
 OIDC_RP_CLIENT_ID = os.environ.get("OIDC_RP_CLIENT_ID", None)
 OIDC_RP_CLIENT_SECRET = os.environ.get("OIDC_RP_CLIENT_SECRET", None)

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     "debug_toolbar",
     'django.contrib.admin',
     'django.contrib.auth',
+    'mozilla_django_oidc',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
@@ -66,6 +67,18 @@ MIDDLEWARE = [
     'regulations.middleware.NoIndex',
     'regcore.middleware.HtmlApi',
 ]
+OIDC_RP_IDP_SIGN_KEY = os.environ.get("OIDC_RP_IDP_SIGN_KEY", None)
+# Add 'mozilla_django_oidc' authentication backend
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
+    # ...
+)
+OIDC_RP_CLIENT_ID = os.environ.get("OIDC_RP_CLIENT_ID", None)
+OIDC_RP_CLIENT_SECRET = os.environ.get("OIDC_RP_CLIENT_SECRET", None)
+OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("OIDC_OP_AUTHORIZATION_ENDPOINT", None)
+OIDC_OP_TOKEN_ENDPOINT = os.environ.get("OIDC_OP_TOKEN_ENDPOINT", None)
+OIDC_OP_USER_ENDPOINT = os.environ.get("OIDC_OP_USER_ENDPOINT", None)
 
 REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (

--- a/solution/backend/cmcs_regulations/urls.py
+++ b/solution/backend/cmcs_regulations/urls.py
@@ -36,4 +36,5 @@ urlpatterns = [
     path('__debug__/', include('debug_toolbar.urls')),
     path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
     path('latest/feed/', ResourceFeed()),
+    path('oidc/', include('mozilla_django_oidc.urls')),
 ]

--- a/solution/static-assets/requirements.txt
+++ b/solution/static-assets/requirements.txt
@@ -20,3 +20,4 @@ pytest
 pytest-django==4.5
 pre-commit
 defusedxml
+mozilla-django-oidc


### PR DESCRIPTION
Resolves # EREGCSC-2041

**Description-**

In order for us to set up oAuth we need a call back url.  This is getting us set up.

**This pull request changes...**

- A call back url is set up for our app at {{host}}//oidc/callback/


**Steps to manually verify this change...**

1. Go to https://gqhz3je798.execute-api.us-east-1.amazonaws.com/dev914/oidc/callback  .  You will see a forbidden message.  We do not have a client secret yet so it wont work.
2. Go to the admin panel and log in.  You should be able to log in still with the old method of django.  You can do this either through your local or the dev site.  We expanded the django auth backends to include a new method as well as the old method.  Without explicitly adding the old method in settings it will not work.

