### PR TITLE
EREGCSC-2111 -- Determine ShowIfEmpty status for sidebar items on the front end

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/sidebar_right.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_right.html
@@ -1,7 +1,6 @@
 {% load string_formatters %}
 
 {{ categories|json_script:"categories" }}
-{{ sub_categories|json_script:"sub_categories" }}
 
 <section id="right-sidebar" data-cache-key="sidebar" data-cache-value="{{label_id}}">
     {% include "regulations/partials/view-button.html" %}

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -22,7 +22,6 @@ from regulations.views.utils import find_subpart
 from resources.models import (
     AbstractLocation,
     Category,
-    SubCategory,
 )
 
 
@@ -54,7 +53,6 @@ class ReaderView(CitationContextMixin, TemplateView):
         tree = self.get_content(context, document, toc)
         node_list = self.get_supp_content_params(context, [tree])
         categories = list(Category.objects.filter(show_if_empty=True).contains_fr_docs().order_by('order').values())
-        sub_categories = list(SubCategory.objects.filter(show_if_empty=True).contains_fr_docs().order_by('order').values())
 
         locations = AbstractLocation.objects.filter(part=reg_part).select_subclasses().annotate(
             num_locations=Count(
@@ -93,7 +91,6 @@ class ReaderView(CitationContextMixin, TemplateView):
             'node_list':    node_list,
             'view_type':    self.get_view_type(),
             'categories':   categories,
-            'sub_categories': sub_categories,
             'resource_count': resource_count,
             'link_conversions': conversions,
             'link_config': statute_link_config,

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -52,7 +52,7 @@ class ReaderView(CitationContextMixin, TemplateView):
         part_label = toc['label_description']
         tree = self.get_content(context, document, toc)
         node_list = self.get_supp_content_params(context, [tree])
-        categories = list(Category.objects.filter(show_if_empty=True).contains_fr_docs().order_by('order').values())
+        categories = list(Category.objects.contains_fr_docs().order_by('order').values())
 
         locations = AbstractLocation.objects.filter(part=reg_part).select_subclasses().annotate(
             num_locations=Count(

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
@@ -49,15 +49,10 @@ function getDefaultCategories() {
     const rawCategories = JSON.parse(
         document.getElementById("categories").textContent
     );
-    const rawSubCategories = JSON.parse(
-        document.getElementById("sub_categories").textContent
-    );
 
     return rawCategories.map((c) => {
         const category = JSON.parse(JSON.stringify(c));
-        category.sub_categories = rawSubCategories.filter(
-            (subcategory) => subcategory.parent_id === category.id
-        );
+        category.sub_categories = [];
         return category;
     });
 }

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
@@ -30,6 +30,7 @@
                 :sub_categories="category.sub_categories"
                 :is-fetching="isFetching"
                 :is-fr-doc-category="category.is_fr_doc_category"
+                :show-if-empty="category.show_if_empty"
             >
             </supplemental-content-category>
             <simple-spinner v-if="isFetching"></simple-spinner>

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentCategory.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentCategory.vue
@@ -1,5 +1,8 @@
 <template>
-    <div class="supplemental-content-category">
+    <div
+        v-if="has_children || (!has_children && showIfEmpty)"
+        class="supplemental-content-category"
+    >
         <div class="category">
             <collapse-button
                 v-if="has_children"
@@ -70,7 +73,6 @@ import RelatedRuleList from "./RelatedRuleList.vue";
 import SupplementalContentList from "./SupplementalContentList.vue";
 import CollapseButton from "./CollapseButton.vue";
 import Collapsible from "./Collapsible.vue";
-import SimpleSpinner from "./SimpleSpinner.vue";
 
 export default {
     name: "supplemental-content-category",
@@ -80,7 +82,6 @@ export default {
         SupplementalContentList,
         CollapseButton,
         Collapsible,
-        SimpleSpinner,
     },
 
     props: {
@@ -101,6 +102,11 @@ export default {
         description: {
             type: String,
             required: true,
+        },
+        showIfEmpty: {
+            type: Boolean,
+            required: false,
+            default: false,
         },
         supplemental_content: {
             type: Array,

--- a/solution/ui/regulations/msw/mocks/categories.js
+++ b/solution/ui/regulations/msw/mocks/categories.js
@@ -34,6 +34,24 @@ const categories = [
         show_if_empty: true,
         abstractcategory_ptr_id: 23,
     },
+    {
+        id: 100,
+        name: "Empty and Hidden",
+        description:
+            "This category is empty and should not be shown in the sidebar",
+        order: 1000,
+        show_if_empty: false,
+        abstractcategory_ptr_id: 100,
+    },
+    {
+        id: 200,
+        name: "Empty but Visible",
+        description:
+            "This category is empty but should be shown in the sidebar",
+        order: 2000,
+        show_if_empty: true,
+        abstractcategory_ptr_id: 200,
+    },
 ];
 
 export { categories };

--- a/solution/ui/regulations/msw/mocks/categories.js
+++ b/solution/ui/regulations/msw/mocks/categories.js
@@ -35,5 +35,5 @@ const categories = [
         abstractcategory_ptr_id: 23,
     },
 ];
-const subCategories = [{}];
-export { categories, subCategories };
+
+export { categories };

--- a/solution/ui/regulations/test/unit-test/SupplementalContent.test.js
+++ b/solution/ui/regulations/test/unit-test/SupplementalContent.test.js
@@ -42,6 +42,25 @@ describe("Supplemental Content", () => {
         expect(subG).toBeTruthy();
     });
 
+    it("Properly shows and hides empty categories", async () => {
+        render(SupplementalContent, {
+            props: {
+                apiUrl: "http://localhost:8000/",
+                title: "42",
+                part: "433",
+                subparts: ["A"],
+            },
+        });
+
+        await flushPromises();
+
+        const subEmptyButVisible = screen.queryByText("Empty but Visible");
+        expect(subEmptyButVisible).toBeTruthy();
+
+        const subEmptyAndHidden = screen.queryByText("Empty and Hidden");
+        expect(subEmptyAndHidden).toBeNull();
+    });
+
     it("Clicks a drop down", async () => {
         render(SupplementalContent, {
             props: {

--- a/solution/ui/regulations/test/unit-test/SupplementalContent.test.js
+++ b/solution/ui/regulations/test/unit-test/SupplementalContent.test.js
@@ -2,29 +2,27 @@ import { render, screen, fireEvent } from "@testing-library/vue";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import SupplementalContent from "eregsComponentLib/src/components/SupplementalContent.vue";
 import flushPromises from "flush-promises";
-import { categories, subCategories } from "../../msw/mocks/categories";
+import { categories } from "../../msw/mocks/categories";
 
 describe("Supplemental Content", () => {
     beforeEach(() => {
         const docCat = document.createElement("div");
         docCat.id = "categories";
         docCat.textContent = JSON.stringify(categories);
-        const subcat = document.createElement("div");
-        subcat.id = "sub_categories";
-        subcat.textContent = JSON.stringify(subCategories);
         document.body.appendChild(docCat);
-        document.body.appendChild(subcat);
+
         const url = "http://eregs.com/";
+
         Object.defineProperty(window, "location", {
             value: new URL(url),
         });
     });
+
     afterEach(() => {
         const cat = document.getElementById("categories");
-        const sub = document.getElementById("sub_categories");
         cat.remove();
-        sub.remove();
     });
+
     it("Populates some content", async () => {
         render(SupplementalContent, {
             props: {
@@ -34,13 +32,16 @@ describe("Supplemental Content", () => {
                 subparts: ["A"],
             },
         });
+
         await flushPromises();
 
         const view = screen.getByText("Subpart A Resources");
         expect(view.id).toBe("subpart-resources-heading");
+
         const subG = screen.getByText("Subregulatory Guidance");
         expect(subG).toBeTruthy();
     });
+
     it("Clicks a drop down", async () => {
         render(SupplementalContent, {
             props: {
@@ -50,25 +51,29 @@ describe("Supplemental Content", () => {
                 subparts: ["A"],
             },
         });
+
         await flushPromises();
         const subG = await screen.getByLabelText(
             "expand Subregulatory Guidance"
         );
         expect(subG).toBeTruthy();
-        await fireEvent.click(subG);
 
+        await fireEvent.click(subG);
         expect(subG.textContent).toStrictEqual("Subregulatory Guidance ");
+
         const stateMedBtn = await screen.getByText(
             "State Medicaid Director Letter (SMDL)"
         );
         await flushPromises();
         expect(stateMedBtn.classList.contains("visible")).toBe(false);
-        await fireEvent.click(stateMedBtn);
 
+        await fireEvent.click(stateMedBtn);
         expect(stateMedBtn.classList.contains("visible")).toBe(true);
     });
+
     it("Navigates to a section then a subpart", async () => {
         window.location.href += "#433-10";
+
         render(SupplementalContent, {
             props: {
                 apiUrl: "http://localhost:8000/",
@@ -79,28 +84,37 @@ describe("Supplemental Content", () => {
         });
 
         expect(window.location.hash).toEqual("#433-10");
+
         await flushPromises();
         const heading = screen.getByText("§ 433.10 Resources");
         expect(heading.id).toBe("subpart-resources-heading");
+
         let viewAllSubpartRes = screen.getByTestId(
             "view-all-subpart-resources"
         );
         expect(viewAllSubpartRes.textContent).toBe(
             " View All Subpart A Resources (136) "
         );
+
         const subG = screen.getByLabelText("expand Subregulatory Guidance");
         await fireEvent.click(subG);
+
         const stateHealth = screen.getByLabelText(
             "expand State Health Official (SHO) Letter"
         );
         await fireEvent.click(stateHealth);
         await fireEvent.click(viewAllSubpartRes);
+
         await flushPromises();
+
         viewAllSubpartRes = screen.queryByTestId("view-all-subpart-resources");
         expect(viewAllSubpartRes).toBeFalsy();
+
         expect(heading.textContent).toBe("Subpart A Resources");
+
         const relatedStatues = screen.getByLabelText("expand Related Statutes");
         expect(relatedStatues).toBeTruthy();
+
         await fireEvent.click(relatedStatues);
     });
 
@@ -113,6 +127,7 @@ describe("Supplemental Content", () => {
                 subparts: ["A"],
             },
         });
+
         await flushPromises();
 
         expect(wrapper).toMatchSnapshot();

--- a/solution/ui/regulations/test/unit-test/__snapshots__/SupplementalContent.test.js.snap
+++ b/solution/ui/regulations/test/unit-test/__snapshots__/SupplementalContent.test.js.snap
@@ -6,7 +6,7 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
     <div
       id="categories"
     >
-      [{"id":5,"name":"Subregulatory Guidance","description":"SMDLs, SHOs, CIBs, FAQs, SMM","order":400,"show_if_empty":true,"abstractcategory_ptr_id":5},{"id":11,"name":"Implementation Resources","description":"State Technical Assistance, Toolkits, SPA/Waiver Resources","order":500,"show_if_empty":true,"abstractcategory_ptr_id":11},{"id":19,"name":"Reports to Congress","description":"CMS policy analysis and research reports sent to Congress","order":501,"show_if_empty":true,"abstractcategory_ptr_id":19},{"id":23,"name":"Oversight Reports","description":"Reports from HHS Office of Inspector General and U.S. Government Accountability Office","order":600,"show_if_empty":true,"abstractcategory_ptr_id":23}]
+      [{"id":5,"name":"Subregulatory Guidance","description":"SMDLs, SHOs, CIBs, FAQs, SMM","order":400,"show_if_empty":true,"abstractcategory_ptr_id":5},{"id":11,"name":"Implementation Resources","description":"State Technical Assistance, Toolkits, SPA/Waiver Resources","order":500,"show_if_empty":true,"abstractcategory_ptr_id":11},{"id":19,"name":"Reports to Congress","description":"CMS policy analysis and research reports sent to Congress","order":501,"show_if_empty":true,"abstractcategory_ptr_id":19},{"id":23,"name":"Oversight Reports","description":"Reports from HHS Office of Inspector General and U.S. Government Accountability Office","order":600,"show_if_empty":true,"abstractcategory_ptr_id":23},{"id":100,"name":"Empty and Hidden","description":"This category is empty and should not be shown in the sidebar","order":1000,"show_if_empty":false,"abstractcategory_ptr_id":100},{"id":200,"name":"Empty but Visible","description":"This category is empty but should be shown in the sidebar","order":2000,"show_if_empty":true,"abstractcategory_ptr_id":200}]
     </div>
     <div>
       <div>
@@ -5863,6 +5863,30 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                 </div>
                 <!---->
               </div>
+            </div>
+          </div>
+          <!---->
+          <div
+            class="supplemental-content-category"
+          >
+            <div
+              class="category"
+            >
+              <div
+                class="category-title childless collapsible-title"
+              >
+                 Empty but Visible 
+              </div>
+              <span
+                class="childless category-description"
+              >
+                None
+              </span>
+              <div
+                class="category-content invisible display-none"
+                data-test="Empty but Visible"
+                style="transition: 0.5s; overflow: hidden;"
+              />
             </div>
           </div>
           <!---->
@@ -11725,6 +11749,30 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
               </div>
               <!---->
             </div>
+          </div>
+        </div>
+        <!---->
+        <div
+          class="supplemental-content-category"
+        >
+          <div
+            class="category"
+          >
+            <div
+              class="category-title childless collapsible-title"
+            >
+               Empty but Visible 
+            </div>
+            <span
+              class="childless category-description"
+            >
+              None
+            </span>
+            <div
+              class="category-content invisible display-none"
+              data-test="Empty but Visible"
+              style="transition: 0.5s; overflow: hidden;"
+            />
           </div>
         </div>
         <!---->

--- a/solution/ui/regulations/test/unit-test/__snapshots__/SupplementalContent.test.js.snap
+++ b/solution/ui/regulations/test/unit-test/__snapshots__/SupplementalContent.test.js.snap
@@ -8,11 +8,6 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
     >
       [{"id":5,"name":"Subregulatory Guidance","description":"SMDLs, SHOs, CIBs, FAQs, SMM","order":400,"show_if_empty":true,"abstractcategory_ptr_id":5},{"id":11,"name":"Implementation Resources","description":"State Technical Assistance, Toolkits, SPA/Waiver Resources","order":500,"show_if_empty":true,"abstractcategory_ptr_id":11},{"id":19,"name":"Reports to Congress","description":"CMS policy analysis and research reports sent to Congress","order":501,"show_if_empty":true,"abstractcategory_ptr_id":19},{"id":23,"name":"Oversight Reports","description":"Reports from HHS Office of Inspector General and U.S. Government Accountability Office","order":600,"show_if_empty":true,"abstractcategory_ptr_id":23}]
     </div>
-    <div
-      id="sub_categories"
-    >
-      [{}]
-    </div>
     <div>
       <div>
         <!---->

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -528,32 +528,20 @@ const formatResourceCategories = (resources) => {
             }
         });
 
-    const rawSubCategories = JSON.parse(
-        document.getElementById("sub_categories").textContent
-    );
+    const subCategories = [];
+
     resources
         .filter((resource) => resource.category.type === "subcategory")
         .forEach((resource) => {
-            const existingSubCategory = rawSubCategories.find(
-                (category) => category.name === resource.category.name
+            const newSubCategory = JSON.parse(
+                JSON.stringify(resource.category)
             );
-
-            if (existingSubCategory) {
-                if (!existingSubCategory.supplemental_content) {
-                    existingSubCategory.supplemental_content = [];
-                }
-                existingSubCategory.supplemental_content.push(resource);
-            } else {
-                const newSubCategory = JSON.parse(
-                    JSON.stringify(resource.category)
-                );
-                newSubCategory.supplemental_content = [resource];
-                rawSubCategories.push(newSubCategory);
-            }
+            newSubCategory.supplemental_content = [resource];
+            subCategories.push(newSubCategory);
         });
     const categories = rawCategories.map((c) => {
         const category = JSON.parse(JSON.stringify(c));
-        category.sub_categories = rawSubCategories.filter(
+        category.sub_categories = subCategories.filter(
             (subcategory) => subcategory.parent?.id === category?.id
         );
         return category;

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -533,23 +533,38 @@ const formatResourceCategories = (resources) => {
     resources
         .filter((resource) => resource.category.type === "subcategory")
         .forEach((resource) => {
-            const newSubCategory = JSON.parse(
-                JSON.stringify(resource.category)
+            const existingSubCategory = subCategories.find(
+                (category) => category.name === resource.category.name
             );
-            newSubCategory.supplemental_content = [resource];
-            subCategories.push(newSubCategory);
+
+            if (existingSubCategory) {
+                if (!existingSubCategory.supplemental_content) {
+                    existingSubCategory.supplemental_content = [];
+                }
+                existingSubCategory.supplemental_content.push(resource);
+            } else {
+                const newSubCategory = JSON.parse(
+                    JSON.stringify(resource.category)
+                );
+                newSubCategory.supplemental_content = [resource];
+                subCategories.push(newSubCategory);
+            }
         });
+
     const categories = rawCategories.map((c) => {
         const category = JSON.parse(JSON.stringify(c));
         category.sub_categories = subCategories.filter(
             (subcategory) => subcategory.parent?.id === category?.id
         );
+
         return category;
     });
+
     categories.sort((a, b) => a.order - b.order);
     categories.forEach((category) => {
         category.sub_categories.sort((a, b) => a.order - b.order);
     });
+
     return categories;
 };
 


### PR DESCRIPTION
Resolves[ EREGCSC-2111 ](https://jiraent.cms.gov/browse/EREGCSC-2111)

**Description**

The right sidebar of the reader view has resources categories that can have or not have children.  We should have the ability to show or hide these categories even if they are empty.  Unfortunately, this was being incorrectly filtered in the Django view and wasn't working properly.  

This PR will move the logic to determine showing or hiding an empty category to the front end.

**This pull request changes:**

- No longer passes `sub_categories` into the template from the Django view.  This was refactored long ago to just pass in an empty object; we don't need to do that, so it has been removed.
- Removes code and logic everywhere (Vue component, utility function, unit tests) that assumed an empty `sub_categories` object was passed in to the Django template.
- Passes in all categories from the Django view into the Django template and the Vue component -- no longer filters on `show_if_empty=True` in the Django view.
- Determines on the front end if an empty category should be hidden or shown in the Vue component.
- Updates tests to make sure `showIfEmpty` is properly working in the Vue component.

**Steps to manually verify this change:**

1. Visit [experimental deployment](https://cx4wcijizl.execute-api.us-east-1.amazonaws.com/dev931/) and go to section 440.130
2. Visit admin page for experimental deployment and go to Resources and Regulations > Categories
3. Toggle Show if Empty for a bunch of categories and make sure everything behaves as expected
4. Specifically, 440.130 should still show "Reports and Evaluations" even when "Show if Empty" is set to `false`
   - compare against the [`dev` site](https://cqeki073yh.execute-api.us-east-1.amazonaws.com/dev/42/440/Subpart-A/2020-12-16/#440-130), which hides "Reports and Evaluations" when "Show if Empty" is `false`

