### PR TITLE
EREGCSC-1848 -- better JS/CSS cache busting

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -119,7 +119,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          RUN_ATTEMPT=${{ github.run_attempt }} serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
+          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -119,7 +119,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
+          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} --run_attempt ${{ github.run_attempt }} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -119,7 +119,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} --run_attempt ${{ github.run_attempt }} | tee output.log
+          RUN_ATTEMPT=${{ github.run_attempt }} serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -119,7 +119,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
+          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} --param='deploy_num=${{ gitub.run_id }}' | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}

--- a/solution/backend/cmcs_regulations/context_processors.py
+++ b/solution/backend/cmcs_regulations/context_processors.py
@@ -36,3 +36,9 @@ def api_base(request):
     return {
         "API_BASE": f"{reverse('homepage')}{settings.API_BASE}"
     }
+
+
+def deploy_number(request):
+    return {
+        "DEPLOY_NUMBER": settings.DEPLOY_NUMBER
+    }

--- a/solution/backend/regulations/templates/error_base.html
+++ b/solution/backend/regulations/templates/error_base.html
@@ -20,5 +20,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -261,5 +261,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/cache.html
+++ b/solution/backend/regulations/templates/regulations/cache.html
@@ -20,5 +20,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -25,6 +25,7 @@ Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
 
 {% block body %}
 <main>
+    deply num: {{ DEPLOY_NUMBER }}
     <nav id="placeholderNav"></nav>
     <left-nav-collapse contents-description="table of contents">
         <toc-container

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -151,5 +151,5 @@ Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
 
 {% block post_footer %}
 <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-<script src="{% static '/js/eregs-main.iife.js' %}"></script>
+<script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -40,5 +40,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/regulation_landing.html
+++ b/solution/backend/regulations/templates/regulations/regulation_landing.html
@@ -35,5 +35,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/resources.html
+++ b/solution/backend/regulations/templates/regulations/resources.html
@@ -30,5 +30,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -32,5 +32,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -32,5 +32,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -30,6 +30,7 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
+    DEPLOY_NUMBER: ${param:deploy_num}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -30,6 +30,7 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
+    DEPLOY_NUMBER: ${opt:run_attempt, '0'}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -30,7 +30,6 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
-    DEPLOY_NUMBER: ${env:RUN_ATTEMPT}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -30,7 +30,7 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
-    DEPLOY_NUMBER: ${opt:run_attempt, '0'}
+    DEPLOY_NUMBER: ${env:RUN_ATTEMPT}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}


### PR DESCRIPTION
Resolves [EREGCSC-1848](https://jiraent.cms.gov/browse/EREGCSC-1848)

**Description**

We want to be able to push CSS and JS updates to the site at any time of day and have users transparently download the newest, latest CSS/JS files even if they've already visited the site that day.  This should not require any action from the user.  They should just be served the newest, freshest JS/CSS files by the browser as soon as they have been deployed.

This means the browser must be told that something has changed and that it should fetch a new copy of the CSS/JS files from the server instead of using a cached local copy.

**This pull request changes:**

- TBD

**Steps to manually verify this change:**

1. TBD

