### PR TITLE
EREGCSC-2296 -- "Sign up for session" link fix

### DIFF
--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -142,6 +142,7 @@ TEMPLATES = [
                 "cmcs_regulations.context_processors.google_analytics",
                 "cmcs_regulations.context_processors.custom_url",
                 "cmcs_regulations.context_processors.survey_url",
+                "cmcs_regulations.context_processors.signup_url",
                 "cmcs_regulations.context_processors.deploy_number",
                 "cmcs_regulations.context_processors.automated_testing",
                 'cmcs_regulations.context_processors.api_base',
@@ -211,6 +212,10 @@ CUSTOM_URL = os.environ.get("CUSTOM_URL")
 SURVEY_URL = os.environ.get(
     "SURVEY_URL",
     "https://docs.google.com/forms/d/e/1FAIpQLSdcG9mfTz6Kebdni8YSacl27rIwpGy2a7GsMGO0kb_T7FSNxg/viewform?embedded=true"
+)
+SIGNUP_URL = os.environ.get(
+    "SIGNUP_URL",
+    "https://public.govdelivery.com/accounts/USCMS/subscriber/new?topic_id=USCMS_124"
 )
 
 DEPLOY_NUMBER = os.environ.get("DEPLOY_NUMBER", datetime.now())

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -215,7 +215,7 @@ SURVEY_URL = os.environ.get(
 )
 SIGNUP_URL = os.environ.get(
     "SIGNUP_URL",
-    "https://public.govdelivery.com/accounts/USCMS/subscriber/new?topic_id=USCMS_124"
+    "https://docs.google.com/forms/d/e/1FAIpQLSdcG9mfTz6Kebdni8YSacl27rIwpGy2a7GsMGO0kb_T7FSNxg/viewform?embedded=true"
 )
 
 DEPLOY_NUMBER = os.environ.get("DEPLOY_NUMBER", datetime.now())

--- a/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
@@ -383,4 +383,22 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
         cy.viewport("iphone-x");
         cy.get("nav#leftNav").should("have.attr", "class", "open");
     });
+
+    it("takes you to a google doc when you click the 'Contact the Team' link", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/");
+        cy.get(".contact__column a")
+            .scrollIntoView()
+            .should("have.attr", "href")
+            .and("include", "https://docs.google.com");
+    });
+
+    it("takes you to a google doc when you click the 'Sign up for a session' link", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/");
+        cy.get(".signup__column a")
+            .scrollIntoView()
+            .should("have.attr", "href")
+            .and("include", "https://docs.google.com");
+    });
 });


### PR DESCRIPTION
Resolves [EREGCSC-2296](https://jiraent.cms.gov/browse/EREGCSC-2296)

**Description:**

The "sign up for a session" link in the homepage footer goes to the homepage.  It should go out to a signup google doc.

**This pull request changes:**

- Adds `SIGNUP_URL` back to `base.py`.

**Steps to manually verify this change:**

1. Visit the [experimental deployment](https://y1wso3q2b2.execute-api.us-east-1.amazonaws.com/dev985)
2. The "Sign up for a session" link on the homepage takes you to a google doc and does not refresh the eregs homepage.

