### PR TITLE
EREGCSC-1964-C Collapse exceptions widgets by default

### DIFF
--- a/solution/backend/regulations/admin.py
+++ b/solution/backend/regulations/admin.py
@@ -87,7 +87,28 @@ class SiteConfigurationAdmin(SingletonModelAdmin):
 
 @admin.register(StatuteLinkConfiguration)
 class StatuteLinkConfigurationAdmin(SingletonModelAdmin):
-    pass
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": ["link_statute_refs", "link_usc_refs"],
+            },
+        ),
+        (
+            "Statute Ref Link Exceptions",
+            {
+                "classes": ["collapse"],
+                "fields": ["statute_ref_exceptions"],
+            },
+        ),
+        (
+            "U.S.C. Ref Link Exceptions",
+            {
+                "classes": ["collapse"],
+                "fields": ["usc_ref_exceptions"],
+            },
+        ),
+    ]
 
 
 @admin.register(StatuteLinkConverter)


### PR DESCRIPTION
Resolves #1964

**Description-**

This PR is not part of the AC for the original ticket, it just collapses the widgets on the admin panel by default to reduce clutter on the config page. This is particularly helpful once lots of exceptions are added so users don't have to scroll far down to get to U.S.C. exceptions, for example.

**This pull request changes...**

- Widget is collapsed by default

**Steps to manually verify this change...**

1. Go to Statute Link Configuration and make sure the Statute and U.S.C. Ref Exceptions widgets are collapsed and show properly when clicked.

