### PR TITLE
EREGCSC-2144 -- Show authenticated-only content in eRegs

### DIFF
--- a/solution/backend/regulations/templates/regulations/base.html
+++ b/solution/backend/regulations/templates/regulations/base.html
@@ -62,6 +62,10 @@ CSS/Javascript etc., should inherit from this template.
 
                 {% block body %}{% endblock %}
 
+                {% block login_indicator %}
+                    {% include "regulations/partials/login_indicator.html" %}
+                {% endblock %}
+
                 {% block footer %}
                     <footer>
                         {% include "regulations/partials/footer.html" %}

--- a/solution/backend/regulations/templates/regulations/partials/login_indicator.html
+++ b/solution/backend/regulations/templates/regulations/partials/login_indicator.html
@@ -1,9 +1,10 @@
-<div id="loginIndicator">
 {% if user.is_authenticated %}
+<div id="loginIndicator">
     <span class="span__login-lamp span__login-lamp--success"></span>
     <span class="span__login-greeting">Hello, <b>{{ user.username }}</b>!</span>
     <a href="{% url 'logout' %}?next={{ request.path }}">Log Out</a>
 {% else %}
+<div id="loginIndicator" class="display-none">
     <span class="span__login-lamp span__login-lamp--error"></span>
     <span class="span__login-greeting">Hello, <b>Guest</b>!</span>
     <a href="{% url 'login' %}?next={{ request.path }}">Log In</a>

--- a/solution/backend/regulations/templates/regulations/partials/login_indicator.html
+++ b/solution/backend/regulations/templates/regulations/partials/login_indicator.html
@@ -2,5 +2,6 @@
 <div id="loginIndicator">
     <span class="span__login-lamp span__login-lamp--success"></span>
     <span class="span__login-greeting">Hello, <b>{{ user.username }}</b>!</span>
+    <a href="{% url 'logout' %}?next=/">Log Out</a>
 </div>
 {% endif %}

--- a/solution/backend/regulations/templates/regulations/partials/login_indicator.html
+++ b/solution/backend/regulations/templates/regulations/partials/login_indicator.html
@@ -1,0 +1,6 @@
+{% if user.is_authenticated %}
+<div id="loginIndicator">
+    <span class="span__login-lamp span__login-lamp--success"></span>
+    <span class="span__login-greeting">Hello, <b>{{ user.username }}</b>!</span>
+</div>
+{% endif %}

--- a/solution/backend/regulations/templates/regulations/partials/login_indicator.html
+++ b/solution/backend/regulations/templates/regulations/partials/login_indicator.html
@@ -2,10 +2,10 @@
 {% if user.is_authenticated %}
     <span class="span__login-lamp span__login-lamp--success"></span>
     <span class="span__login-greeting">Hello, <b>{{ user.username }}</b>!</span>
-    <a href="{% url 'logout' %}?next=/">Log Out</a>
+    <a href="{% url 'logout' %}?next={{ request.path }}">Log Out</a>
 {% else %}
     <span class="span__login-lamp span__login-lamp--error"></span>
     <span class="span__login-greeting">Hello, <b>Guest</b>!</span>
-    <a href="{% url 'login' %}?next=/">Log In</a>
+    <a href="{% url 'login' %}?next={{ request.path }}">Log In</a>
 {% endif %}
 </div>

--- a/solution/backend/regulations/templates/regulations/partials/login_indicator.html
+++ b/solution/backend/regulations/templates/regulations/partials/login_indicator.html
@@ -1,7 +1,11 @@
-{% if user.is_authenticated %}
 <div id="loginIndicator">
+{% if user.is_authenticated %}
     <span class="span__login-lamp span__login-lamp--success"></span>
     <span class="span__login-greeting">Hello, <b>{{ user.username }}</b>!</span>
     <a href="{% url 'logout' %}?next=/">Log Out</a>
-</div>
+{% else %}
+    <span class="span__login-lamp span__login-lamp--error"></span>
+    <span class="span__login-greeting">Hello, <b>Guest</b>!</span>
+    <a href="{% url 'login' %}?next=/">Log In</a>
 {% endif %}
+</div>

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -14,6 +14,8 @@
 
 {% block body %}
     <div class="content">
+        <p>Is Superuser: {{ user.is_superuser }}</p>
+        <p>User {{ user.username }} is authenticated: {{ is_user_authenticated }}</p>
         {% include "regulations/partials/view-and-compare.html" %}
         <div class="flexbox">
             <aside tabindex="-1" class="left-sidebar match-sides" data-state="expanded" data-state-name="left-sidebar">

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -14,8 +14,6 @@
 
 {% block body %}
     <div class="content">
-        <p>Is Superuser: {{ user.is_superuser }}</p>
-        <p>User {{ user.username }} is authenticated: {{ is_user_authenticated }}</p>
         {% include "regulations/partials/view-and-compare.html" %}
         <div class="flexbox">
             <aside tabindex="-1" class="left-sidebar match-sides" data-state="expanded" data-state-name="left-sidebar">

--- a/solution/backend/regulations/urls.py
+++ b/solution/backend/regulations/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path, register_converter
+from django.contrib.auth import views as auth_views
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from regulations import converters
@@ -52,4 +53,5 @@ urlpatterns = [
             "get": "list",
         })),
     ])),
+    path('logout/', auth_views.LogoutView.as_view(), name='logout'),
 ]

--- a/solution/backend/regulations/urls.py
+++ b/solution/backend/regulations/urls.py
@@ -1,5 +1,5 @@
-from django.urls import include, path, register_converter
 from django.contrib.auth import views as auth_views
+from django.urls import include, path, register_converter
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from regulations import converters

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -81,6 +81,9 @@ class ReaderView(CitationContextMixin, TemplateView):
             "usc_ref_exceptions": statute_link_config.usc_ref_exceptions_dict,
         }
 
+        user = self.request.user
+        is_user_authenticated = user.is_authenticated
+
         c = {
             'tree':         tree,
             'title':        reg_title,
@@ -97,6 +100,8 @@ class ReaderView(CitationContextMixin, TemplateView):
             'resource_count': resource_count,
             'link_conversions': conversions,
             'link_config': statute_link_config,
+            'is_user_authenticated': is_user_authenticated,
+            'user': user,
         }
 
         end = datetime.now().timestamp()

--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -159,6 +159,9 @@ footer {
     border-top: 1px solid $light_gray;
     border-left: 1px solid $light_gray;
     border-top-left-radius: 10px;
+    box-shadow: 0 3px 10px 0px rgba(0, 0, 0, 0.08);
+    -webkit-box-shadow: 0 3px 10px 0px rgba(0, 0, 0, 0.08);
+    -moz-box-shadow: 0 3px 10px 0px rgba(0, 0, 0, 0.08);
 
     .span__login-lamp {
         display: inline-block;

--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -159,9 +159,9 @@ footer {
     border-top: 1px solid $light_gray;
     border-left: 1px solid $light_gray;
     border-top-left-radius: 10px;
-    box-shadow: 0 3px 10px 0px rgba(0, 0, 0, 0.08);
-    -webkit-box-shadow: 0 3px 10px 0px rgba(0, 0, 0, 0.08);
-    -moz-box-shadow: 0 3px 10px 0px rgba(0, 0, 0, 0.08);
+    box-shadow: -3px 3px 10px 0px rgba(0, 0, 0, 0.08);
+    -webkit-box-shadow: -3px 3px 10px 0px rgba(0, 0, 0, 0.08);
+    -moz-box-shadow: -3px 3px 10px 0px rgba(0, 0, 0, 0.08);
 
     .span__login-lamp {
         display: inline-block;

--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -150,6 +150,30 @@ footer {
     }
 }
 
+#loginIndicator {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    padding: 1rem 3rem 1rem 1rem;
+    background-color: $lighter_gray;
+    border-top: 1px solid $light_gray;
+    border-left: 1px solid $light_gray;
+    border-top-left-radius: 10px;
+
+    .span__login-lamp {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background-color: $teal;
+        margin-right: 0.5rem;
+
+        &--success {
+            background-color: $green;
+        }
+    }
+}
+
 .invisible {
     height: 0px !important;
     margin-top: 0px !important;

--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -174,6 +174,10 @@ footer {
         &--success {
             background-color: $green;
         }
+
+        &--error {
+            background-color: $dark-gray;
+        }
     }
 }
 

--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -176,7 +176,7 @@ footer {
         }
 
         &--error {
-            background-color: $dark-gray;
+            background-color: $mid_gray_3;
         }
     }
 }


### PR DESCRIPTION
Resolves [EREGCSC-2144](https://jiraent.cms.gov/browse/EREGCSC-2144)

**Description**

We need to shown authenticated-only content on eRegs *outside* of the admin panel.  

**This pull request changes:**

- Adds `login_indicator.html` template partial that indicates if user is logged in and provides link to log out

**Steps to manually verify this change:**

1. Go to [experimental deployment](https://v77jx88gn1.execute-api.us-east-1.amazonaws.com/dev934/)
2. Log in using the admin panel
3. Return to experimental deployment.  In the bottom right corner of the screen you should see a little sticky div that contains a green indicator and a "Hello!" Greeting that includes your username.
   - There should also be a "Log Out" link to the right of your username
5. Make sure the logged in indicator at the bottom right of the screen is visible on every page or eEregs
6. Click "Log Out".  The current page should reload and the logged in indicator should disappear.  You are logged out.  Go to the admin panel to ensure that you are logged out.

