### PR TITLE
[Hotfix] EREGCSC-1848 -- hotfix to add github.run_id to deploy step that needs it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,8 @@ jobs:
       - name: Populate content for ${{ matrix.environment }}
         id: condtional-output-for-not-prod
         if: ${{ matrix.environment  != 'prod' }}
+        env:
+          RUN_ID: ${{ github.run_id }}
         run: |
           pushd solution/backend
           npm install serverless -g


### PR DESCRIPTION
Resolves [EREGCSC-1848](https://jiraent.cms.gov/browse/EREGCSC-1848)

**Description:**

The `dev`/`val`/`prod` `deploy.yml` file is constructed a bit differently than our `deply_experimental.yml` file.  What was all encapsulated in a single step in `deploy_experimental.yml` is spread across two steps in `deploy.yml`, but the new environment variable `RUN_ID` was only added to the first step.

**This pull request changes:**

- adds `RUN_ID` to the `env` of the "Populate Content for {{ environment }}" step

**Steps to manually verify this change:**

1. Merge this PR to main and make sure `dev`/`val`/`prod` deployments work as expected.

