### PR TITLE
EREGCSC-2027 -- Adding ruff rules for E

### DIFF
--- a/solution/backend/pyproject.toml
+++ b/solution/backend/pyproject.toml
@@ -3,11 +3,17 @@ DJANGO_SETTINGS_MODULE = "cmcs_regulations.settings.test_settings"
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F", "G", "I", "S", "W", "ASYNC"]
+select = ["E", "F", "G", "I", "S", "W", "ASYNC",
+          "E111", "E112", "E113", "E114", "E115", "E116", "E117", "E201", "E202", "E203", "E211", "E222", "E222", "E223",
+          "E224", "E225", "E226", "E227", "E228", "E231", "E241", "E242", "E251", "E252", "E261", "E262", "E265", "E266",
+          "E271", "E272", "E273", "E274", "E275",
+        ]
 ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["E", "F", "I", "W"]
+fixable = ["E", "F", "I", "W",
+           "E201", "E202", "E203", "E211", "E231",
+          ]
 unfixable = []
 
 # Exclude a variety of commonly ignored directories.

--- a/solution/backend/regcore/models.py
+++ b/solution/backend/regcore/models.py
@@ -42,7 +42,7 @@ class Part(models.Model):
     @property
     def subchapter(self):
         structure = self.structure
-        for _ in range(self.depth-1):
+        for _ in range(self.depth - 1):
             structure = structure["children"][0]
         return structure["label"]
 

--- a/solution/backend/regulations/tests/test_statute_links.py
+++ b/solution/backend/regulations/tests/test_statute_links.py
@@ -161,7 +161,7 @@ class StatuteConvertersAPITestCase(APITestCase):
         with open("regulations/tests/fixtures/statute_link_api_test.json", "r") as f:
             self.objects = json.load(f)
             # Objects are inserted in reverse order to ensure endpoint ordering is correct
-            for i in range(len(self.objects)-1, -1, -1):
+            for i in range(len(self.objects) - 1, -1, -1):
                 obj = self.objects[i]
                 roman = obj["statute_title_roman"]
                 del obj["statute_title_roman"]

--- a/solution/backend/regulations/views/utils.py
+++ b/solution/backend/regulations/views/utils.py
@@ -29,10 +29,10 @@ def different(one, two):
 
 
 def merge_children(one, two):
-    if different(one[len(one)-1], two):
+    if different(one[len(one) - 1], two):
         one.append(two)
         return
-    merge_children(one[len(one)-1]['children'], two['children'][0])
+    merge_children(one[len(one) - 1]['children'], two['children'][0])
 
 
 def get_structure(parts):

--- a/solution/backend/resources/admin.py
+++ b/solution/backend/resources/admin.py
@@ -397,7 +397,7 @@ class FederalResourceForm(ResourceForm):
     def __init__(self, *args, **kwargs):
         super(FederalResourceForm, self).__init__(*args, **kwargs)
         if self.instance.id:
-            CHOICES_INCLUDING_DB_VALUE = [(self.instance.doc_type,)*2] + self.doc_types
+            CHOICES_INCLUDING_DB_VALUE = [(self.instance.doc_type,) * 2] + self.doc_types
             self.fields['doc_type'] = forms.ChoiceField(
                 choices=CHOICES_INCLUDING_DB_VALUE)
 

--- a/solution/backend/resources/tests/test_queryset_functions.py
+++ b/solution/backend/resources/tests/test_queryset_functions.py
@@ -32,7 +32,7 @@ class TestMixinFunctions(TestCase):
     def get_annotated_group(self):
         return Case(
             When(federalregisterdocument__isnull=False, then=F("federalregisterdocument__group")),
-            default=-1*F("pk"),
+            default=-1 * F("pk"),
         )
 
     def test_get_id_one_groups(self):

--- a/solution/backend/resources/views/mixins.py
+++ b/solution/backend/resources/views/mixins.py
@@ -155,7 +155,7 @@ class ResourceExplorerViewSetMixin(OptionalPaginationMixin, LocationFiltererMixi
         return F("description_sort")
 
     def get_annotated_group(self):
-        return -1*F("pk")
+        return -1 * F("pk")
 
     def get_serializer_context(self):
         context = super().get_serializer_context()


### PR DESCRIPTION
Resolves # EREGCSC-2027

**Description-**
Rule E for Ruff has some rules that are not included in the E by default.  In order for us to eventually remove flake8 these rules will need to be added.  

The rules for E were put after the rest of the rules for readability.  Not many of these rules have autofix currently.

https://beta.ruff.rs/docs/rules/#error-e

**This pull request changes...**

- Adds missing "E" rules for ruff.
- A couple spaces were added for  compliance to the rules

**Steps to manually verify this change...**

1. Ruff runs correctly on the branch.
2. Experimental deploys correctly.

