### PR TITLE
[Hotfix] EREGCSC-1848 -- hotfix to add github.run_id to Remove Experimental step that needs it

### DIFF
--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -60,6 +60,7 @@ jobs:
         if: success() || failure()
         env:
           PR: ${{ github.event.number }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           pushd solution/backend
           npm install serverless -g
@@ -72,6 +73,7 @@ jobs:
       - name: remove static assets
         env:
           PR: ${{ github.event.number }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           pushd solution/static-assets
           npm install serverless -g


### PR DESCRIPTION
Resolves [EREGCSC-1848](https://jiraent.cms.gov/browse/EREGCSC-1848)

**Description:**

The `remove-experimental.yml` file needs the new environment variable RUN_ID that was recently added to the deploy `yml` files.

**This pull request changes:**

- adds `RUN_ID` to the `env` to the remove steps that need it

**Steps to manually verify this change...**

1. Make sure the `remove_experimental` step works for this PR once it has been merged to `main`
2. Note that Remove Experimental was successful when this PR was previously closed: https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/runs/5964740287


