### PR TITLE
EREGCSC-2086 -- Jump To fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.28
+    rev: v0.0.282
     hooks:
       - id: ruff
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.12.0
+    rev: v8.17.0
     hooks:
       - id: gitleaks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,4 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.0.282
-    hooks:
-      - id: ruff
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.17.0
     hooks:

--- a/solution/backend/regulations/templates/regulations/partials/header.html
+++ b/solution/backend/regulations/templates/regulations/partials/header.html
@@ -4,6 +4,8 @@
             slot="jump-to"
             api-url="{{ API_BASE }}"
             home-url="{% url 'homepage' %}"
+            {% if title %}title="{{ title }}"{% endif %}
+            {% if part %}part="{{ part }}"{% endif %}
         ></jump-to>
         <header-links
             slot="links"

--- a/solution/ui/e2e/cypress/e2e/part.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/part.spec.cy.js
@@ -14,6 +14,8 @@ describe("Part View", () => {
         cy.contains("Part 433 - State Fiscal Administration").should(
             "be.visible"
         );
+        cy.get("#jumpToTitle").invoke("val").should("equal", "42");
+        cy.get("#jumpToPart").invoke("val").should("equal", "433");
         cy.checkAccessibility();
     });
 
@@ -37,6 +39,8 @@ describe("Part View", () => {
         cy.contains("433.51").click({ force: true });
 
         cy.url().should("include", "Subpart-B");
+        cy.get("#jumpToTitle").invoke("val").should("equal", "42");
+        cy.get("#jumpToPart").invoke("val").should("equal", "433");
         cy.get("#433-51-title").should("be.visible");
         cy.get(".latest-version").should("exist");
         cy.get("#subpart-resources-heading").contains("433.51 Resources");
@@ -82,6 +86,8 @@ describe("Part View", () => {
 
         // goes to first part of the appropriate subpart (this is odd)
         cy.url().should("include", "#433-1");
+        cy.get("#jumpToTitle").invoke("val").should("equal", "42");
+        cy.get("#jumpToPart").invoke("val").should("equal", "433");
         cy.get(".latest-version").should("exist");
         cy.get("#433-1-title").should("be.visible");
         cy.focused().then(($el) => {


### PR DESCRIPTION
Resolves [EREGCSC-2086](https://jiraent.cms.gov/browse/EREGCSC-2086)

**Description:**

This PR fixes a regression where the Title and Part dropdown selects are not pre-populated with the correct title and part when the user is at the Part ToC or the Part Reader view.

This feature was originally implemented as part of [EREGCSC-1564](https://jiraent.cms.gov/browse/EREGCSC-1564) but was broken some time after that; likely during additional header work.

**This pull request changes:**

- Passes in `title` and `part` as props to the JumpTo Vue component if those values exist in the context of the Django view

**Steps to manually verify this change:**

1. Go to the reader view for a part and make sure the Jump To selects in the header are populated with the correct title and part

