### PR TITLE
EREGCSC-1562 - Slack notifications for Snyk scan & Sync Security Hub and Jira

### DIFF
--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -36,3 +36,7 @@ jobs:
           aws-severities: CRITICAL, HIGH, MEDIUM
           #assign-jira-ticket-to: VU6Q
           #auto-close: false
+      - name: Alert Slack On Failure
+          if: failure()
+          run: |
+            curl -X POST -H 'Content-type: application/json' --data '{"text": "Failure completing Syncing Security Hub and Jira.","blocks":[{"type": "section","text":{"type": "mrkdwn","text": "The nightly scheduled Job: https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/runs/${{ github.run_id  }} to Sync Security Hub and Jira has failed to complete successfully "}}]}' ${{ secrets.DEV_BOTS_SLACK_WEBHOOK }}

--- a/.github/workflows/snyk-test.yml
+++ b/.github/workflows/snyk-test.yml
@@ -56,4 +56,9 @@ jobs:
               #assign-jira-ticket-to: ''
               scan-output-path: 'snyk_output.txt'
               scan-type: 'snyk'
+              
+        - name: Alert Slack On Failure
+          if: failure()
+          run: |
+            curl -X POST -H 'Content-type: application/json' --data '{"text": "Failure completing scheduled Snyk Scan.","blocks":[{"type": "section","text":{"type": "mrkdwn","text": "The nightly scheduled Snyk Scan for Job: https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/runs/${{ github.run_id  }} has failed to complete successfully "}}]}' ${{ secrets.DEV_BOTS_SLACK_WEBHOOK }}
     


### PR DESCRIPTION
Added Slack notification for security scan job failure 

Description-

Added a slack notification step to allow notification to be sent to shared-eregs-dev-bots channel  for both nightly snyk security scan and Sync Security Hub and Jira workflows  

This pull request adds 
Alert Slack On Failure step for both workflow

steps to manually verify this change
In this GitHub repo under .github/workflows/snyk-test.yml and .github/workflows/schedule-jira-sync.yml
comment one of the fields in the steps i.e jira-host: ${{secrets.JIRA_HOST}}
Specifically, the workflow to trigger when there is a push
on:
  push:
    branches: [ branchName ]
save the yaml file, that should trigger workflow to run 

save the file

