### PR TITLE
EREGCSC-1848 -- better JS/CSS cache busting, take two

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -119,7 +119,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          RUN_ATTEMPT=${{ github.run_attempt }} serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
+          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -119,7 +119,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} --param deploy_num=${{ gitub.run_id }} | tee output.log
+          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -119,7 +119,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
+          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} --run_attempt ${{ github.run_attempt }} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -119,7 +119,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} --run_attempt ${{ github.run_attempt }} | tee output.log
+          RUN_ATTEMPT=${{ github.run_attempt }} serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -119,7 +119,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} --param='deploy_num=${{ gitub.run_id }}' | tee output.log
+          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} --param deploy_num=${{ gitub.run_id }} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -119,7 +119,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
+          serverless deploy --config ./serverless-experimental.yml --stage dev${PR} --param='deploy_num=${{ gitub.run_id }}' | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function create_su --stage dev${PR}

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -115,6 +115,7 @@ jobs:
         if: success() && steps.findPr.outputs.number
         env:
           PR: ${{ steps.findPr.outputs.pr }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           pushd solution/backend
           npm install serverless -g

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,8 @@ jobs:
           popd
       - name: deploy regulations site server
         id: deploy-regulations-site-server
+        env:
+          RUN_ID: ${{ github.run_id }}
         run: |
           pushd solution/backend
           npm install serverless -g

--- a/solution/backend/cmcs_regulations/context_processors.py
+++ b/solution/backend/cmcs_regulations/context_processors.py
@@ -36,3 +36,9 @@ def api_base(request):
     return {
         "API_BASE": f"{reverse('homepage')}{settings.API_BASE}"
     }
+
+
+def deploy_number(request):
+    return {
+        "DEPLOY_NUMBER": settings.DEPLOY_NUMBER
+    }

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -147,6 +147,7 @@ TEMPLATES = [
                 "cmcs_regulations.context_processors.google_analytics",
                 "cmcs_regulations.context_processors.custom_url",
                 "cmcs_regulations.context_processors.survey_url",
+                "cmcs_regulations.context_processors.deploy_number",
                 "cmcs_regulations.context_processors.automated_testing",
                 'cmcs_regulations.context_processors.api_base',
                 'regulations.context_processors.site_config',
@@ -216,6 +217,7 @@ SURVEY_URL = os.environ.get(
     "https://docs.google.com/forms/d/e/1FAIpQLSdcG9mfTz6Kebdni8YSacl27rIwpGy2a7GsMGO0kb_T7FSNxg/viewform?embedded=true"
 )
 
+DEPLOY_NUMBER = os.environ.get("DEPLOY_NUMBER", "0000")
 
 OPENSEARCH_DSL = {
     'default': {

--- a/solution/backend/regulations/templates/error_base.html
+++ b/solution/backend/regulations/templates/error_base.html
@@ -17,8 +17,3 @@
         <img class="error-image" src="{% static 'images/browser.svg' %}" alt=""/>
     </main>
 {% endblock %}
-
-{% block post_footer %}
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}?{% DEPLOY_NUMBER %}"></script>
-{% endblock %}

--- a/solution/backend/regulations/templates/error_base.html
+++ b/solution/backend/regulations/templates/error_base.html
@@ -20,5 +20,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/error_base.html
+++ b/solution/backend/regulations/templates/error_base.html
@@ -20,5 +20,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -261,5 +261,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -261,5 +261,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -258,8 +258,3 @@
     </main>
 </div>
 {% endblock %}
-
-{% block post_footer %}
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}?{% DEPLOY_NUMBER %}"></script>
-{% endblock %}

--- a/solution/backend/regulations/templates/regulations/base.html
+++ b/solution/backend/regulations/templates/regulations/base.html
@@ -31,7 +31,7 @@ CSS/Javascript etc., should inherit from this template.
         </title>
         {% include "regulations/partials/favicon.html" %}
         {% block spa_styles %}{% endblock %}
-        <link rel="stylesheet" href="{% static '/css/main.css' %}?{% now "Y-m-d" %}" />
+        <link rel="stylesheet" href="{% static '/css/main.css' %}?{% DEPLOY_NUMBER %}" />
     </head>
     <body class="ds-base {% block body_class %}{% endblock %}">
         <div id="vue-app">

--- a/solution/backend/regulations/templates/regulations/base.html
+++ b/solution/backend/regulations/templates/regulations/base.html
@@ -31,7 +31,7 @@ CSS/Javascript etc., should inherit from this template.
         </title>
         {% include "regulations/partials/favicon.html" %}
         {% block spa_styles %}{% endblock %}
-        <link rel="stylesheet" href="{% static '/css/main.css' %}?{% DEPLOY_NUMBER %}" />
+        <link rel="stylesheet" href="{% static '/css/main.css' %}?{{ DEPLOY_NUMBER }}" />
     </head>
     <body class="ds-base {% block body_class %}{% endblock %}">
         <div id="vue-app">
@@ -68,7 +68,10 @@ CSS/Javascript etc., should inherit from this template.
                     </footer>
                 {% endblock %}
 
-                {% block post_footer %}{% endblock %}
+                {% block post_footer %}
+                    <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
+                    <script src="{% static '/js/eregs-main.iife.js' %}?{{ DEPLOY_NUMBER }}"></script>
+                {% endblock %}
             </div>
         </div>
     </body>

--- a/solution/backend/regulations/templates/regulations/cache.html
+++ b/solution/backend/regulations/templates/regulations/cache.html
@@ -20,5 +20,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/cache.html
+++ b/solution/backend/regulations/templates/regulations/cache.html
@@ -1,4 +1,4 @@
-{% extends "regulations/base.html" %}
+{% extends "regulations/spa_base.html" %}
 
 {% load static %}
 
@@ -17,8 +17,4 @@
 {% endblock %}
 
 {% block footer %}
-{% endblock %}
-
-{% block post_footer %}
-    <script src="{% static '/vite/index.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/cache.html
+++ b/solution/backend/regulations/templates/regulations/cache.html
@@ -20,5 +20,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -25,7 +25,6 @@ Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
 
 {% block body %}
 <main>
-    deply num: {{ DEPLOY_NUMBER }}
     <nav id="placeholderNav"></nav>
     <left-nav-collapse contents-description="table of contents">
         <toc-container

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -152,5 +152,5 @@ Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
 
 {% block post_footer %}
 <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-<script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
+<script src="{% static '/js/eregs-main.iife.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -25,6 +25,7 @@ Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
 
 {% block body %}
 <main>
+    deply num: {{ DEPLOY_NUMBER }}
     <nav id="placeholderNav"></nav>
     <left-nav-collapse contents-description="table of contents">
         <toc-container

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -151,5 +151,5 @@ Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
 
 {% block post_footer %}
 <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-<script src="{% static '/js/eregs-main.iife.js' %}"></script>
+<script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -148,8 +148,3 @@ Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
 </main>
 
 {% endblock %}
-
-{% block post_footer %}
-<script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-<script src="{% static '/js/eregs-main.iife.js' %}?{% DEPLOY_NUMBER %}"></script>
-{% endblock %}

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -40,5 +40,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -40,5 +40,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/reader.html
+++ b/solution/backend/regulations/templates/regulations/reader.html
@@ -37,8 +37,3 @@
         </div>
     </div>
 {% endblock %}
-
-{% block post_footer %}
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}?{% DEPLOY_NUMBER %}"></script>
-{% endblock %}

--- a/solution/backend/regulations/templates/regulations/regulation_landing.html
+++ b/solution/backend/regulations/templates/regulations/regulation_landing.html
@@ -32,8 +32,3 @@
         {% include "regulations/partials/footer.html" %}
     </footer>
 {% endblock %}
-
-{% block post_footer %}
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}?{% DEPLOY_NUMBER %}"></script>
-{% endblock %}

--- a/solution/backend/regulations/templates/regulations/regulation_landing.html
+++ b/solution/backend/regulations/templates/regulations/regulation_landing.html
@@ -35,5 +35,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/regulation_landing.html
+++ b/solution/backend/regulations/templates/regulations/regulation_landing.html
@@ -35,5 +35,5 @@
 
 {% block post_footer %}
     <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
-    <script src="{% static '/js/eregs-main.iife.js' %}?{% now "Y-m-d" %}"></script>
+    <script src="{% static '/js/eregs-main.iife.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/resources.html
+++ b/solution/backend/regulations/templates/regulations/resources.html
@@ -30,5 +30,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/resources.html
+++ b/solution/backend/regulations/templates/regulations/resources.html
@@ -30,5 +30,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/resources.html
+++ b/solution/backend/regulations/templates/regulations/resources.html
@@ -1,4 +1,4 @@
-{% extends "regulations/base.html" %}
+{% extends "regulations/spa_base.html" %}
 
 {% load static %}
 
@@ -27,8 +27,4 @@
     data-host="{{ host }}"
     data-statutes-url="{% url 'statutes' %}"
 ></div>
-{% endblock %}
-
-{% block post_footer %}
-    <script src="{% static '/vite/index.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -32,5 +32,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -1,4 +1,4 @@
-{% extends "regulations/base.html" %}
+{% extends "regulations/spa_base.html" %}
 {% load static %}
 {% load string_formatters %}
 
@@ -29,8 +29,4 @@
     data-host="{{ host }}"
     data-statutes-url="{% url 'statutes' %}"
 ></div>
-{% endblock %}
-
-{% block post_footer %}
-    <script src="{% static '/vite/index.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -32,5 +32,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/spa_base.html
+++ b/solution/backend/regulations/templates/regulations/spa_base.html
@@ -2,6 +2,5 @@
 {% load static %}
 
 {% block post_footer %}
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
     <script src="{% static '/vite/index.js' %}?{{ DEPLOY_NUMBER }}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/spa_base.html
+++ b/solution/backend/regulations/templates/regulations/spa_base.html
@@ -1,0 +1,7 @@
+{% extends "regulations/base.html" %}
+{% load static %}
+
+{% block post_footer %}
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.7.14"></script>
+    <script src="{% static '/vite/index.js' %}?{{ DEPLOY_NUMBER }}"></script>
+{% endblock %}

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -32,5 +32,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -1,4 +1,4 @@
-{% extends "regulations/base.html" %}
+{% extends "regulations/spa_base.html" %}
 {% load static %}
 {% load string_formatters %}
 
@@ -29,8 +29,4 @@
     data-search-url="{% url 'search' %}"
     data-host="{{ host }}"
 ></div>
-{% endblock %}
-
-{% block post_footer %}
-    <script src="{% static '/vite/index.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -32,5 +32,5 @@
 {% endblock %}
 
 {% block post_footer %}
-    <script src="{% static '/vite/index.js' %}?{% now "Y-m-d" %}"></script>
+    <script src="{% static '/vite/index.js' %}?{% DEPLOY_NUMBER %}"></script>
 {% endblock %}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -30,6 +30,7 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
+    DEPLOY_NUMBER: ${param:deploy_num}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -30,7 +30,7 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
-    DEPLOY_NUMBER: ${param:deploy_num}
+    DEPLOY_NUMBER: ${env:RUN_ID}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -30,6 +30,7 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
+    DEPLOY_NUMBER: ${opt:run_attempt, '0'}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -30,7 +30,6 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
-    DEPLOY_NUMBER: ${env:RUN_ATTEMPT}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -30,7 +30,7 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
-    DEPLOY_NUMBER: ${opt:run_attempt, '0'}
+    DEPLOY_NUMBER: ${env:RUN_ATTEMPT}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -33,6 +33,7 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
+    DEPLOY_NUMBER: ${env:RUN_ID}
   tracing:
     apiGateway: true
   vpc:


### PR DESCRIPTION
Resolves [EREGCSC-1848](https://jiraent.cms.gov/browse/EREGCSC-1848)

**Description:**

We want to be able to push CSS and JS updates to the site at any time of day and have users transparently download the newest, latest CSS/JS files even if they've already visited the site that day. This should not require any action from the user. They should just be served the newest, freshest JS/CSS files by the browser as soon as they have been deployed.

This means the browser must be told that something has changed and that it should fetch a new copy of the CSS/JS files from the server instead of using a cached local copy.

We are going to grab an [artifact from the Github Action workflows called `run_id`](https://docs.github.com/en/actions/learn-github-actions/contexts#about-contexts), which is unique to each workflow:
   - `deploy-experimental.yml` for Pull Request deployments
   - `deploy.yml` for `dev`/`val`/`prod` deployments

As a result, every time the `deploy.yml` workflow is run, a new unique `run_id` will be created and used to force the browser to reload JS and CSS files.

**This pull request changes:**

- Gets `run_id`and passes it into Django deployment when Github Action is run
- uses `run_id` as [parameter to append to end of JS and CSS link/script tags in Django templates to "bust" those cached files](https://www.wkoorts.com/2009/07/12/css-auto-reload-with-django-templates/) when this parameter changes and force browser to reload the files from the server

**Steps to manually verify this change:**

1. Go to [Experimental Deployment](https://3rs9ts08we.execute-api.us-east-1.amazonaws.com/dev938), open the Network Tab in your browser's DevTools, and look at the name of the JS/CSS files being requested by the browser.  The JS/CSS files should end with a parameter that is a string of 10+ numbers. The filenames should look something like this:
   - `main.css?5939141493`
   - `eregs-main.iife.js?5939141493` (Django template used for most content) or `index.js?5939141493` (Vue Single Page App used for most content) depending on which page you're on 
2. Visit this PR's [Experimental Deployment Action's `deploy-django` step summary page on Github](https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/runs/5939141493/job/16105052416)
   - The URL should have the same `runs` number that you see appended to the JS/CSS files
3. Expand the `deploy regulations site server` step and then expand the `Run pushd solution/backend` command
4. Scroll down to `env` (around line 13) and make sure the `RUN_ID` env variable matches all the numbers mentioned in the steps above
5. Visit a few other deployment action summary pages, experimental or otherwise, and notice that the `runs` URL parameter for each PR is unique

