### PR TITLE
EREGCSC-2217 - Buckets use SSL

### DIFF
--- a/solution/backend/file_manager/admin.py
+++ b/solution/backend/file_manager/admin.py
@@ -84,7 +84,7 @@ class UploadedFileAdmin(BaseAdmin):
     def download_file(self, obj):
         if obj.id:
             link = reverse("file-download", kwargs={"file_id": obj.uid})
-            html = '<input type="button" onclick="location.href=\'{}\'" value="Doswnload File" />'.format(link)
+            html = '<input type="button" onclick="location.href=\'{}\'" value="Download File" />'.format(link)
         else:
             return "N/A"
         return format_html(html)

--- a/solution/backend/file_manager/admin.py
+++ b/solution/backend/file_manager/admin.py
@@ -84,7 +84,7 @@ class UploadedFileAdmin(BaseAdmin):
     def download_file(self, obj):
         if obj.id:
             link = reverse("file-download", kwargs={"file_id": obj.uid})
-            html = '<input type="button" onclick="location.href=\'{}\'" value="Download File" />'.format(link)
+            html = '<input type="button" onclick="location.href=\'{}\'" value="Doswnload File" />'.format(link)
         else:
             return "N/A"
         return format_html(html)

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -137,6 +137,22 @@ resources:
         ManagedPolicyArns:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         Policies:
+          - PolicyName: StorageBucketPolicy
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Deny
+                  Principal: "*"
+                  Action: "*"
+                  Condition:
+                    Bool:
+                      "aws:SecureTransport": false
+                  Resource:
+                    - Fn::Join:
+                      - ""
+                      - - "arn:aws:s3:::"
+                        - "Ref" : "ServerlessDeploymentBucket"
+                    - "arn:aws:s3:::file-repo-eregs-${self:custom.stage}/*"
           - PolicyName: LambdaPolicy
             PolicyDocument:
               Version: '2012-10-17'

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -142,7 +142,6 @@ resources:
               Version: '2012-10-17'
               Statement:
                 - Effect: Deny
-                  Principal: "*"
                   Action: "*"
                   Condition:
                     Bool:

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -134,6 +134,21 @@ resources:
         ManagedPolicyArns:
           - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
         Policies:
+          - PolicyName: StorageBucketPolicy
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Deny
+                  Action: "*"
+                  Condition:
+                    Bool:
+                      "aws:SecureTransport": false
+                   Resource:
+                     - Fn::Join:
+                       - ""
+                       - - "arn:aws:s3:::"
+                         - "Ref" : "ServerlessDeploymentBucket"
+                     - "arn:aws:s3:::file-repo-eregs-${self:custom.stage}/*"
           - PolicyName: LambdaPolicy
             PolicyDocument:
               Version: '2012-10-17'


### PR DESCRIPTION
Resolves # EREGCSC-2217

**Description-**

Security scan issue on our S3 bucket due to it not requiring SSL.   This merely adds it.

**This pull request changes...**

- SSL is required for accessing the bucket

**Steps to manually verify this change...**

1. Bucket upload works successfully as well as retrieval.  Upload and download a doucment.  Full verification wont be done until it hits prod.
2.  Bucket was first created with the ticket without SSL.  Item was uploaded.  Then SSL was added.  Item was still accessible.  This test was done to make sure it wouldnt rewrite the existing bucket.
