### PR TITLE
EREGCSC-2113 -- Reflect edited statute dates in frontend

### DIFF
--- a/solution/backend/regulations/templates/error_base.html
+++ b/solution/backend/regulations/templates/error_base.html
@@ -4,26 +4,7 @@
 {% block title %}Page Not Found | Medicaid & CHIP eRegulations {% endblock %}
 
 {% block header %}
-    <header id="header" class="sticky">
-        <header-component
-            home-url="{% url 'homepage' %}"
-        >
-            <jump-to
-                slot="jump-to"
-                api-url="{{ API_BASE }}"
-                home-url="{% url 'homepage' %}"
-            ></jump-to>
-            <header-links
-                slot="links"
-                about-url="{% url 'about' %}"
-                resources-url="{% url 'resources' %}"
-            ></header-links>
-            <header-search
-                slot="search"
-                search-url="{% url 'search' %}"
-            ></header-search>
-        </header-component>
-    </header>
+    {% include "regulations/partials/header.html" %}
 {% endblock %}
 
 {% block body %}

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -18,6 +18,7 @@
 {% endblock %}
 
 {% block body %}
+{{ site_config|json_script:"site_config" }}
 <div
     id="vite-app"
     data-api-url="{{ API_BASE }}"

--- a/solution/backend/regulations/views/statute.py
+++ b/solution/backend/regulations/views/statute.py
@@ -12,19 +12,19 @@ class StatuteView(TemplateView):
         host = self.request.get_host()
         site_config = SiteConfiguration.get_solo()
         site_config = {
-            'us_code_house_gov_date': {
+            'us_code_house_gov': {
                 'type': site_config.us_code_house_gov_date_type,
                 'date': site_config.us_code_house_gov_date,
             },
-            'us_code_annual_date': {
+            'us_code_annual': {
                 'type': site_config.us_code_annual_date_type,
                 'date': site_config.us_code_annual_date,
             },
-            'statute_compilation_date': {
+            'statute_compilation': {
                 'type': site_config.statute_compilation_date_type,
                 'date': site_config.statute_compilation_date,
             },
-            'ssa_gov_compilation_date': {
+            'ssa_gov_compilation': {
                 'type': site_config.ssa_gov_compilation_date_type,
                 'date': site_config.ssa_gov_compilation_date,
             },

--- a/solution/backend/regulations/views/statute.py
+++ b/solution/backend/regulations/views/statute.py
@@ -4,6 +4,7 @@ from regulations.models import (
     SiteConfiguration,
 )
 
+
 class StatuteView(TemplateView):
     template_name = 'regulations/statute.html'
 

--- a/solution/backend/regulations/views/statute.py
+++ b/solution/backend/regulations/views/statute.py
@@ -1,5 +1,8 @@
 from django.views.generic.base import TemplateView
 
+from regulations.models import (
+    SiteConfiguration,
+)
 
 class StatuteView(TemplateView):
     template_name = 'regulations/statute.html'
@@ -7,9 +10,29 @@ class StatuteView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         host = self.request.get_host()
+        site_config = SiteConfiguration.get_solo()
+        site_config = {
+            'us_code_house_gov_date': {
+                'type': site_config.us_code_house_gov_date_type,
+                'date': site_config.us_code_house_gov_date,
+            },
+            'us_code_annual_date': {
+                'type': site_config.us_code_annual_date_type,
+                'date': site_config.us_code_annual_date,
+            },
+            'statute_compilation_date': {
+                'type': site_config.statute_compilation_date_type,
+                'date': site_config.statute_compilation_date,
+            },
+            'ssa_gov_compilation_date': {
+                'type': site_config.ssa_gov_compilation_date_type,
+                'date': site_config.ssa_gov_compilation_date,
+            },
+        }
 
         c = {
-            'host': host
+            'host': host,
+            'site_config': site_config,
          }
 
         return {**context, **c, **self.request.GET.dict()}

--- a/solution/ui/e2e/cypress/fixtures/statute-dates.json
+++ b/solution/ui/e2e/cypress/fixtures/statute-dates.json
@@ -1,0 +1,6 @@
+{
+    "ssa_gov_compilation": {"date": "2019-12", "type": "amended"},
+    "statute_compilation": {"date": "2022-12", "type": "amended"},
+    "us_code_annual": {"date": "2022-01", "type": "effective"},
+    "us_code_house_gov": {"date": "2023-08", "type": "effective"}
+}

--- a/solution/ui/e2e/cypress/fixtures/statute-dates.json
+++ b/solution/ui/e2e/cypress/fixtures/statute-dates.json
@@ -1,6 +1,6 @@
 {
-    "ssa_gov_compilation": {"date": "2019-12", "type": "amended"},
-    "statute_compilation": {"date": "2022-12", "type": "amended"},
-    "us_code_annual": {"date": "2022-01", "type": "effective"},
+    "ssa_gov_compilation": {"date": "2023-08", "type": "effective"},
+    "statute_compilation": {"date": "2023-08", "type": "effective"},
+    "us_code_annual": {"date": "2023-08", "type": "effective"},
     "us_code_house_gov": {"date": "2023-08", "type": "effective"}
 }

--- a/solution/ui/regulations/css/scss/partials/_statutes.scss
+++ b/solution/ui/regulations/css/scss/partials/_statutes.scss
@@ -190,6 +190,7 @@
                             line-height: 22px;
                             font-weight: normal;
                             font-style: italic;
+                            text-transform: capitalize;
                         }
 
                         .cell__usc-label {

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteTable.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteTable.vue
@@ -40,7 +40,7 @@ const tableSchema = computed(() => {
 
 // Get column dates from Django template
 const getColumnDates = () => {
-    if (!document.getElementById("site_config")) return [];
+    if (!document.getElementById("site_config")) return {};
 
     const rawDates = JSON.parse(
         document.getElementById("site_config").textContent

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteTable.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteTable.vue
@@ -54,7 +54,6 @@ const columnDates = getColumnDates();
 
 <template>
     <div>
-        Column Dates {{ columnDates }}
         <div v-if="props.displayType === 'list'" id="statuteList">
             <div
                 v-for="(statute, i) in props.filteredStatutes"
@@ -83,6 +82,7 @@ const columnDates = getColumnDates();
                     :key="`statute-table-header-${i}`"
                     :cell-data="column.header"
                     :display-type="props.displayType"
+                    :column-dates="columnDates"
                 />
             </tr>
             <tbody class="table__body">

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteTable.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteTable.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 import { acaSchema, ssaSchema } from "./schemas/tableSchemas";
 import { ACT_TYPES, DISPLAY_TYPES } from "./utils/enums";
@@ -36,10 +36,25 @@ const tableSchema = computed(() => {
             return ssaSchema;
     }
 });
+
+
+// Get column dates from Django template
+const getColumnDates = () => {
+    if (!document.getElementById("site_config")) return [];
+
+    const rawDates = JSON.parse(
+        document.getElementById("site_config").textContent
+    );
+
+    return rawDates;
+}
+
+const columnDates = getColumnDates();
 </script>
 
 <template>
     <div>
+        Column Dates {{ columnDates }}
         <div v-if="props.displayType === 'list'" id="statuteList">
             <div
                 v-for="(statute, i) in props.filteredStatutes"

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
@@ -1,8 +1,8 @@
 import {
     houseGovUrl,
+    ssaGovUrl,
     statuteCompilationUrl,
     usCodeUrl,
-    ssaGovUrl,
 } from "../utils/urlMethods.js";
 import { getDateLabel } from "../utils/dateMethods.js";
 

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
@@ -50,6 +50,7 @@ const ssaSchema = [
     },
     {
         header: {
+            testId: "house-gov-link",
             title: "US Code House.gov",
             secondary: true,
             subtitles: [
@@ -67,6 +68,7 @@ const ssaSchema = [
     },
     {
         header: {
+            testId: "statute-compilation-link",
             title: "Statute Compilation",
             secondary: true,
             subtitles: [
@@ -84,6 +86,7 @@ const ssaSchema = [
     },
     {
         header: {
+            testId: "us-code-annual-link",
             title: "US Code Annual",
             secondary: true,
             subtitles: [
@@ -101,6 +104,7 @@ const ssaSchema = [
     },
     {
         header: {
+            testId: "ssa-gov-link",
             title: "SSA.gov Compilation",
             secondary: true,
             subtitles: [

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
@@ -6,11 +6,6 @@ import {
 } from "../utils/urlMethods.js";
 import { getDateLabel } from "../utils/dateMethods.js";
 
-const defaultDateLabelObj = {
-    title: undefined,
-    date: undefined,
-};
-
 // placeholder for future schema
 const acaSchema = [
     {
@@ -60,9 +55,7 @@ const ssaSchema = [
             subtitles: [
                 () => "Web Page",
                 (columnDates) =>
-                    getDateLabel(
-                        columnDates?.us_code_house_gov ?? defaultDateLabelObj
-                    ),
+                    getDateLabel(columnDates?.us_code_house_gov ?? {}),
             ],
         },
         body: {
@@ -79,9 +72,7 @@ const ssaSchema = [
             subtitles: [
                 () => "PDF Document",
                 (columnDates) =>
-                    getDateLabel(
-                        columnDates?.statute_compilation ?? defaultDateLabelObj
-                    ),
+                    getDateLabel(columnDates?.statute_compilation ?? {}),
             ],
         },
         body: {
@@ -98,9 +89,7 @@ const ssaSchema = [
             subtitles: [
                 () => "PDF Document",
                 (columnDates) =>
-                    getDateLabel(
-                        columnDates?.us_code_annual ?? defaultDateLabelObj
-                    ),
+                    getDateLabel(columnDates?.us_code_annual ?? {}),
             ],
         },
         body: {
@@ -117,9 +106,7 @@ const ssaSchema = [
             subtitles: [
                 () => "Web Page",
                 (columnDates) =>
-                    getDateLabel(
-                        columnDates?.ssa_gov_compilation ?? defaultDateLabelObj
-                    ),
+                    getDateLabel(columnDates?.ssa_gov_compilation ?? {}),
             ],
         },
         body: {

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
@@ -1,4 +1,15 @@
-import { houseGovUrl, statuteCompilationUrl, usCodeUrl, ssaGovUrl } from "../utils/urlMethods.js";
+import {
+    houseGovUrl,
+    statuteCompilationUrl,
+    usCodeUrl,
+    ssaGovUrl,
+} from "../utils/urlMethods.js";
+import { getDateLabel } from "../utils/dateMethods.js";
+
+const defaultDateLabelObj = {
+    title: undefined,
+    date: undefined,
+};
 
 // placeholder for future schema
 const acaSchema = [
@@ -12,8 +23,9 @@ const acaSchema = [
             label: "ACA Label",
             name: "ACA Name",
             primary: true,
-        }
-    },{
+        },
+    },
+    {
         header: {
             title: "Secondary Column",
             secondary: true,
@@ -45,7 +57,13 @@ const ssaSchema = [
         header: {
             title: "US Code House.gov",
             secondary: true,
-            subtitles: ["Web Page", "Effective Jul 2023"],
+            subtitles: [
+                () => "Web Page",
+                (columnDates) =>
+                    getDateLabel(
+                        columnDates?.us_code_house_gov ?? defaultDateLabelObj
+                    ),
+            ],
         },
         body: {
             url: (statute) => houseGovUrl(statute),
@@ -58,7 +76,13 @@ const ssaSchema = [
         header: {
             title: "Statute Compilation",
             secondary: true,
-            subtitles: ["PDF Document", "Amended Dec 2022"],
+            subtitles: [
+                () => "PDF Document",
+                (columnDates) =>
+                    getDateLabel(
+                        columnDates?.statute_compilation ?? defaultDateLabelObj
+                    ),
+            ],
         },
         body: {
             url: (statute) => statuteCompilationUrl(statute),
@@ -71,7 +95,13 @@ const ssaSchema = [
         header: {
             title: "US Code Annual",
             secondary: true,
-            subtitles: ["PDF Document", "Effective Jan 2022"],
+            subtitles: [
+                () => "PDF Document",
+                (columnDates) =>
+                    getDateLabel(
+                        columnDates?.us_code_annual ?? defaultDateLabelObj
+                    ),
+            ],
         },
         body: {
             url: (statute) => usCodeUrl(statute),
@@ -84,7 +114,13 @@ const ssaSchema = [
         header: {
             title: "SSA.gov Compilation",
             secondary: true,
-            subtitles: ["Web Page", "Amended Dec 2019"],
+            subtitles: [
+                () => "Web Page",
+                (columnDates) =>
+                    getDateLabel(
+                        columnDates?.ssa_gov_compilation ?? defaultDateLabelObj
+                    ),
+            ],
         },
         body: {
             url: (statute) => ssaGovUrl(statute),
@@ -95,7 +131,4 @@ const ssaSchema = [
     },
 ];
 
-export {
-    acaSchema,
-    ssaSchema,
-};
+export { acaSchema, ssaSchema };

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.test.js
@@ -2,6 +2,8 @@ import flushPromises from "flush-promises";
 import { render } from "@testing-library/vue";
 import { describe, it, expect } from "vitest";
 
+import statuteDatesFixture from "cypress/fixtures/statute-dates.json";
+
 import { ssaSchema } from "../schemas/tableSchemas";
 
 import HeaderCell from "./HeaderCell.vue";
@@ -9,11 +11,23 @@ import HeaderCell from "./HeaderCell.vue";
 describe("Statute Table Header Cell", () => {
     describe("SSA table header", () => {
         ssaSchema.forEach((column, index) => {
-            it(`Creates a snapshot of header cell for column ${index + 1}`, async () => {
+            it(`Creates a snapshot of header cell for column ${index + 1} without dates`, async () => {
                 const wrapper = render(HeaderCell, {
                     props: {
                         cellData: column.header,
                         displayType: "table",
+                    },
+                });
+                await flushPromises();
+                expect(wrapper).toMatchSnapshot();
+            });
+
+            it(`Creates a snapshot of header cell for column ${index + 1} with dates`, async () => {
+                const wrapper = render(HeaderCell, {
+                    props: {
+                        cellData: column.header,
+                        displayType: "table",
+                        columnDates: statuteDatesFixture,
                     },
                 });
                 await flushPromises();

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.test.js
@@ -10,7 +10,9 @@ import HeaderCell from "./HeaderCell.vue";
 
 describe("Statute Table Header Cell", () => {
     describe("SSA table header", () => {
-        ssaSchema.forEach((column, index) => {
+        const secondaryCells = ssaSchema.filter((column) => column.header.secondary);
+
+        secondaryCells.forEach((column, index) => {
             it(`Creates a snapshot of header cell for column ${index + 1} without dates`, async () => {
                 const wrapper = render(HeaderCell, {
                     props: {
@@ -19,6 +21,10 @@ describe("Statute Table Header Cell", () => {
                     },
                 });
                 await flushPromises();
+
+                const dateCell = wrapper.getByTestId(`${column.header.testId}-subtitle-1`).textContent;
+                expect(dateCell.trim()).toEqual("");
+
                 expect(wrapper).toMatchSnapshot();
             });
 
@@ -31,6 +37,10 @@ describe("Statute Table Header Cell", () => {
                     },
                 });
                 await flushPromises();
+
+                const dateCell = wrapper.getByTestId(`${column.header.testId}-subtitle-1`).textContent;
+                expect(dateCell.trim()).toEqual("effective Aug 2023");
+
                 expect(wrapper).toMatchSnapshot();
             });
         });

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.vue
@@ -35,6 +35,7 @@ const props = defineProps({
                 v-for="(subtitle, i) in cellData.subtitles"
                 :key="`${props.displayType}-subtitle-${i}`"
                 class="cell__subtitle"
+                :data-testid="`${props.cellData.testId}-subtitle-${i}`"
             >
                 {{ subtitle(columnDates) }}
             </div>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.vue
@@ -11,6 +11,11 @@ const props = defineProps({
         required: false,
         default: "table",
     },
+    columnDates: {
+        type: Object,
+        required: false,
+        default: () => {},
+    },
 });
 </script>
 
@@ -31,7 +36,7 @@ const props = defineProps({
                 :key="`${props.displayType}-subtitle-${i}`"
                 class="cell__subtitle"
             >
-                {{ subtitle }}
+                {{ subtitle(columnDates) }}
             </div>
         </template>
     </th>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/HeaderCell.test.js.snap
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/HeaderCell.test.js.snap
@@ -5,27 +5,49 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
   "baseElement": <body>
     <div>
       <th
-        class="row__cell row__cell--header row__cell--primary"
+        class="row__cell row__cell--header row__cell--secondary"
       >
         <div
           class="cell__title"
         >
-           Statute Citation 
+           US Code House.gov 
         </div>
-        <!---->
+        <div
+          class="cell__subtitle"
+          data-testid="house-gov-link-subtitle-0"
+        >
+           Web Page 
+        </div>
+        <div
+          class="cell__subtitle"
+          data-testid="house-gov-link-subtitle-1"
+        >
+           effective Aug 2023 
+        </div>
       </th>
     </div>
   </body>,
   "container": <div>
     <th
-      class="row__cell row__cell--header row__cell--primary"
+      class="row__cell row__cell--header row__cell--secondary"
     >
       <div
         class="cell__title"
       >
-         Statute Citation 
+         US Code House.gov 
       </div>
-      <!---->
+      <div
+        class="cell__subtitle"
+        data-testid="house-gov-link-subtitle-0"
+      >
+         Web Page 
+      </div>
+      <div
+        class="cell__subtitle"
+        data-testid="house-gov-link-subtitle-1"
+      >
+         effective Aug 2023 
+      </div>
     </th>
   </div>,
   "debug": [Function],
@@ -90,27 +112,49 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
   "baseElement": <body>
     <div>
       <th
-        class="row__cell row__cell--header row__cell--primary"
+        class="row__cell row__cell--header row__cell--secondary"
       >
         <div
           class="cell__title"
         >
-           Statute Citation 
+           US Code House.gov 
         </div>
-        <!---->
+        <div
+          class="cell__subtitle"
+          data-testid="house-gov-link-subtitle-0"
+        >
+           Web Page 
+        </div>
+        <div
+          class="cell__subtitle"
+          data-testid="house-gov-link-subtitle-1"
+        >
+            
+        </div>
       </th>
     </div>
   </body>,
   "container": <div>
     <th
-      class="row__cell row__cell--header row__cell--primary"
+      class="row__cell row__cell--header row__cell--secondary"
     >
       <div
         class="cell__title"
       >
-         Statute Citation 
+         US Code House.gov 
       </div>
-      <!---->
+      <div
+        class="cell__subtitle"
+        data-testid="house-gov-link-subtitle-0"
+      >
+         Web Page 
+      </div>
+      <div
+        class="cell__subtitle"
+        data-testid="house-gov-link-subtitle-1"
+      >
+          
+      </div>
     </th>
   </div>,
   "debug": [Function],
@@ -180,15 +224,17 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
         <div
           class="cell__title"
         >
-           US Code House.gov 
+           Statute Compilation 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="statute-compilation-link-subtitle-0"
         >
-           Web Page 
+           PDF Document 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="statute-compilation-link-subtitle-1"
         >
            effective Aug 2023 
         </div>
@@ -202,15 +248,17 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
       <div
         class="cell__title"
       >
-         US Code House.gov 
+         Statute Compilation 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="statute-compilation-link-subtitle-0"
       >
-         Web Page 
+         PDF Document 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="statute-compilation-link-subtitle-1"
       >
          effective Aug 2023 
       </div>
@@ -283,15 +331,17 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
         <div
           class="cell__title"
         >
-           US Code House.gov 
+           Statute Compilation 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="statute-compilation-link-subtitle-0"
         >
-           Web Page 
+           PDF Document 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="statute-compilation-link-subtitle-1"
         >
             
         </div>
@@ -305,15 +355,17 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
       <div
         class="cell__title"
       >
-         US Code House.gov 
+         Statute Compilation 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="statute-compilation-link-subtitle-0"
       >
-         Web Page 
+         PDF Document 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="statute-compilation-link-subtitle-1"
       >
           
       </div>
@@ -386,17 +438,19 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
         <div
           class="cell__title"
         >
-           Statute Compilation 
+           US Code Annual 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="us-code-annual-link-subtitle-0"
         >
            PDF Document 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="us-code-annual-link-subtitle-1"
         >
-           amended Dec 2022 
+           effective Aug 2023 
         </div>
       </th>
     </div>
@@ -408,17 +462,19 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
       <div
         class="cell__title"
       >
-         Statute Compilation 
+         US Code Annual 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="us-code-annual-link-subtitle-0"
       >
          PDF Document 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="us-code-annual-link-subtitle-1"
       >
-         amended Dec 2022 
+         effective Aug 2023 
       </div>
     </th>
   </div>,
@@ -489,15 +545,17 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
         <div
           class="cell__title"
         >
-           Statute Compilation 
+           US Code Annual 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="us-code-annual-link-subtitle-0"
         >
            PDF Document 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="us-code-annual-link-subtitle-1"
         >
             
         </div>
@@ -511,15 +569,17 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
       <div
         class="cell__title"
       >
-         Statute Compilation 
+         US Code Annual 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="us-code-annual-link-subtitle-0"
       >
          PDF Document 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="us-code-annual-link-subtitle-1"
       >
           
       </div>
@@ -592,17 +652,19 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
         <div
           class="cell__title"
         >
-           US Code Annual 
+           SSA.gov Compilation 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="ssa-gov-link-subtitle-0"
         >
-           PDF Document 
+           Web Page 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="ssa-gov-link-subtitle-1"
         >
-           effective Jan 2022 
+           effective Aug 2023 
         </div>
       </th>
     </div>
@@ -614,17 +676,19 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
       <div
         class="cell__title"
       >
-         US Code Annual 
+         SSA.gov Compilation 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="ssa-gov-link-subtitle-0"
       >
-         PDF Document 
+         Web Page 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="ssa-gov-link-subtitle-1"
       >
-         effective Jan 2022 
+         effective Aug 2023 
       </div>
     </th>
   </div>,
@@ -695,221 +759,17 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
         <div
           class="cell__title"
         >
-           US Code Annual 
-        </div>
-        <div
-          class="cell__subtitle"
-        >
-           PDF Document 
-        </div>
-        <div
-          class="cell__subtitle"
-        >
-            
-        </div>
-      </th>
-    </div>
-  </body>,
-  "container": <div>
-    <th
-      class="row__cell row__cell--header row__cell--secondary"
-    >
-      <div
-        class="cell__title"
-      >
-         US Code Annual 
-      </div>
-      <div
-        class="cell__subtitle"
-      >
-         PDF Document 
-      </div>
-      <div
-        class="cell__subtitle"
-      >
-          
-      </div>
-    </th>
-  </div>,
-  "debug": [Function],
-  "emitted": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "html": [Function],
-  "isUnmounted": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "unmount": [Function],
-  "updateProps": [Function],
-}
-`;
-
-exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 5 with dates 1`] = `
-{
-  "baseElement": <body>
-    <div>
-      <th
-        class="row__cell row__cell--header row__cell--secondary"
-      >
-        <div
-          class="cell__title"
-        >
            SSA.gov Compilation 
         </div>
         <div
           class="cell__subtitle"
+          data-testid="ssa-gov-link-subtitle-0"
         >
            Web Page 
         </div>
         <div
           class="cell__subtitle"
-        >
-           amended Dec 2019 
-        </div>
-      </th>
-    </div>
-  </body>,
-  "container": <div>
-    <th
-      class="row__cell row__cell--header row__cell--secondary"
-    >
-      <div
-        class="cell__title"
-      >
-         SSA.gov Compilation 
-      </div>
-      <div
-        class="cell__subtitle"
-      >
-         Web Page 
-      </div>
-      <div
-        class="cell__subtitle"
-      >
-         amended Dec 2019 
-      </div>
-    </th>
-  </div>,
-  "debug": [Function],
-  "emitted": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "html": [Function],
-  "isUnmounted": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "unmount": [Function],
-  "updateProps": [Function],
-}
-`;
-
-exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 5 without dates 1`] = `
-{
-  "baseElement": <body>
-    <div>
-      <th
-        class="row__cell row__cell--header row__cell--secondary"
-      >
-        <div
-          class="cell__title"
-        >
-           SSA.gov Compilation 
-        </div>
-        <div
-          class="cell__subtitle"
-        >
-           Web Page 
-        </div>
-        <div
-          class="cell__subtitle"
+          data-testid="ssa-gov-link-subtitle-1"
         >
             
         </div>
@@ -927,11 +787,13 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
       </div>
       <div
         class="cell__subtitle"
+        data-testid="ssa-gov-link-subtitle-0"
       >
          Web Page 
       </div>
       <div
         class="cell__subtitle"
+        data-testid="ssa-gov-link-subtitle-1"
       >
           
       </div>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/HeaderCell.test.js.snap
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/__snapshots__/HeaderCell.test.js.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 1 1`] = `
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 1 with dates 1`] = `
 {
   "baseElement": <body>
     <div>
@@ -85,7 +85,92 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
 }
 `;
 
-exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 2 1`] = `
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 1 without dates 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <th
+        class="row__cell row__cell--header row__cell--primary"
+      >
+        <div
+          class="cell__title"
+        >
+           Statute Citation 
+        </div>
+        <!---->
+      </th>
+    </div>
+  </body>,
+  "container": <div>
+    <th
+      class="row__cell row__cell--header row__cell--primary"
+    >
+      <div
+        class="cell__title"
+      >
+         Statute Citation 
+      </div>
+      <!---->
+    </th>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 2 with dates 1`] = `
 {
   "baseElement": <body>
     <div>
@@ -105,7 +190,7 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
         <div
           class="cell__subtitle"
         >
-           Effective Jul 2023 
+           effective Aug 2023 
         </div>
       </th>
     </div>
@@ -127,7 +212,7 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
       <div
         class="cell__subtitle"
       >
-         Effective Jul 2023 
+         effective Aug 2023 
       </div>
     </th>
   </div>,
@@ -188,7 +273,110 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
 }
 `;
 
-exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 3 1`] = `
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 2 without dates 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <th
+        class="row__cell row__cell--header row__cell--secondary"
+      >
+        <div
+          class="cell__title"
+        >
+           US Code House.gov 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           Web Page 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+            
+        </div>
+      </th>
+    </div>
+  </body>,
+  "container": <div>
+    <th
+      class="row__cell row__cell--header row__cell--secondary"
+    >
+      <div
+        class="cell__title"
+      >
+         US Code House.gov 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         Web Page 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+          
+      </div>
+    </th>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 3 with dates 1`] = `
 {
   "baseElement": <body>
     <div>
@@ -208,7 +396,7 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
         <div
           class="cell__subtitle"
         >
-           Amended Dec 2022 
+           amended Dec 2022 
         </div>
       </th>
     </div>
@@ -230,7 +418,7 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
       <div
         class="cell__subtitle"
       >
-         Amended Dec 2022 
+         amended Dec 2022 
       </div>
     </th>
   </div>,
@@ -291,7 +479,110 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
 }
 `;
 
-exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 4 1`] = `
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 3 without dates 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <th
+        class="row__cell row__cell--header row__cell--secondary"
+      >
+        <div
+          class="cell__title"
+        >
+           Statute Compilation 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           PDF Document 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+            
+        </div>
+      </th>
+    </div>
+  </body>,
+  "container": <div>
+    <th
+      class="row__cell row__cell--header row__cell--secondary"
+    >
+      <div
+        class="cell__title"
+      >
+         Statute Compilation 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         PDF Document 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+          
+      </div>
+    </th>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 4 with dates 1`] = `
 {
   "baseElement": <body>
     <div>
@@ -311,7 +602,7 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
         <div
           class="cell__subtitle"
         >
-           Effective Jan 2022 
+           effective Jan 2022 
         </div>
       </th>
     </div>
@@ -333,7 +624,7 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
       <div
         class="cell__subtitle"
       >
-         Effective Jan 2022 
+         effective Jan 2022 
       </div>
     </th>
   </div>,
@@ -394,7 +685,110 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
 }
 `;
 
-exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 5 1`] = `
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 4 without dates 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <th
+        class="row__cell row__cell--header row__cell--secondary"
+      >
+        <div
+          class="cell__title"
+        >
+           US Code Annual 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           PDF Document 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+            
+        </div>
+      </th>
+    </div>
+  </body>,
+  "container": <div>
+    <th
+      class="row__cell row__cell--header row__cell--secondary"
+    >
+      <div
+        class="cell__title"
+      >
+         US Code Annual 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         PDF Document 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+          
+      </div>
+    </th>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 5 with dates 1`] = `
 {
   "baseElement": <body>
     <div>
@@ -414,7 +808,7 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
         <div
           class="cell__subtitle"
         >
-           Amended Dec 2019 
+           amended Dec 2019 
         </div>
       </th>
     </div>
@@ -436,7 +830,110 @@ exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of he
       <div
         class="cell__subtitle"
       >
-         Amended Dec 2019 
+         amended Dec 2019 
+      </div>
+    </th>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Statute Table Header Cell > SSA table header > Creates a snapshot of header cell for column 5 without dates 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <th
+        class="row__cell row__cell--header row__cell--secondary"
+      >
+        <div
+          class="cell__title"
+        >
+           SSA.gov Compilation 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+           Web Page 
+        </div>
+        <div
+          class="cell__subtitle"
+        >
+            
+        </div>
+      </th>
+    </div>
+  </body>,
+  "container": <div>
+    <th
+      class="row__cell row__cell--header row__cell--secondary"
+    >
+      <div
+        class="cell__title"
+      >
+         SSA.gov Compilation 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+         Web Page 
+      </div>
+      <div
+        class="cell__subtitle"
+      >
+          
       </div>
     </th>
   </div>,

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
@@ -15,7 +15,7 @@ const getDateLabel = ({ type, date }) => {
     if (_isUndefined(type) || _isUndefined(date)) return "";
 
     const rawDate = new Date(date);
-    const formattedDate = rawDate.tolocalestring("default", {
+    const formattedDate = rawDate.toLocaleString("default", {
         month: "short",
         year: "numeric",
     });

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 /* eslint-disable eqeqeq */
 
+import _isNull from "lodash/isNull";
 import _isUndefined from "lodash/isUndefined";
 
 // SSA table column date methods
@@ -9,10 +10,16 @@ import _isUndefined from "lodash/isUndefined";
  * @param {string} type - Label for the date
  * @param {string} date - Date to be formatted
  *
- * @returns {string} - Formatted date label
+ * @returns {string} - Formatted date label or empty string
  */
 const getDateLabel = ({ type, date }) => {
-    if (_isUndefined(type) || _isUndefined(date)) return "";
+    if (
+        _isNull(type) ||
+        _isNull(date) ||
+        _isUndefined(type) ||
+        _isUndefined(date)
+    )
+        return "";
 
     const rawDate = new Date(date);
     const formattedDate = rawDate.toLocaleString("default", {
@@ -20,7 +27,7 @@ const getDateLabel = ({ type, date }) => {
         year: "numeric",
     });
 
-    if (formattedDate == "Invalid Date") return "";
+    if (formattedDate === "Invalid Date") return "";
 
     return `${type} ${formattedDate}`;
 };

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
@@ -11,7 +11,7 @@ import _isUndefined from "lodash/isUndefined";
  *
  * @returns {string} - Formatted date label
  */
-const getDateLabel = ({ type=undefined, date=undefined }) => {
+const getDateLabel = ({ type, date }) => {
     if (_isUndefined(type) || _isUndefined(date)) return "";
     return `${type} ${date}`;
 };

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
@@ -13,7 +13,16 @@ import _isUndefined from "lodash/isUndefined";
  */
 const getDateLabel = ({ type, date }) => {
     if (_isUndefined(type) || _isUndefined(date)) return "";
-    return `${type} ${date}`;
+
+    const rawDate = new Date(date);
+    const formattedDate = rawDate.tolocalestring("default", {
+        month: "short",
+        year: "numeric",
+    });
+
+    if (formattedDate == "Invalid Date") return "";
+
+    return `${type} ${formattedDate}`;
 };
 
 export { getDateLabel };

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
@@ -22,6 +22,8 @@ const getDateLabel = ({ type, date }) => {
         return "";
 
     const rawDate = new Date(date);
+    // add a day to get correct month because Javascript dates are weird
+    rawDate.setDate(rawDate.getDate() + 1);
     const formattedDate = rawDate.toLocaleString("default", {
         month: "short",
         year: "numeric",

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+/* eslint-disable eqeqeq */
+
+import _isUndefined from "lodash/isUndefined";
+
+// SSA table column date methods
+
+/**
+ * @param {string} type - Label for the date
+ * @param {string} date - Date to be formatted
+ *
+ * @returns {string} - Formatted date label
+ */
+const getDateLabel = ({ type=undefined, date=undefined }) => {
+    if (_isUndefined(type) || _isUndefined(date)) return "";
+    return `${type} ${date}`;
+};
+
+export { getDateLabel };

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.js
@@ -17,7 +17,8 @@ const getDateLabel = ({ type, date }) => {
         _isNull(type) ||
         _isNull(date) ||
         _isUndefined(type) ||
-        _isUndefined(date)
+        _isUndefined(date) ||
+        type === ""
     )
         return "";
 

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/utils/dateMethods.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+
+import { getDateLabel } from "./dateMethods";
+
+describe("Date Methods", () => {
+    describe("getDateLabel", () => {
+        it("returns empty string when date is null", () => {
+            const label = getDateLabel({ type: "effective", date: null });
+            expect(label).toEqual("");
+        });
+
+        it("returns empty string when date is undefined", () => {
+            const label = getDateLabel({ type: "effective", date: undefined });
+            expect(label).toEqual("");
+        });
+
+        it("returns empty string when date is empty string", () => {
+            const label = getDateLabel({ type: "effective", date: "" });
+            expect(label).toEqual("");
+        });
+
+        it("returns empty string when type is null", () => {
+            const label = getDateLabel({ type: null, date: "2023-08" });
+            expect(label).toEqual("");
+        });
+
+        it("returns empty string when type is undefined", () => {
+            const label = getDateLabel({ type: undefined, date: "2023-08" });
+            expect(label).toEqual("");
+        });
+
+        it("returns empty string when type is empty string", () => {
+            const label = getDateLabel({ type: "", date: "2023-08" });
+            expect(label).toEqual("");
+        });
+
+        it("returns empty string when date is invalid", () => {
+            const label = getDateLabel({ type: "effective", date: "20.22-08" });
+            expect(label).toEqual("");
+        });
+
+        it("returns properly formatted date string when date and type are valid", () => {
+            const label = getDateLabel({ type: "effective", date: "2023-08" });
+            expect(label).toEqual("effective Aug 2023");
+        });
+    });
+});


### PR DESCRIPTION
Resolves [EREGCSC-2113](https://jiraent.cms.gov/browse/EREGCSC-2113)

**Description:**

Pulls dates from site configuration in admin panel into front end for Statute Table column header labels.

**This pull request changes:**

- Adds statute table site configuration labels and dates into Statutes template using [best practice](https://adamj.eu/tech/2022/10/06/how-to-safely-pass-data-to-javascript-in-a-django-template/)
- Only shows dates if both label and date exist, and if date is a valid date
- Updates snapshot tests and adds unit front end unit test coverage

**Steps to manually verify this change:**

1. Go into [admin panel for experimental deployment](https://1ghm0p11p3.execute-api.us-east-1.amazonaws.com/dev929/admin/) > Regulations > Site Configuration
2. Edit Date Type and Date
3. Try out a bunch of options.  If Date Type and Date are both valid, the date subtitle should appear in the column header.  If one or both of the Date Type and Date are empty strings or invalid, the date subtitle will not appear.

