### PR TITLE
EREGCSC-2196 Seed data for file manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If adding a new model to this process please refer to the adding a new model pro
 
 1.  Connect to the VPN and run the following command below for postgresql in the command line.  Replace db_address and port_number with the database address and port number respectively.  A file called `backup.sql` should populate in the directory the command is run in.
 ```
-pg_dump -h <db_address> -p <port_number> -U eregsuser -f backup.sql -t 'search_sy*' -t 'resources_*' -t 'regulations_*' -t 'auth_g*' -t 'auth_permission' -t 'django_content_type' --data-only --column-inserts eregs
+pg_dump -h <db_address> -p <port_number> -U eregsuser -f backup.sql -t 'search_sy*' -t 'resources_*' -t 'regulations_*' -t 'file_manager_subject' -t 'file_manager_documenttype' -t 'auth_g*' -t 'auth_permission' -t 'django_content_type' --data-only --column-inserts eregs
 ```
 2. Run the command `make python.emptyseedtables`.  This will clear out many of our resources tables and the synonym table for population of the database.
 3. Run the postges script `backup.sql` produced in step 2 on your local database.  This will update your database with up to date production data. 

--- a/solution/Makefile
+++ b/solution/Makefile
@@ -195,12 +195,14 @@ local.seed:
 
 # Do not change the order of these objects.  In some cases it matters
 resource_objects = resources.abstractcategory resources.category resources.subcategory resources.abstractlocation resources.section resources.subpart resources.federalregisterdocumentgroup resources.resourcesconfiguration resources.abstractresource resources.federalregisterdocument resources.supplementalcontent
-reg_objects = regulations.siteconfiguration regulations.statutelinkconfiguration regulations.statutelinkconverter
+reg_objects = regulations.siteconfiguration regulations.statutelinkconfiguration regulations.statutelinkconverter regulations.regulationlinkconfiguration
+file_manager_objects = file_manager.subject file_manager.documenttype
 auth_objects = contenttypes.contenttype auth.permission auth.group
 
 local.dump:
 	$(foreach object, $(objects), docker-compose exec regulations python manage.py dumpdata $(object) --indent 4 > ./backend/resources/fixtures/$(object).json;) \
 	$(foreach object, $(reg_objects), docker-compose exec regulations python manage.py dumpdata $(object) --indent 4 > ./backend/regulations/fixtures/$(object).json;) \
+	$(foreach object, $(file_manager_objects), docker-compose exec regulations python manage.py dumpdata $(object) --indent 4 > ./backend/file_manager/fixtures/$(object).json;) \
 	$(foreach object, $(auth_objects), docker-compose exec regulations python manage.py dumpdata $(object) --indent 4 > ./backend/cmcs_regulations/fixtures/$(object).json;) \
 	docker-compose exec regulations python manage.py dumpdata contenttypes.contenttype --indent 4 > ./backend/cmcs_regulations/fixtures/contenttypes.contenttype.json
 	docker-compose exec regulations python manage.py dumpdata search.synonym --indent 4 > ./backend/regcore/search/fixtures/search.synonym.json 

--- a/solution/backend/cmcs_regulations/fixtures/auth.permission.json
+++ b/solution/backend/cmcs_regulations/fixtures/auth.permission.json
@@ -1510,5 +1510,149 @@
         "content_type": 167,
         "codename": "view_statutelinkconfiguration"
     }
+},
+{
+    "model": "auth.permission",
+    "pk": 240,
+    "fields": {
+        "name": "Can add Regulation Link Configuration",
+        "content_type": 168,
+        "codename": "add_regulationlinkconfiguration"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 241,
+    "fields": {
+        "name": "Can change Regulation Link Configuration",
+        "content_type": 168,
+        "codename": "change_regulationlinkconfiguration"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 242,
+    "fields": {
+        "name": "Can delete Regulation Link Configuration",
+        "content_type": 168,
+        "codename": "delete_regulationlinkconfiguration"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 243,
+    "fields": {
+        "name": "Can view Regulation Link Configuration",
+        "content_type": 168,
+        "codename": "view_regulationlinkconfiguration"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 244,
+    "fields": {
+        "name": "Can add uploaded file",
+        "content_type": 169,
+        "codename": "add_uploadedfile"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 245,
+    "fields": {
+        "name": "Can change uploaded file",
+        "content_type": 169,
+        "codename": "change_uploadedfile"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 246,
+    "fields": {
+        "name": "Can delete uploaded file",
+        "content_type": 169,
+        "codename": "delete_uploadedfile"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 247,
+    "fields": {
+        "name": "Can view uploaded file",
+        "content_type": 169,
+        "codename": "view_uploadedfile"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 248,
+    "fields": {
+        "name": "Can add subject",
+        "content_type": 170,
+        "codename": "add_subject"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 249,
+    "fields": {
+        "name": "Can change subject",
+        "content_type": 170,
+        "codename": "change_subject"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 250,
+    "fields": {
+        "name": "Can delete subject",
+        "content_type": 170,
+        "codename": "delete_subject"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 251,
+    "fields": {
+        "name": "Can view subject",
+        "content_type": 170,
+        "codename": "view_subject"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 252,
+    "fields": {
+        "name": "Can add document type",
+        "content_type": 171,
+        "codename": "add_documenttype"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 253,
+    "fields": {
+        "name": "Can change document type",
+        "content_type": 171,
+        "codename": "change_documenttype"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 254,
+    "fields": {
+        "name": "Can delete document type",
+        "content_type": 171,
+        "codename": "delete_documenttype"
+    }
+},
+{
+    "model": "auth.permission",
+    "pk": 255,
+    "fields": {
+        "name": "Can view document type",
+        "content_type": 171,
+        "codename": "view_documenttype"
+    }
 }
 ]

--- a/solution/backend/cmcs_regulations/fixtures/contenttypes.contenttype.json
+++ b/solution/backend/cmcs_regulations/fixtures/contenttypes.contenttype.json
@@ -334,5 +334,37 @@
         "app_label": "regulations",
         "model": "statutelinkconfiguration"
     }
+},
+{
+    "model": "contenttypes.contenttype",
+    "pk": 168,
+    "fields": {
+        "app_label": "regulations",
+        "model": "regulationlinkconfiguration"
+    }
+},
+{
+    "model": "contenttypes.contenttype",
+    "pk": 169,
+    "fields": {
+        "app_label": "file_manager",
+        "model": "uploadedfile"
+    }
+},
+{
+    "model": "contenttypes.contenttype",
+    "pk": 170,
+    "fields": {
+        "app_label": "file_manager",
+        "model": "subject"
+    }
+},
+{
+    "model": "contenttypes.contenttype",
+    "pk": 171,
+    "fields": {
+        "app_label": "file_manager",
+        "model": "documenttype"
+    }
 }
 ]

--- a/solution/backend/common/functions.py
+++ b/solution/backend/common/functions.py
@@ -3,8 +3,14 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 
+from file_manager.models import DocumentType, Subject
 from regcore.search.models import Synonym
-from regulations.models import SiteConfiguration, StatuteLinkConfiguration, StatuteLinkConverter
+from regulations.models import (
+    RegulationLinkConfiguration,
+    SiteConfiguration,
+    StatuteLinkConfiguration,
+    StatuteLinkConverter,
+)
 from resources.models import (
     AbstractCategory,
     AbstractLocation,
@@ -35,8 +41,11 @@ def loadSeedData():
         ("resources.federalregisterdocument.json", FederalRegisterDocument),
         ("resources.resourcesconfiguration.json", ResourcesConfiguration),
         ("search.synonym.json", Synonym),
+        ("regulations.regulationlinkconfiguration.json", RegulationLinkConfiguration),
         ("regulations.statutelinkconverter.json", StatuteLinkConverter),
         ("regulations.statutelinkconfiguration.json", StatuteLinkConfiguration),
+        ("file_manager.documenttype.json", DocumentType),
+        ("file_manager.subject.json", Subject),
         ("cmcs_regulations/fixtures/contenttypes.contenttype.json", ContentType),
         ("cmcs_regulations/fixtures/auth.permission.json", Permission),
         ("cmcs_regulations/fixtures/auth.group.json", Group),

--- a/solution/backend/file_manager/fixtures/file_manager.documenttype.json
+++ b/solution/backend/file_manager/fixtures/file_manager.documenttype.json
@@ -1,0 +1,65 @@
+[
+{
+    "model": "file_manager.documenttype",
+    "pk": 1,
+    "fields": {
+        "name": "OGC Opinions",
+        "description": "Non-public legal information, including emails",
+        "order": 2
+    }
+},
+{
+    "model": "file_manager.documenttype",
+    "pk": 2,
+    "fields": {
+        "name": "Curated Formal Guidance",
+        "description": "Collections of references and excerpts from public materials, such as State Medicaid Manual",
+        "order": 1
+    }
+},
+{
+    "model": "file_manager.documenttype",
+    "pk": 3,
+    "fields": {
+        "name": "SOPs and Checklists",
+        "description": "Internal instructional documents (emails, etc) with step-by-step guidance",
+        "order": 3
+    }
+},
+{
+    "model": "file_manager.documenttype",
+    "pk": 4,
+    "fields": {
+        "name": "Informal Guidance",
+        "description": "Useful internal emails and one-pagers",
+        "order": 2
+    }
+},
+{
+    "model": "file_manager.documenttype",
+    "pk": 5,
+    "fields": {
+        "name": "Memos to States",
+        "description": "Non-public memos, such as older ARA memos that are not posted online",
+        "order": 5
+    }
+},
+{
+    "model": "file_manager.documenttype",
+    "pk": 6,
+    "fields": {
+        "name": "Sample Language",
+        "description": "Exemplar SPAs and other model language",
+        "order": 6
+    }
+},
+{
+    "model": "file_manager.documenttype",
+    "pk": 7,
+    "fields": {
+        "name": "Training Material",
+        "description": "Presentations and other non-public training documents",
+        "order": 6
+    }
+}
+]

--- a/solution/backend/file_manager/fixtures/file_manager.subject.json
+++ b/solution/backend/file_manager/fixtures/file_manager.subject.json
@@ -1,0 +1,704 @@
+[
+{
+    "model": "file_manager.subject",
+    "pk": 1,
+    "fields": {
+        "full_name": "21st Century Cures Act",
+        "short_name": null,
+        "abbreviation": "Cures Act"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 2,
+    "fields": {
+        "full_name": "Alternative Benefit Plan",
+        "short_name": null,
+        "abbreviation": "ABP"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 3,
+    "fields": {
+        "full_name": "Access to Services",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 4,
+    "fields": {
+        "full_name": "Adult Day Health",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 5,
+    "fields": {
+        "full_name": "Ambulatory Prenatal Care",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 6,
+    "fields": {
+        "full_name": "Asthma",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 7,
+    "fields": {
+        "full_name": "Autism Spectrum Disorder",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 8,
+    "fields": {
+        "full_name": "Blood Products",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 9,
+    "fields": {
+        "full_name": "Care Coordination",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 10,
+    "fields": {
+        "full_name": "Certified Community Behavioral Health Clinics",
+        "short_name": null,
+        "abbreviation": "CCBHCs"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 11,
+    "fields": {
+        "full_name": "Certified Nurse Practitioner",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 12,
+    "fields": {
+        "full_name": "Community First Choice",
+        "short_name": null,
+        "abbreviation": "CFC"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 13,
+    "fields": {
+        "full_name": "Clinical Trials and Experimental Policy",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 14,
+    "fields": {
+        "full_name": "Clinic Services",
+        "short_name": "Clinics",
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 15,
+    "fields": {
+        "full_name": "\"Case Management and Targeted Case Management\"",
+        "short_name": null,
+        "abbreviation": "CM TCM"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 16,
+    "fields": {
+        "full_name": "Coding",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 17,
+    "fields": {
+        "full_name": "Collaborative Care Model",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 18,
+    "fields": {
+        "full_name": "Collateral Contacts",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 19,
+    "fields": {
+        "full_name": "Community Health Worker",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 20,
+    "fields": {
+        "full_name": "Comparability",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 21,
+    "fields": {
+        "full_name": "Consultations",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 22,
+    "fields": {
+        "full_name": "Contingency Management",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 23,
+    "fields": {
+        "full_name": "Comprehensive Outpatient Rehabilitation Facilities",
+        "short_name": null,
+        "abbreviation": "CORF"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 24,
+    "fields": {
+        "full_name": "Critical Access Hospital",
+        "short_name": null,
+        "abbreviation": "CAH"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 25,
+    "fields": {
+        "full_name": "Dental Services",
+        "short_name": "Dental",
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 26,
+    "fields": {
+        "full_name": "Diabetes Prevention",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 27,
+    "fields": {
+        "full_name": "Diagnostic Services",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 28,
+    "fields": {
+        "full_name": "Digital Therapeutics",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 29,
+    "fields": {
+        "full_name": "Disease Management",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 30,
+    "fields": {
+        "full_name": "Donor Milk",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 31,
+    "fields": {
+        "full_name": "Doula Services",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 32,
+    "fields": {
+        "full_name": "Electronic Monitoring",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 33,
+    "fields": {
+        "full_name": "Eligibility",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 34,
+    "fields": {
+        "full_name": "Emergency Hospital Services",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 35,
+    "fields": {
+        "full_name": "Emergency Services for Aliens",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 36,
+    "fields": {
+        "full_name": "Early and Periodic Screening, Diagnostic, and Treatment",
+        "short_name": null,
+        "abbreviation": "EPSDT"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 37,
+    "fields": {
+        "full_name": "Excluded Practitioners",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 38,
+    "fields": {
+        "full_name": "Expedited Partner Therapy",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 39,
+    "fields": {
+        "full_name": "Family Planning Services",
+        "short_name": "Family Planning",
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 40,
+    "fields": {
+        "full_name": "Federally Qualified Health Centers",
+        "short_name": null,
+        "abbreviation": "FQHC"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 41,
+    "fields": {
+        "full_name": "Fetal Alcohol Syndrome",
+        "short_name": null,
+        "abbreviation": "FAS"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 42,
+    "fields": {
+        "full_name": "Foster Care",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 43,
+    "fields": {
+        "full_name": "Free Care",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 44,
+    "fields": {
+        "full_name": "Free Choice of Providers",
+        "short_name": "Freedom of Choice",
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 45,
+    "fields": {
+        "full_name": "Freestanding Birth Centers",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 46,
+    "fields": {
+        "full_name": "Gender Affirming Care",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 47,
+    "fields": {
+        "full_name": "Habilitative Services",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 48,
+    "fields": {
+        "full_name": "Healthcare Common Procedure Coding System",
+        "short_name": null,
+        "abbreviation": "HCPCS"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 49,
+    "fields": {
+        "full_name": "Health Homes for Enrollees with Chronic Conditions",
+        "short_name": "Health Homes",
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 50,
+    "fields": {
+        "full_name": "Home Visiting Services",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 51,
+    "fields": {
+        "full_name": "Homelessness Housing",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 52,
+    "fields": {
+        "full_name": "Hospice",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 53,
+    "fields": {
+        "full_name": "Intermediate Care Facilities for Individuals with Intellectual Disabilities",
+        "short_name": null,
+        "abbreviation": "ICF IID"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 54,
+    "fields": {
+        "full_name": "Institutions for Mental Disease",
+        "short_name": null,
+        "abbreviation": "IMD"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 55,
+    "fields": {
+        "full_name": "Inmates",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 56,
+    "fields": {
+        "full_name": "Inpatient Hospital Services",
+        "short_name": "Inpatient Hospital",
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 57,
+    "fields": {
+        "full_name": "Integrated Care Model",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 58,
+    "fields": {
+        "full_name": "Interpreter-Translation Services",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 59,
+    "fields": {
+        "full_name": "Laboratory and X-ray Services",
+        "short_name": "Lab & X-Ray",
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 60,
+    "fields": {
+        "full_name": "Lactation Consultant",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 61,
+    "fields": {
+        "full_name": "Long-Term Services and Supports",
+        "short_name": null,
+        "abbreviation": "LTSS"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 62,
+    "fields": {
+        "full_name": "MACPro User Group",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 63,
+    "fields": {
+        "full_name": "Managed Care",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 64,
+    "fields": {
+        "full_name": "Maternal Depression",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 65,
+    "fields": {
+        "full_name": "Medical Marijuana",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 66,
+    "fields": {
+        "full_name": "Medical Necessity",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 67,
+    "fields": {
+        "full_name": "Medication Assisted Treatment",
+        "short_name": null,
+        "abbreviation": "MAT"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 68,
+    "fields": {
+        "full_name": "Minimum Essential Coverage",
+        "short_name": null,
+        "abbreviation": "MEC"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 69,
+    "fields": {
+        "full_name": "Missed Appointments",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 70,
+    "fields": {
+        "full_name": "Mobile Crisis",
+        "short_name": "Mobile Crisis Services",
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 71,
+    "fields": {
+        "full_name": "Neonatal Abstinence Syndrome",
+        "short_name": null,
+        "abbreviation": "NAS"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 72,
+    "fields": {
+        "full_name": "National Correct Coding Initiative",
+        "short_name": null,
+        "abbreviation": "NCCI"
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 73,
+    "fields": {
+        "full_name": "Non-Discrimination",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 74,
+    "fields": {
+        "full_name": "Non-Opioid Pain Management",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 75,
+    "fields": {
+        "full_name": "Notices",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 76,
+    "fields": {
+        "full_name": "Nurse Advice Lines",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 77,
+    "fields": {
+        "full_name": "Nutrition",
+        "short_name": null,
+        "abbreviation": null
+    }
+},
+{
+    "model": "file_manager.subject",
+    "pk": 78,
+    "fields": {
+        "full_name": "Omnibus Budget Reconciliation Act of 1989",
+        "short_name": "OBRA 89",
+        "abbreviation": null
+    }
+}
+]

--- a/solution/backend/regcore/management/commands/emptyseedtables.py
+++ b/solution/backend/regcore/management/commands/emptyseedtables.py
@@ -3,8 +3,14 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 
+from file_manager.models import DocumentType, Subject
 from regcore.search.models import Synonym
-from regulations.models import SiteConfiguration, StatuteLinkConfiguration, StatuteLinkConverter
+from regulations.models import (
+    RegulationLinkConfiguration,
+    SiteConfiguration,
+    StatuteLinkConfiguration,
+    StatuteLinkConverter,
+)
 from resources.models import (
     AbstractCategory,
     AbstractLocation,
@@ -28,4 +34,7 @@ class Command(BaseCommand):
         Group.objects.all().delete()
         Permission.objects.all().delete()
         ContentType.objects.all().delete()
+        RegulationLinkConfiguration.objects.all().delete()
         SiteConfiguration.objects.all().delete()
+        Subject.objects.all().delete()
+        DocumentType.objects.all().delete()

--- a/solution/backend/regcore/search/fixtures/search.synonym.json
+++ b/solution/backend/regcore/search/fixtures/search.synonym.json
@@ -20,10 +20,10 @@
         "isActive": true,
         "baseWord": "MMIS",
         "synonyms": [
-            75,
             3,
             4,
-            5
+            5,
+            75
         ]
     }
 },
@@ -34,10 +34,10 @@
         "isActive": true,
         "baseWord": "Medicaid Management Information System",
         "synonyms": [
-            75,
             2,
             4,
-            5
+            5,
+            75
         ]
     }
 },
@@ -48,10 +48,10 @@
         "isActive": true,
         "baseWord": "Mechanized claims processing and information retrieval system",
         "synonyms": [
-            75,
             2,
             3,
-            5
+            5,
+            75
         ]
     }
 },
@@ -62,10 +62,10 @@
         "isActive": false,
         "baseWord": "MCPIRS",
         "synonyms": [
-            75,
             2,
             3,
-            4
+            4,
+            75
         ]
     }
 },
@@ -76,8 +76,8 @@
         "isActive": true,
         "baseWord": "APD",
         "synonyms": [
-            53,
-            7
+            7,
+            53
         ]
     }
 },
@@ -88,8 +88,8 @@
         "isActive": false,
         "baseWord": "Advanced Planning Document",
         "synonyms": [
-            53,
-            6
+            6,
+            53
         ]
     }
 },
@@ -100,10 +100,10 @@
         "isActive": true,
         "baseWord": "T-MSIS",
         "synonyms": [
+            9,
             54,
             55,
-            56,
-            9
+            56
         ]
     }
 },
@@ -114,10 +114,10 @@
         "isActive": true,
         "baseWord": "Transformed Medicaid Statistical Information System",
         "synonyms": [
+            8,
             54,
             55,
-            56,
-            8
+            56
         ]
     }
 },
@@ -128,9 +128,9 @@
         "isActive": false,
         "baseWord": "PASRR",
         "synonyms": [
+            11,
             57,
-            67,
-            11
+            67
         ]
     }
 },
@@ -141,9 +141,9 @@
         "isActive": true,
         "baseWord": "Preadmission Screening and Resident Review",
         "synonyms": [
+            10,
             57,
-            67,
-            10
+            67
         ]
     }
 },
@@ -238,10 +238,10 @@
         "isActive": true,
         "baseWord": "Post-Eligibility Treatment of Income",
         "synonyms": [
+            1,
             20,
             21,
-            22,
-            1
+            22
         ]
     }
 },
@@ -252,10 +252,10 @@
         "isActive": true,
         "baseWord": "Post-Eligibility Financial Requirements",
         "synonyms": [
+            1,
             19,
             21,
-            22,
-            1
+            22
         ]
     }
 },
@@ -266,10 +266,10 @@
         "isActive": true,
         "baseWord": "Application of patient income to the cost of care",
         "synonyms": [
+            1,
             19,
             20,
-            22,
-            1
+            22
         ]
     }
 },
@@ -280,10 +280,10 @@
         "isActive": true,
         "baseWord": "Personal Needs Allowance",
         "synonyms": [
+            1,
             19,
             20,
-            21,
-            1
+            21
         ]
     }
 },
@@ -654,10 +654,10 @@
         "isActive": true,
         "baseWord": "TMSIS",
         "synonyms": [
-            55,
-            56,
             8,
-            9
+            9,
+            55,
+            56
         ]
     }
 },
@@ -668,10 +668,10 @@
         "isActive": true,
         "baseWord": "Medicaid Statistical Information System",
         "synonyms": [
-            54,
-            56,
             8,
-            9
+            9,
+            54,
+            56
         ]
     }
 },
@@ -682,10 +682,10 @@
         "isActive": true,
         "baseWord": "MSIS",
         "synonyms": [
-            54,
-            55,
             8,
-            9
+            9,
+            54,
+            55
         ]
     }
 },
@@ -696,9 +696,9 @@
         "isActive": true,
         "baseWord": "PASARR",
         "synonyms": [
-            67,
             10,
-            11
+            11,
+            67
         ]
     }
 },
@@ -800,9 +800,9 @@
         "isActive": true,
         "baseWord": "Preadmission Screening and Annual Resident Review",
         "synonyms": [
-            57,
             10,
-            11
+            11,
+            57
         ]
     }
 },
@@ -1251,6 +1251,7 @@
             531,
             533,
             534,
+            535,
             536
         ]
     }
@@ -1266,6 +1267,7 @@
             531,
             533,
             534,
+            535,
             536
         ]
     }
@@ -3920,7 +3922,8 @@
         "isActive": true,
         "baseWord": "Families First Coronavirus Response Act",
         "synonyms": [
-            390
+            390,
+            535
         ]
     }
 },
@@ -4316,7 +4319,9 @@
     "fields": {
         "isActive": true,
         "baseWord": "HCERA",
-        "synonyms": []
+        "synonyms": [
+            429
+        ]
     }
 },
 {
@@ -4325,7 +4330,9 @@
     "fields": {
         "isActive": true,
         "baseWord": "Health Care and Education Reconciliation Act",
-        "synonyms": []
+        "synonyms": [
+            428
+        ]
     }
 },
 {
@@ -4334,7 +4341,9 @@
     "fields": {
         "isActive": true,
         "baseWord": "HCFA",
-        "synonyms": []
+        "synonyms": [
+            431
+        ]
     }
 },
 {
@@ -4343,7 +4352,9 @@
     "fields": {
         "isActive": true,
         "baseWord": "Health Care Financing Administration",
-        "synonyms": []
+        "synonyms": [
+            430
+        ]
     }
 },
 {
@@ -4352,7 +4363,9 @@
     "fields": {
         "isActive": true,
         "baseWord": "HCFAC",
-        "synonyms": []
+        "synonyms": [
+            433
+        ]
     }
 },
 {
@@ -4361,7 +4374,9 @@
     "fields": {
         "isActive": true,
         "baseWord": "Health Care Fraud and Abuse Control Program",
-        "synonyms": []
+        "synonyms": [
+            432
+        ]
     }
 },
 {
@@ -4370,7 +4385,9 @@
     "fields": {
         "isActive": true,
         "baseWord": "HCPCS",
-        "synonyms": []
+        "synonyms": [
+            435
+        ]
     }
 },
 {
@@ -4379,7 +4396,9 @@
     "fields": {
         "isActive": true,
         "baseWord": "Health Care Common Procedure Coding System",
-        "synonyms": []
+        "synonyms": [
+            434
+        ]
     }
 },
 {
@@ -5070,6 +5089,7 @@
             531,
             533,
             534,
+            535,
             536
         ]
     }
@@ -5083,7 +5103,8 @@
         "synonyms": [
             510,
             533,
-            534
+            534,
+            535
         ]
     }
 },
@@ -5163,7 +5184,8 @@
             523,
             531,
             533,
-            534
+            534,
+            535
         ]
     }
 },
@@ -5198,6 +5220,7 @@
         "baseWord": "Consolidated Appropriations Act of 2023",
         "synonyms": [
             528,
+            535,
             536
         ]
     }
@@ -5210,6 +5233,7 @@
         "baseWord": "CAA",
         "synonyms": [
             527,
+            535,
             536
         ]
     }
@@ -5246,7 +5270,8 @@
             140,
             141,
             510,
-            524
+            524,
+            535
         ]
     }
 },
@@ -5286,7 +5311,17 @@
     "fields": {
         "isActive": false,
         "baseWord": "Returning to Regular Operations after COVID-19",
-        "synonyms": []
+        "synonyms": [
+            140,
+            141,
+            391,
+            510,
+            511,
+            524,
+            527,
+            528,
+            531
+        ]
     }
 },
 {
@@ -5638,7 +5673,6 @@
             677,
             678,
             679,
-            680,
             681,
             695
         ]
@@ -5654,7 +5688,6 @@
             676,
             678,
             679,
-            680,
             681,
             695
         ]
@@ -5670,7 +5703,6 @@
             676,
             677,
             679,
-            680,
             681,
             695
         ]
@@ -5686,23 +5718,6 @@
             676,
             677,
             678,
-            680,
-            681,
-            695
-        ]
-    }
-},
-{
-    "model": "search.synonym",
-    "pk": 680,
-    "fields": {
-        "isActive": true,
-        "baseWord": "institution for mental diseases (IMD) exclusion",
-        "synonyms": [
-            676,
-            677,
-            678,
-            679,
             681,
             695
         ]
@@ -5719,7 +5734,6 @@
             677,
             678,
             679,
-            680,
             695
         ]
     }
@@ -5888,7 +5902,6 @@
             677,
             678,
             679,
-            680,
             681,
             682
         ]
@@ -6148,6 +6161,37 @@
             714,
             715
         ]
+    }
+},
+{
+    "model": "search.synonym",
+    "pk": 717,
+    "fields": {
+        "isActive": true,
+        "baseWord": "electronic service",
+        "synonyms": [
+            718
+        ]
+    }
+},
+{
+    "model": "search.synonym",
+    "pk": 718,
+    "fields": {
+        "isActive": true,
+        "baseWord": "Federal Data Services Hub",
+        "synonyms": [
+            717
+        ]
+    }
+},
+{
+    "model": "search.synonym",
+    "pk": 719,
+    "fields": {
+        "isActive": true,
+        "baseWord": "low-income childless adults",
+        "synonyms": []
     }
 }
 ]

--- a/solution/backend/regulations/fixtures/regulations.regulationlinkconfiguration.json
+++ b/solution/backend/regulations/fixtures/regulations.regulationlinkconfiguration.json
@@ -1,0 +1,11 @@
+[
+{
+    "model": "regulations.regulationlinkconfiguration",
+    "pk": 1,
+    "fields": {
+        "link_to_ecfr": true,
+        "link_cfr_refs": true,
+        "cfr_ref_exceptions": []
+    }
+}
+]

--- a/solution/backend/regulations/fixtures/regulations.statutelinkconfiguration.json
+++ b/solution/backend/regulations/fixtures/regulations.statutelinkconfiguration.json
@@ -5,8 +5,134 @@
     "fields": {
         "link_statute_refs": true,
         "link_usc_refs": true,
-        "statute_ref_exceptions": [],
-        "usc_ref_exceptions": []
+        "statute_ref_exceptions": [
+            {
+                "act": "Social Security Act",
+                "section": "1903(a)(29)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1905(1)(2)(B)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1902(a)(10)(i)(IV)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1902(a)(10)(ii)(XVIII)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1923(c)(l)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1903(g)(1)(A)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1903(g)(1)(B)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1903(g)(1)(C)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1903(g)(1)(D)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1886(c)(5)(F)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1902(a)(10)(i)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1902(a)(26)(A)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1902(a)(31)(A)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1902(a)(29)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1915(i)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1915(i)(1)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1915(i)(1)(f)"
+            },
+            {
+                "act": "Social Security Act",
+                "section": "1919(f)(3)"
+            }
+        ],
+        "usc_ref_exceptions": [
+            {
+                "title": "41",
+                "section": "1320a-7b(b)"
+            },
+            {
+                "title": "25",
+                "section": "1603(12)"
+            },
+            {
+                "title": "8",
+                "section": "1101(a)(22)"
+            },
+            {
+                "title": "25",
+                "section": "450b(l)"
+            },
+            {
+                "title": "25",
+                "section": "450b(e)"
+            },
+            {
+                "title": "25",
+                "section": "1603(12)"
+            },
+            {
+                "title": "10",
+                "section": "2324(e)"
+            },
+            {
+                "title": "10",
+                "section": "2324(e)(1)(P)"
+            },
+            {
+                "title": "5",
+                "section": "5701-11"
+            },
+            {
+                "title": "41",
+                "section": "423"
+            },
+            {
+                "title": "34",
+                "section": "200-212"
+            },
+            {
+                "title": "41",
+                "section": "417b"
+            },
+            {
+                "title": "31",
+                "section": "6301-08"
+            }
+        ]
     }
 }
 ]


### PR DESCRIPTION
Resolves # EREGCSC-2196

**Description-**

Sets up seed data for  subjects and document types for file uploads
**This pull request changes...**

- Seed data will populate for these in our basic seed commands as well as our environments.

**Steps to manually verify this change...**

1. steps to view and verify change
Make sure your database is up to date in main and run "make local.seed"
Log into the admin panel, you should see document types and subjects populated.
On the environment you should see the same.
