### PR TITLE
EREGCSC-2112 -- Resources sidebar in reader view missing items

### DIFF
--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
@@ -220,17 +220,20 @@ export default {
         },
         async fetchContent(location) {
             try {
+                // Page size is set to 1000 to attempt to get all resources.
+                // Defualt page size of 100 was omitting resources from the right sidebar.
+                // Right now no single subpart hits this number so this shouldn't be an issue
+
                 let response = "";
                 if (location) {
                     response = await getSupplementalContent({
                         apiUrl: this.apiUrl,
                         builtLocationString: location,
+                        pageSize: 1000,
                     });
                 }
                 await this.getPartDictionary();
 
-                // Page size is set to 1000 to attempt to get all subpart resources.  Right now no single subpart hits this number
-                // so this shouldn't be an issue
                 const subpartResponse = await getSupplementalContent({
                     apiUrl: this.apiUrl,
                     partDict: this.partDict,


### PR DESCRIPTION
Resolves [EREGCSC-2112](https://jiraent.cms.gov/browse/EREGCSC-2112)

**Description**

The default page size when requesting supplemental content from the `resources` API endpoint is 100 items.  Some sections have more than 100 items attached to them.  As a result, some resource items were not being returned or displayed in the resources sidebar.

**This pull request changes:**

- overrides default `pageSize` parameter to be `1000` instead of `100`

**Steps to manually verify this change:**

1. Visit [Part 440 Section 180](https://47kar1x2vj.execute-api.us-east-1.amazonaws.com/dev927/42/440/Subpart-A/2020-12-16/#440-180) 
2.  In the right sidebar, expand "Subregulatory Guidance" and then expand "State Medicaid Director Letter (SMDL)" subcategory 
3. Scroll to the "Show More" button and note how many results there are.  It should be 29
   - [compare to `dev` environment Part 440 Section 180](https://qavc1ytrff.execute-api.us-east-1.amazonaws.com/val/42/440/Subpart-A/2020-12-16/#440-180), where results count 7, which is the bug
5. Go to the [Resources page and adjust filters to only show SMDLs for Part 440 Section 180](https://47kar1x2vj.execute-api.us-east-1.amazonaws.com/dev927/resources?title=42&sort=newest&part=440&section=440-180&resourceCategory=State%20Medicaid%20Director%20Letter%20%28SMDL%29)
6. The results count on the Resources page should match the results count in the sidebar of the Reader view.  They should both be 29
   - [compare to `dev` environment Resources page](https://47kar1x2vj.execute-api.us-east-1.amazonaws.com/dev927/resources/?part=440&resourceCategory=State%20Medicaid%20Director%20Letter%20%28SMDL%29&section=440-180&sort=newest&title=42), where results are correct at 29


