### PR TITLE
EREGCSC-2193 API gateway configurations for file upload

### DIFF
--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -60,8 +60,6 @@ package:
 custom:
   environment: 'experimental'
   stage: ${opt:stage, self:provider.stage}
-  apiGateway:
-
   wsgi:
     app: handler.application
     packRequirements: false

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -30,7 +30,7 @@ provider:
     SIGNUP_URL: ${ssm:/eregulations/signup_url}
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
-    AWS_STORAGE_BUCKET_NAME: file-upload-${self:custom.stage}
+    AWS_STORAGE_BUCKET_NAME: file-repo-eregs-${self:custom.stage}
     DEPLOY_NUMBER: ${env:RUN_ID}
   vpc:
     securityGroupIds:
@@ -79,7 +79,7 @@ resources:
     MyS3Bucket:
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: file-upload-${self:custom.stage}
+        BucketName: file-repo-eregs-${self:custom.stage}
         BucketEncryption:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
@@ -168,7 +168,7 @@ resources:
                        - ""
                        - - "arn:aws:s3:::"
                          - "Ref" : "ServerlessDeploymentBucket"
-                     - "arn:aws:s3:::file-upload-${self:custom.stage}/*"
+                     - "arn:aws:s3:::file-repo-eregs-${self:custom.stage}/*"
 
 plugins:
   - serverless-wsgi

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -100,23 +100,6 @@ resources:
                 - GET
                 - HEAD
               MaxAge: 3000
-
-    BucketPolicy:
-      Type: AWS::S3::BucketPolicy
-      Properties:
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Action: 's3:GetObject'
-              Resource: !Join
-                - ''
-                - - 'arn:aws:s3:::'
-                  - !Ref MyS3Bucket
-                  - /*
-              Principal: "*"
-        Bucket: !Ref MyS3Bucket
-
     WAFRegionalWebACL: ${file(aws_resources/waf.yml):WAFRegionalWebACL}
     LambdaFunctionRole:
       Type: AWS::IAM::Role

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -34,7 +34,7 @@ provider:
     SEARCHGOV_KEY: ${ssm:/eregulations/searchgov/key}
     SEARCHGOV_SITE_NAME: ${ssm:/eregulations/searchgov/site_name}
     DEPLOY_NUMBER: ${env:RUN_ID}
-    AWS_STORAGE_BUCKET_NAME: file-upload-${self:custom.stage}
+    AWS_STORAGE_BUCKET_NAME: file-repo-eregs-${self:custom.stage}
   tracing:
     apiGateway: true
   vpc:
@@ -77,7 +77,7 @@ resources:
     MyS3Bucket:
       Type: AWS::S3::Bucket
       Properties:
-        BucketName: file-upload-${self:custom.stage}
+        BucketName: file-repo-eregs-${self:custom.stage}
         BucketEncryption:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
@@ -165,7 +165,7 @@ resources:
                        - ""
                        - - "arn:aws:s3:::"
                          - "Ref" : "ServerlessDeploymentBucket"
-                     - "arn:aws:s3:::file-upload-${self:custom.stage}/*"
+                     - "arn:aws:s3:::file-repo-eregs-${self:custom.stage}/*"
 
     ServerlessSecurityGroup:
       Type: AWS::EC2::SecurityGroup

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -12,6 +12,10 @@ provider:
       level: INFO
       roleManagedExternally: true
   lambdaHashingVersion: '20201221'
+  apiGateway:
+    binaryMediaTypes:
+      - 'multipart/form-data'
+      - 'application/pdf'
   environment:
     DB_NAME: ${self:custom.settings.DB_NAME}
     DB_USER: ${self:custom.settings.USERNAME}

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -98,22 +98,6 @@ resources:
                 - GET
                 - HEAD
               MaxAge: 3000
-
-    BucketPolicy:
-      Type: AWS::S3::BucketPolicy
-      Properties:
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Action: 's3:GetObject'
-              Resource: !Join
-                - ''
-                - - 'arn:aws:s3:::'
-                  - !Ref MyS3Bucket
-                  - /*
-              Principal: "*"
-        Bucket: !Ref MyS3Bucket
     WAFRegionalWebACL: ${file(aws_resources/waf.yml):WAFRegionalWebACL}
     LambdaFunctionRole:
       Type: AWS::IAM::Role


### PR DESCRIPTION
Resolves # EREGCSC-2193

**Description-**

The api gateway needs to allow media types to process in order for our file repo to work properly.  Without it the gateway will cause files to not uplaod properly.

**This pull request changes...**

- Configurations for the api gateway at deploy

**Steps to manually verify this change...**

1. The api gateway for the dev branch will have the correct settings.
2. FIle upload will allow files to upload and not be blank.