### PR TITLE
EREGCSC-2029 - Implement I sort ruff

### DIFF
--- a/solution/backend/cmcs_regulations/urls.py
+++ b/solution/backend/cmcs_regulations/urls.py
@@ -13,14 +13,15 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import path, include
 from django.conf import settings
-from django.views.generic.base import RedirectView, TemplateView
-from django.contrib.sitemaps.views import sitemap
+from django.contrib import admin
 from django.contrib.auth import views as auth_views
-from regulations.sitemap import PartSitemap, SupplementalContentSitemap
+from django.contrib.sitemaps.views import sitemap
+from django.urls import include, path
+from django.views.generic.base import RedirectView, TemplateView
+
 from regulations.rss_feeds import ResourceFeed
+from regulations.sitemap import PartSitemap, SupplementalContentSitemap
 
 sitemaps = {
     "Parts": PartSitemap,

--- a/solution/backend/common/auth.py
+++ b/solution/backend/common/auth.py
@@ -1,6 +1,5 @@
 from django.conf import settings
-from rest_framework import authentication
-from rest_framework import exceptions
+from rest_framework import authentication, exceptions
 
 
 class SettingsUser:

--- a/solution/backend/common/mixins.py
+++ b/solution/backend/common/mixins.py
@@ -2,7 +2,6 @@ from rest_framework.pagination import PageNumberPagination
 
 from .api import OpenApiQueryParameter
 
-
 # For viewsets where pagination is disabled by default
 PAGINATION_PARAMS = [
     OpenApiQueryParameter("page", "A page number within the paginated result set.", int, False),

--- a/solution/backend/common/tests/test_fields.py
+++ b/solution/backend/common/tests/test_fields.py
@@ -1,6 +1,8 @@
 import unittest
-from common.fields import VariableDateField
+
 from django.core.exceptions import ValidationError
+
+from common.fields import VariableDateField
 
 
 class VariableDateFieldTest(unittest.TestCase):

--- a/solution/backend/createdb.py
+++ b/solution/backend/createdb.py
@@ -7,7 +7,7 @@ def handler(event, context):
     import django
     django.setup()
 
-    from django.db import connection, ProgrammingError
+    from django.db import ProgrammingError, connection
     connection.ensure_connection()
     if not connection.is_usable():
         raise Exception("database is unreachable")

--- a/solution/backend/migrate.py
+++ b/solution/backend/migrate.py
@@ -16,8 +16,7 @@ def handler(event, context):
     for app in apps.get_app_configs():
         installed_apps.append(app.label)
 
-    from django.core.management import call_command
-    from django.core.management import CommandError
+    from django.core.management import CommandError, call_command
     for app in installed_apps:
         try:
             call_command("migrate", app)

--- a/solution/backend/populate_content.py
+++ b/solution/backend/populate_content.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+
 from django.core.management import call_command
 
 
@@ -9,12 +10,9 @@ def handler(event, context):
     django.setup()
     from django.contrib.auth.models import Group, Permission
     from django.contrib.contenttypes.models import ContentType
+
     from regcore.search.models import Synonym
-    from regulations.models import (
-        SiteConfiguration,
-        StatuteLinkConfiguration,
-        StatuteLinkConverter
-    )
+    from regulations.models import SiteConfiguration, StatuteLinkConfiguration, StatuteLinkConverter
     from resources.models import (
         AbstractCategory,
         AbstractLocation,

--- a/solution/backend/pyproject.toml
+++ b/solution/backend/pyproject.toml
@@ -3,11 +3,11 @@ DJANGO_SETTINGS_MODULE = "cmcs_regulations.settings.test_settings"
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F", "G", "S", "W", "ASYNC"]
+select = ["E", "F", "G", "I", "S", "W", "ASYNC"]
 ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["E", "F", "W"]
+fixable = ["E", "F", "I", "W"]
 unfixable = []
 
 # Exclude a variety of commonly ignored directories.

--- a/solution/backend/regcore/admin.py
+++ b/solution/backend/regcore/admin.py
@@ -1,15 +1,15 @@
 import csv
 
-from django.shortcuts import redirect, render
 from django.contrib import admin, messages
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import models
 from django.forms import TextInput
-from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.shortcuts import redirect, render
 from django.views import View
-
 from solo.admin import SingletonModelAdmin
 
 from resources.admin import BaseAdmin
+
 from .models import ParserConfiguration, PartConfiguration
 from .search.models import Synonym
 

--- a/solution/backend/regcore/management/commands/emptyseedtables.py
+++ b/solution/backend/regcore/management/commands/emptyseedtables.py
@@ -1,14 +1,14 @@
 
-from django.core.management.base import BaseCommand
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.core.management.base import BaseCommand
 
 from regcore.search.models import Synonym
-from regulations.models import StatuteLinkConverter, SiteConfiguration
+from regulations.models import SiteConfiguration, StatuteLinkConverter
 from resources.models import (
     AbstractCategory,
-    AbstractResource,
     AbstractLocation,
+    AbstractResource,
     FederalRegisterDocumentGroup,
     ResourcesConfiguration,
 )

--- a/solution/backend/regcore/models.py
+++ b/solution/backend/regcore/models.py
@@ -1,6 +1,5 @@
-from django.db import models
 from django.core.validators import MinValueValidator, RegexValidator
-
+from django.db import models
 from solo.models import SingletonModel
 
 

--- a/solution/backend/regcore/search/models.py
+++ b/solution/backend/regcore/search/models.py
@@ -1,13 +1,13 @@
 import re
 
-from django.db import models
-from django.db.models.expressions import RawSQL
 from django.contrib.postgres.search import (
+    SearchHeadline,
     SearchQuery,
     SearchRank,
-    SearchHeadline,
     SearchVectorField,
 )
+from django.db import models
+from django.db.models.expressions import RawSQL
 
 from regcore.models import Part
 

--- a/solution/backend/regcore/search/views.py
+++ b/solution/backend/regcore/search/views.py
@@ -1,10 +1,11 @@
 from datetime import date
-from rest_framework import viewsets
-from drf_spectacular.utils import extend_schema
-from django.db.models import F
 
-from common.mixins import OptionalPaginationMixin
+from django.db.models import F
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
+
 from common.api import OpenApiQueryParameter
+from common.mixins import OptionalPaginationMixin
 
 from .models import SearchIndexV2
 from .serializers import SearchResultSerializer

--- a/solution/backend/regcore/serializers/contents.py
+++ b/solution/backend/regcore/serializers/contents.py
@@ -1,5 +1,5 @@
-from rest_framework import serializers
 from drf_spectacular.utils import PolymorphicProxySerializer, extend_schema_field
+from rest_framework import serializers
 
 
 class NodeChildrenField(serializers.DictField):

--- a/solution/backend/regcore/serializers/parser.py
+++ b/solution/backend/regcore/serializers/parser.py
@@ -1,5 +1,5 @@
-from rest_framework import serializers
 from django.apps import apps
+from rest_framework import serializers
 
 from regcore.models import ECFRParserResult
 

--- a/solution/backend/regcore/serializers/toc.py
+++ b/solution/backend/regcore/serializers/toc.py
@@ -1,5 +1,5 @@
-from rest_framework import serializers
 from django.http import Http404
+from rest_framework import serializers
 
 
 class FlatTOCSerializer(serializers.Serializer):

--- a/solution/backend/regcore/tests/test_api_view.py
+++ b/solution/backend/regcore/tests/test_api_view.py
@@ -1,7 +1,8 @@
-from datetime import date
-from collections import OrderedDict
-from unittest.mock import patch
 import json
+from collections import OrderedDict
+from datetime import date
+from unittest.mock import patch
+
 import httpx
 from rest_framework import status
 from rest_framework.test import APITestCase

--- a/solution/backend/regcore/tests/test_models.py
+++ b/solution/backend/regcore/tests/test_models.py
@@ -4,7 +4,7 @@ import json
 from django.test import TestCase
 
 from regcore.models import Part
-from regcore.search.models import create_search, Synonym, SearchIndexQuerySet
+from regcore.search.models import SearchIndexQuerySet, Synonym, create_search
 
 
 class TestRegoreModels(TestCase):

--- a/solution/backend/regcore/urls.py
+++ b/solution/backend/regcore/urls.py
@@ -1,16 +1,15 @@
-from django.urls import path, include
+from django.urls import include, path
 
 from regcore.admin import BulkSynonymView
 from regcore.views import (
-    title,
-    part,
     contents,
-    metadata,
-    synonyms,
-    parser,
     history,
+    metadata,
+    parser,
+    part,
+    synonyms,
+    title,
 )
-
 
 urlpatterns = [
     path("admin/bulk_synonyms", BulkSynonymView.as_view(), name="bulk_synonyms"),

--- a/solution/backend/regcore/views/contents.py
+++ b/solution/backend/regcore/views/contents.py
@@ -1,19 +1,18 @@
-from rest_framework.response import Response
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
-
-from .utils import OpenApiPathParameter
-
-from .mixins import (
-    PartPropertiesMixin,
-    NodeFinderMixin,
-)
+from rest_framework.response import Response
 
 from regcore.serializers.contents import (
     PartSerializer,
     SectionContentsSerializer,
     SubpartContentsSerializer,
 )
+
+from .mixins import (
+    NodeFinderMixin,
+    PartPropertiesMixin,
+)
+from .utils import OpenApiPathParameter
 
 
 @extend_schema(

--- a/solution/backend/regcore/views/history.py
+++ b/solution/backend/regcore/views/history.py
@@ -1,12 +1,13 @@
-import datetime
 import asyncio
-import httpx
+import datetime
 
+import httpx
+from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 from rest_framework.response import Response
-from drf_spectacular.utils import extend_schema
 
 from regcore.serializers.history import HistorySerializer
+
 from .utils import OpenApiPathParameter
 
 GOVINFO_YEAR_MIN = 1996

--- a/solution/backend/regcore/views/metadata.py
+++ b/solution/backend/regcore/views/metadata.py
@@ -1,16 +1,15 @@
-from rest_framework.response import Response
 from django.http import Http404
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
+from rest_framework.response import Response
 
-from .utils import OpenApiPathParameter
+from regcore.serializers.toc import TOCSerializer
 
 from .mixins import (
     PartPropertiesMixin,
     PartStructureNodesMixin,
 )
-
-from regcore.serializers.toc import TOCSerializer
+from .utils import OpenApiPathParameter
 
 
 @extend_schema(

--- a/solution/backend/regcore/views/mixins.py
+++ b/solution/backend/regcore/views/mixins.py
@@ -2,10 +2,10 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
 
-from .utils import OpenApiPathParameter
-
 from regcore.models import Part
 from regcore.serializers.toc import FlatTOCSerializer
+
+from .utils import OpenApiPathParameter
 
 
 # must define lookup_fields mapping with entries like { "field_name": "url_parameter", ... }

--- a/solution/backend/regcore/views/parser.py
+++ b/solution/backend/regcore/views/parser.py
@@ -1,19 +1,19 @@
-from rest_framework import viewsets
-from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from django.http import Http404
-from drf_spectacular.utils import extend_schema
 from django.db import transaction
-from django.http import JsonResponse
+from django.http import Http404, JsonResponse
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.response import Response
 
-from .utils import OpenApiPathParameter
+from common.auth import SettingsAuthentication
+from regcore.models import ECFRParserResult, ParserConfiguration, Part
 from regcore.serializers.parser import (
+    ParserConfigurationSerializer,
     ParserResultSerializer,
     PartUploadSerializer,
-    ParserConfigurationSerializer,
 )
-from common.auth import SettingsAuthentication
-from regcore.models import ECFRParserResult, Part, ParserConfiguration
+
+from .utils import OpenApiPathParameter
 
 
 @extend_schema(description="Retrieve configuration for the eCFR and Federal Register parsers.")

--- a/solution/backend/regcore/views/part.py
+++ b/solution/backend/regcore/views/part.py
@@ -1,10 +1,10 @@
-from rest_framework import viewsets
 from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
+
+from regcore.models import Part
+from regcore.serializers.metadata import StringListSerializer
 
 from .utils import OpenApiPathParameter
-
-from regcore.serializers.metadata import StringListSerializer
-from regcore.models import Part
 
 
 @extend_schema(

--- a/solution/backend/regcore/views/synonyms.py
+++ b/solution/backend/regcore/views/synonyms.py
@@ -1,9 +1,9 @@
-from rest_framework import viewsets
 from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
 
 from common.api import OpenApiQueryParameter
-from regcore.serializers.synonyms import SynonymsSerializer
 from regcore.search.models import Synonym
+from regcore.serializers.synonyms import SynonymsSerializer
 
 
 @extend_schema(

--- a/solution/backend/regcore/views/title.py
+++ b/solution/backend/regcore/views/title.py
@@ -1,19 +1,17 @@
-from rest_framework import viewsets
-from drf_spectacular.utils import extend_schema
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db import models
 from django.db.models.functions import Cast
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
 
-from .utils import OpenApiPathParameter
 from regcore.models import Part
-
+from regcore.serializers.metadata import PartsSerializer, StringListSerializer, VersionsSerializer
 from regcore.serializers.toc import (
     FrontPageTOCSerializer,
     TitleTOCSerializer,
 )
-from regcore.serializers.metadata import PartsSerializer, VersionsSerializer
 
-from regcore.serializers.metadata import StringListSerializer
+from .utils import OpenApiPathParameter
 
 
 @extend_schema(description="Retrieve the table of contents (TOC) for all Titles, with detail down to the Part level. "

--- a/solution/backend/regulations/admin.py
+++ b/solution/backend/regulations/admin.py
@@ -1,22 +1,20 @@
 import re
 
+import requests
+from defusedxml.minidom import parseString
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import path, reverse
-
-import requests
 from solo.admin import SingletonModelAdmin
-from defusedxml.minidom import parseString
 
 from .models import (
     SiteConfiguration,
     StatuteLinkConfiguration,
     StatuteLinkConverter,
 )
-
 
 # Finds all HTML/XML tags for removal, e.g. "<a href="#">abc</a>" becomes "abc".
 MARKUP_PATTERN = r"</?[^>]+>"

--- a/solution/backend/regulations/models.py
+++ b/solution/backend/regulations/models.py
@@ -1,10 +1,10 @@
 import re
 
 from django.db import models
-from common.fields import VariableDateField, NaturalSortField
 from django_jsonform.models.fields import JSONField
 from solo.models import SingletonModel
 
+from common.fields import NaturalSortField, VariableDateField
 
 DASH_PATTERN = r"[-—–-–]|&#x2013;"
 DASH_REGEX = re.compile(DASH_PATTERN, re.IGNORECASE)

--- a/solution/backend/regulations/rss_feeds.py
+++ b/solution/backend/regulations/rss_feeds.py
@@ -1,6 +1,7 @@
-from resources.models import AbstractResource
-from django.contrib.syndication.views import Feed
 from dateutil import parser
+from django.contrib.syndication.views import Feed
+
+from resources.models import AbstractResource
 
 
 class ResourceFeed(Feed):

--- a/solution/backend/regulations/sitemap.py
+++ b/solution/backend/regulations/sitemap.py
@@ -1,5 +1,6 @@
-from django.contrib.sitemaps import Sitemap
 from datetime import datetime
+
+from django.contrib.sitemaps import Sitemap
 from django.urls import reverse
 
 from regcore.models import Part

--- a/solution/backend/regulations/templatetags/citation.py
+++ b/solution/backend/regulations/templatetags/citation.py
@@ -1,8 +1,9 @@
 import re
+
 from django import template
 from django.template.defaultfilters import stringfilter
-from django.utils.safestring import mark_safe
 from django.utils.html import conditional_escape
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 

--- a/solution/backend/regulations/templatetags/render_nested.py
+++ b/solution/backend/regulations/templatetags/render_nested.py
@@ -1,4 +1,4 @@
-from django.template import Library, loader, TemplateDoesNotExist
+from django.template import Library, TemplateDoesNotExist, loader
 
 register = Library()
 

--- a/solution/backend/regulations/templatetags/site_statistics.py
+++ b/solution/backend/regulations/templatetags/site_statistics.py
@@ -1,4 +1,5 @@
 from datetime import date
+
 from django.template import Library
 
 from regcore.models import Part

--- a/solution/backend/regulations/templatetags/string_formatters.py
+++ b/solution/backend/regulations/templatetags/string_formatters.py
@@ -1,7 +1,8 @@
+from datetime import datetime
+
 from django import template
 from django.template.defaultfilters import stringfilter
 from django.utils.html import strip_tags
-from datetime import datetime
 
 register = template.Library()
 

--- a/solution/backend/regulations/templatetags/version_date.py
+++ b/solution/backend/regulations/templatetags/version_date.py
@@ -1,6 +1,7 @@
+from datetime import datetime
+
 from django import template
 from django.template.defaultfilters import stringfilter
-from datetime import datetime
 
 register = template.Library()
 

--- a/solution/backend/regulations/tests/test_site_configuration.py
+++ b/solution/backend/regulations/tests/test_site_configuration.py
@@ -1,5 +1,7 @@
 import unittest
+
 import pytest
+
 from regulations.models import SiteConfiguration
 
 

--- a/solution/backend/regulations/tests/test_statute_links.py
+++ b/solution/backend/regulations/tests/test_statute_links.py
@@ -4,11 +4,9 @@ from unittest import mock
 from django.core.exceptions import ValidationError
 from django.template import Context, Template
 from django.test import SimpleTestCase, TestCase
-
+from requests.exceptions import HTTPError
 from rest_framework import status
 from rest_framework.test import APITestCase
-
-from requests.exceptions import HTTPError
 
 from regulations.admin import StatuteLinkConverterAdmin
 from regulations.models import (

--- a/solution/backend/regulations/tests/test_urls.py
+++ b/solution/backend/regulations/tests/test_urls.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 from django.urls import reverse
 
 

--- a/solution/backend/regulations/urls.py
+++ b/solution/backend/regulations/urls.py
@@ -7,16 +7,16 @@ from regulations.views.cache import CacheView
 from regulations.views.goto import GoToRedirectView
 from regulations.views.homepage import HomepageView
 from regulations.views.reader import (
-     PartReaderView,
-     SectionReaderView,
-     SubpartReaderView,
+    PartReaderView,
+    SectionReaderView,
+    SubpartReaderView,
 )
 from regulations.views.regulation_landing import RegulationLandingView
 from regulations.views.resources import ResourcesView
 from regulations.views.search import SearchView
 from regulations.views.statute import StatuteView
-from regulations.views.supplemental_content import SupplementalContentView
 from regulations.views.statutes import ActListViewSet, StatuteLinkConverterViewSet
+from regulations.views.supplemental_content import SupplementalContentView
 
 register_converter(converters.NumericConverter, 'numeric')
 register_converter(converters.SubpartConverter, 'subpart')

--- a/solution/backend/regulations/views/homepage.py
+++ b/solution/backend/regulations/views/homepage.py
@@ -1,12 +1,11 @@
-from datetime import date
 import logging
+from datetime import date
 
 from django.views.generic.base import TemplateView
 
 from regcore.models import Part
 from regcore.serializers.toc import FrontPageTOCSerializer
 from resources.models import ResourcesConfiguration
-
 
 logger = logging.getLogger(__name__)
 

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -1,9 +1,9 @@
 from datetime import date, datetime
 
-from django.db.models import Q, Count
+from django.db.models import Count, Q
 from django.http import (
-    HttpResponseRedirect,
     Http404,
+    HttpResponseRedirect,
 )
 from django.urls import reverse
 from django.views.generic.base import (

--- a/solution/backend/regulations/views/regulation_landing.py
+++ b/solution/backend/regulations/views/regulation_landing.py
@@ -1,7 +1,8 @@
-from requests import HTTPError
-from django.views.generic.base import TemplateView
-from django.http import Http404
 from datetime import date, datetime
+
+from django.http import Http404
+from django.views.generic.base import TemplateView
+from requests import HTTPError
 
 from regcore.models import Part
 

--- a/solution/backend/regulations/views/supplemental_content.py
+++ b/solution/backend/regulations/views/supplemental_content.py
@@ -1,6 +1,6 @@
-from django.views.generic.base import TemplateView
 from django.http import Http404
 from django.urls import reverse
+from django.views.generic.base import TemplateView
 
 from resources.models import AbstractResource
 

--- a/solution/backend/regulations/views/utils.py
+++ b/solution/backend/regulations/views/utils.py
@@ -2,7 +2,6 @@ import logging
 
 from regulations.views.errors import NotInSubpart
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/solution/backend/resources/admin.py
+++ b/solution/backend/resources/admin.py
@@ -1,9 +1,7 @@
+import csv
 import json
 import re
-import csv
 
-from django.http import HttpResponse
-from django.urls import path, reverse
 from django import forms
 from django.apps import apps
 from django.contrib import admin, messages
@@ -18,21 +16,21 @@ from django.db.models import (
     When,
 )
 from django.forms.widgets import Textarea
+from django.http import HttpResponse
 from django.shortcuts import render
+from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django.utils.safestring import mark_safe
 from solo.admin import SingletonModelAdmin
 
 from . import actions
-
 from .filters import (
     PartFilter,
     SectionFilter,
     SubpartFilter,
     TitleFilter,
 )
-
 from .models import (
     AbstractCategory,
     AbstractLocation,
@@ -46,7 +44,6 @@ from .models import (
     Subpart,
     SupplementalContent,
 )
-
 from .serializers.locations import AbstractLocationPolymorphicSerializer
 
 

--- a/solution/backend/resources/models.py
+++ b/solution/backend/resources/models.py
@@ -1,13 +1,12 @@
-from model_utils.managers import InheritanceManager, InheritanceQuerySet
-from django.core.exceptions import ValidationError, NON_FIELD_ERRORS
-from common.fields import VariableDateField
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.db import models
-from django_jsonform.models.fields import ArrayField
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django_jsonform.models.fields import ArrayField
+from model_utils.managers import InheritanceManager, InheritanceQuerySet
 from solo.models import SingletonModel
 
-from common.fields import NaturalSortField
+from common.fields import NaturalSortField, VariableDateField
 
 
 # Field mixins

--- a/solution/backend/resources/serializers/categories.py
+++ b/solution/backend/resources/serializers/categories.py
@@ -1,7 +1,8 @@
+from drf_spectacular.utils import OpenApiTypes, extend_schema_field
 from rest_framework import serializers
-from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 from resources.models import Category, SubCategory
+
 from .mixins import PolymorphicSerializer, PolymorphicTypeField
 from .utils import ProxySerializerWrapper
 

--- a/solution/backend/resources/serializers/locations.py
+++ b/solution/backend/resources/serializers/locations.py
@@ -1,7 +1,8 @@
-from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
 
 from resources.models import Section, Subpart
+
 from .mixins import PolymorphicSerializer, PolymorphicTypeField
 from .utils import ProxySerializerWrapper
 

--- a/solution/backend/resources/serializers/mixins.py
+++ b/solution/backend/resources/serializers/mixins.py
@@ -1,5 +1,5 @@
+from drf_spectacular.utils import OpenApiTypes, extend_schema_field
 from rest_framework import serializers
-from drf_spectacular.utils import extend_schema_field, OpenApiTypes
 
 
 # Retrieves automatically generated search headlines

--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -4,24 +4,6 @@ from django.db.models import Q
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from .categories import (
-    AbstractCategoryPolymorphicSerializer,
-    MetaCategorySerializer
-)
-
-from .locations import (
-    AbstractLocationPolymorphicSerializer,
-    MetaLocationSerializer,
-    SectionCreateSerializer,
-    SectionRangeCreateSerializer,
-)
-
-from .mixins import (
-    HeadlineField,
-    PolymorphicSerializer,
-    PolymorphicTypeField
-)
-
 from resources.models import (
     AbstractCategory,
     AbstractLocation,
@@ -33,6 +15,14 @@ from resources.models import (
     SupplementalContent,
 )
 
+from .categories import AbstractCategoryPolymorphicSerializer, MetaCategorySerializer
+from .locations import (
+    AbstractLocationPolymorphicSerializer,
+    MetaLocationSerializer,
+    SectionCreateSerializer,
+    SectionRangeCreateSerializer,
+)
+from .mixins import HeadlineField, PolymorphicSerializer, PolymorphicTypeField
 from .utils import ProxySerializerWrapper
 
 

--- a/solution/backend/resources/tests/test_admin.py
+++ b/solution/backend/resources/tests/test_admin.py
@@ -4,7 +4,7 @@ from django.contrib.admin import AdminSite
 from django.test import TestCase
 
 from resources.admin import AbstractResourceAdmin, SupplementalContentAdmin
-from resources.models import AbstractResource, AbstractCategory, Section, Subpart, SupplementalContent
+from resources.models import AbstractCategory, AbstractResource, Section, Subpart, SupplementalContent
 
 
 class TestAdminFunctions(TestCase):

--- a/solution/backend/resources/tests/test_models.py
+++ b/solution/backend/resources/tests/test_models.py
@@ -1,5 +1,5 @@
-from django.test import TestCase
 from django.core.exceptions import ValidationError
+from django.test import TestCase
 
 from resources.models import Section, Subpart
 

--- a/solution/backend/resources/tests/test_queryset_functions.py
+++ b/solution/backend/resources/tests/test_queryset_functions.py
@@ -1,14 +1,15 @@
 from datetime import datetime, timedelta
-from django.test import TestCase
-from django.db.models import F, Case, When
 
-from resources.views.mixins import FRDocGroupingMixin
+from django.db.models import Case, F, When
+from django.test import TestCase
+
 from resources.models import (
+    AbstractResource,
     FederalRegisterDocument,
     FederalRegisterDocumentGroup,
-    AbstractResource,
     SupplementalContent,
 )
+from resources.views.mixins import FRDocGroupingMixin
 
 
 class TestMixinFunctions(TestCase):

--- a/solution/backend/resources/tests/test_resources_endpoints.py
+++ b/solution/backend/resources/tests/test_resources_endpoints.py
@@ -1,6 +1,8 @@
-from django.test import TestCase
-from resources.models import FederalRegisterDocument, FederalRegisterDocumentGroup, Section
 from datetime import datetime, timedelta
+
+from django.test import TestCase
+
+from resources.models import FederalRegisterDocument, FederalRegisterDocumentGroup, Section
 
 
 class TestResourcesEndpoint(TestCase):

--- a/solution/backend/resources/tests/test_viewset_functions.py
+++ b/solution/backend/resources/tests/test_viewset_functions.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timedelta
 from itertools import chain
+
 from django.test import TestCase
 from rest_framework.exceptions import NotFound
 

--- a/solution/backend/resources/urls.py
+++ b/solution/backend/resources/urls.py
@@ -6,7 +6,6 @@ from resources.views import (
     resources,
 )
 
-
 urlpatterns = [
     path("search", resources.ResourceSearchViewSet.as_view({
         "get": "list",

--- a/solution/backend/resources/views/categories.py
+++ b/solution/backend/resources/views/categories.py
@@ -1,16 +1,14 @@
-from rest_framework import viewsets
-from drf_spectacular.utils import extend_schema
 from django.db.models import Prefetch
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
 
-from common.mixins import OptionalPaginationMixin, PAGINATION_PARAMS
 from common.api import OpenApiQueryParameter
-
+from common.mixins import PAGINATION_PARAMS, OptionalPaginationMixin
 from resources.models import (
     AbstractCategory,
     Category,
     SubCategory,
 )
-
 from resources.serializers.categories import (
     AbstractCategoryPolymorphicSerializer,
     CategoryTreeSerializer,

--- a/solution/backend/resources/views/locations.py
+++ b/solution/backend/resources/views/locations.py
@@ -1,21 +1,20 @@
-from rest_framework import viewsets
-from drf_spectacular.utils import extend_schema
 from django.db.models import Prefetch
-
-from .mixins import LocationExplorerViewSetMixin
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
 
 from resources.models import (
     AbstractLocation,
     Section,
     Subpart,
 )
-
 from resources.serializers.locations import (
     AbstractLocationPolymorphicSerializer,
     FullSectionSerializer,
     FullSubpartSerializer,
     MetaLocationSerializer,
 )
+
+from .mixins import LocationExplorerViewSetMixin
 
 
 @extend_schema(

--- a/solution/backend/resources/views/mixins.py
+++ b/solution/backend/resources/views/mixins.py
@@ -1,17 +1,16 @@
-from django.db.models import Q, F, Prefetch, OuterRef, Subquery
-from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchVector, SearchRank
+from django.contrib.postgres.search import SearchHeadline, SearchQuery, SearchRank, SearchVector
 from django.core.exceptions import BadRequest
+from django.db.models import F, OuterRef, Prefetch, Q, Subquery
 
 from common.api import OpenApiQueryParameter
+from common.mixins import OptionalPaginationMixin
 from resources.models import (
+    AbstractCategory,
     AbstractLocation,
     AbstractResource,
-    AbstractCategory,
     FederalRegisterDocument,
-    FederalRegisterDocumentGroup
+    FederalRegisterDocumentGroup,
 )
-
-from common.mixins import OptionalPaginationMixin
 
 
 def is_int(x):

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -1,31 +1,22 @@
 import json
 import os
 import re
-import requests
-
+import urllib.parse as urlparse
 from itertools import chain
 
-import urllib.parse as urlparse
-from drf_spectacular.utils import extend_schema
+import requests
 from django.db import transaction
-from django.db.models import Case, When, F, Prefetch, Q
+from django.db.models import Case, F, Prefetch, Q, When
 from django.http import JsonResponse
+from drf_spectacular.utils import extend_schema
 from requests.exceptions import ConnectTimeout
 from rest_framework import viewsets
 from rest_framework.exceptions import NotFound, ParseError
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 
-from .mixins import (
-    ResourceExplorerViewSetMixin,
-    FRDocGroupingMixin
-)
-from common.mixins import (
-    OptionalPaginationMixin,
-    PAGINATION_PARAMS
-)
 from common.auth import SettingsAuthentication
-
+from common.mixins import PAGINATION_PARAMS, OptionalPaginationMixin
 from resources.models import (
     AbstractCategory,
     AbstractLocation,
@@ -33,7 +24,6 @@ from resources.models import (
     FederalRegisterDocument,
     SupplementalContent,
 )
-
 from resources.serializers.resources import (
     AbstractResourcePolymorphicSerializer,
     FederalRegisterDocumentCreateSerializer,
@@ -43,6 +33,8 @@ from resources.serializers.resources import (
     StringListSerializer,
     SupplementalContentSerializer,
 )
+
+from .mixins import FRDocGroupingMixin, ResourceExplorerViewSetMixin
 
 
 @extend_schema(


### PR DESCRIPTION
Resolves # EREGCSC-2029

**Description-**

This is to implement ISORT in ruff.  It forces correct ordering of of our imports for python.  Isort allows auto reordering for it to make it easy for us to correct them.

**This pull request changes...**

- The python imports are set to order in a particular way.
- It will automatically do them if we ask it to "make ruff-fix"

**Steps to manually verify this change...**

1. Application runs without breaking.  All test pass and deployments.
