### PR TITLE
EREGCSC-2062 -- Added populate content to deploy for val and dev

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,14 +88,16 @@ jobs:
           serverless invoke --function create_su --stage ${{ matrix.environment }}
           echo "url=$(cat output.log | grep -m1 'ANY -' | cut -c 9-)" >> $GITHUB_OUTPUT
           popd
-      - name: condtional output for prod
-        id: condtional-output-for-prod
-        if: ${{ matrix.environment  == 'prod' }}
-        run: echo "prod is here"
-      - name: conditional output for other environments
+      - name: Populate content for ${{ matrix.environment }}
         id: condtional-output-for-not-prod
         if: ${{ matrix.environment  != 'prod' }}
-        run: echo "this is not prod"
+        run: |
+          pushd solution/backend
+          npm install serverless -g
+          npm install
+          serverless invoke --function populate_content --stage ${{ matrix.environment }}
+          echo "url=$(cat output.log | grep -m1 'ANY -' | cut -c 9-)" >> $GITHUB_OUTPUT
+          popd
       # vite needs the .env file in order to know the URL of the api.
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3


### PR DESCRIPTION
Resolves # EREGCSC-2062

Populate dev and val with populate content on build

**Description-**

Currently dev and val seed data are only populated when you log into aws and run the lambda.  This will execute the lambda on those environments on deploy.  The populate content lamda only exist in dev and val.  it does not exist in prod anymore so it has no chance of populting.  On deploy it will check the envrionment and if it is not prod it will run the lambda.

**This pull request changes...**

- Populatecontent lambda executes in dev and val.

**Steps to manually verify this change...**

1. When the deploy happens in dev the step for running in dev will run.
2. When the deploy happens in val the lamda will run.
3. The step will be skipped in prod(the lambda does not exist in prod which has already been verified).

