### PR TITLE
EREGCSC-2046 -- Add external link icon to citation

### DIFF
--- a/solution/backend/regulations/templatetags/citation.py
+++ b/solution/backend/regulations/templatetags/citation.py
@@ -6,7 +6,7 @@ from django.utils.html import conditional_escape
 
 register = template.Library()
 
-el = ('<a href="https://federalregister.gov/citation/', '" target="_blank" rel="noopener noreferrer">', '</a>')
+el = ('<a href="https://federalregister.gov/citation/', '" target="_blank" rel="noopener noreferrer" class="external">', '</a>')
 
 
 @register.filter(name='citation', needs_autoescape=True, is_safe=True)


### PR DESCRIPTION
Resolves # ERGCSC-2046

**Description-**

The external link icon is missing on citations for sections in the reader view.  This is to add the icon

**This pull request changes...**

- An external link icon will appear on citations in sections

**Steps to manually verify this change...**

1. Go to any subpart view that has a sections in it that have citations.
2. All hyperlinks will have the external link icon in it.

