### PR TITLE
oidc removal

### DIFF
--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -32,7 +32,7 @@ INSTALLED_APPS = [
     "debug_toolbar",
     'django.contrib.admin',
     'django.contrib.auth',
-    'mozilla_django_oidc',
+    #'mozilla_django_oidc',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
@@ -67,17 +67,14 @@ MIDDLEWARE = [
     'regulations.middleware.NoIndex',
     'regcore.middleware.HtmlApi',
 ]
-OIDC_RP_IDP_SIGN_KEY = os.environ.get("OIDC_RP_IDP_SIGN_KEY", None)
+#  OIDC_RP_IDP_SIGN_KEY = os.environ.get("OIDC_RP_IDP_SIGN_KEY", None)
 # Add 'mozilla_django_oidc' authentication backend
-AUTHENTICATION_BACKENDS = (
-    'django.contrib.auth.backends.ModelBackend',
-    'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
-)
-OIDC_RP_CLIENT_ID = os.environ.get("OIDC_RP_CLIENT_ID", None)
-OIDC_RP_CLIENT_SECRET = os.environ.get("OIDC_RP_CLIENT_SECRET", None)
-OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("OIDC_OP_AUTHORIZATION_ENDPOINT", None)
-OIDC_OP_TOKEN_ENDPOINT = os.environ.get("OIDC_OP_TOKEN_ENDPOINT", None)
-OIDC_OP_USER_ENDPOINT = os.environ.get("OIDC_OP_USER_ENDPOINT", None)
+
+# OIDC_RP_CLIENT_ID = os.environ.get("OIDC_RP_CLIENT_ID", None)
+# OIDC_RP_CLIENT_SECRET = os.environ.get("OIDC_RP_CLIENT_SECRET", None)
+# OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("OIDC_OP_AUTHORIZATION_ENDPOINT", None)
+# OIDC_OP_TOKEN_ENDPOINT = os.environ.get("OIDC_OP_TOKEN_ENDPOINT", None)
+# OIDC_OP_USER_ENDPOINT = os.environ.get("OIDC_OP_USER_ENDPOINT", None)
 
 REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -32,7 +32,7 @@ INSTALLED_APPS = [
     "debug_toolbar",
     'django.contrib.admin',
     'django.contrib.auth',
-    #'mozilla_django_oidc',
+    # 'mozilla_django_oidc',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -32,7 +32,6 @@ INSTALLED_APPS = [
     "debug_toolbar",
     'django.contrib.admin',
     'django.contrib.auth',
-    # 'mozilla_django_oidc',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',

--- a/solution/backend/cmcs_regulations/settings/eua_settings.py
+++ b/solution/backend/cmcs_regulations/settings/eua_settings.py
@@ -1,0 +1,37 @@
+from .base import * # noqa
+import os
+
+INSTALLED_APPS += [ # noqa
+    'mozilla_django_oidc',
+]
+
+OIDC_RP_IDP_SIGN_KEY = os.environ.get("OIDC_RP_IDP_SIGN_KEY", None)
+# Add 'mozilla_django_oidc' authentication backend
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'mozilla_django_oidc.auth.OIDCAuthenticationBackend',
+)
+OIDC_RP_CLIENT_ID = os.environ.get("OIDC_RP_CLIENT_ID", None)
+OIDC_RP_CLIENT_SECRET = os.environ.get("OIDC_RP_CLIENT_SECRET", None)
+OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("OIDC_OP_AUTHORIZATION_ENDPOINT", None)
+OIDC_OP_TOKEN_ENDPOINT = os.environ.get("OIDC_OP_TOKEN_ENDPOINT", None)
+OIDC_OP_USER_ENDPOINT = os.environ.get("OIDC_OP_USER_ENDPOINT", None)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'USER': os.environ.get('DB_USER', 'eregs'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', 'sgere'),
+        'HOST': os.environ.get('DB_HOST', 'db'),
+        'PORT': os.environ.get('DB_PORT', '5432'),
+        'NAME': os.environ.get('DB_NAME', 'eregs'),
+    },
+    'postgres': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'USER': os.environ.get('DB_USER', 'eregs'),
+        'PASSWORD': os.environ.get('DB_PASSWORD', 'sgere'),
+        'HOST': os.environ.get('DB_HOST', 'db'),
+        'PORT': os.environ.get('DB_PORT', '5432'),
+        'NAME': "postgres",
+    },
+}

--- a/solution/backend/cmcs_regulations/urls.py
+++ b/solution/backend/cmcs_regulations/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
     path('__debug__/', include('debug_toolbar.urls')),
     path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
     path('latest/feed/', ResourceFeed()),
-    # path('oidc/', include('mozilla_django_oidc.urls')),
+    path('oidc/', include('mozilla_django_oidc.urls')),
 ]
 admin.site.site_header = "eRegs"
 admin.site.site_title = 'eRegs Admin Panel'

--- a/solution/backend/cmcs_regulations/urls.py
+++ b/solution/backend/cmcs_regulations/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
     path('__debug__/', include('debug_toolbar.urls')),
     path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
     path('latest/feed/', ResourceFeed()),
-    path('oidc/', include('mozilla_django_oidc.urls')),
+    # path('oidc/', include('mozilla_django_oidc.urls')),
 ]
 admin.site.site_header = "eRegs"
 admin.site.site_title = 'eRegs Admin Panel'


### PR DESCRIPTION
Resolves #

**Description-**

There seems to be an issue with django admin when someone changes their password.  We arent to sure the cause but it might have something to do with the OIDC login not being fully set up yet.  We are seprating the OIDC settings to its own file.  OIDC settings will not be used yet.  This was going to be done in a later stage but this might fix the issue we are seeing.

**This pull request changes...**

- OIDC settings are split into its own settings file.  This will not be used yet.

**Steps to manually verify this change...**
1.  Go to the dev admin site for the experimental branch: https://x3l5zt4in1.execute-api.us-east-1.amazonaws.com/dev921/admin/
2. login with the account
3. change the password
4. log out and log back in.

1. Prod login for admin is working.  


