### PR TITLE
hotfix - Dev seed data issue

### DIFF
--- a/solution/backend/common/functions.py
+++ b/solution/backend/common/functions.py
@@ -46,9 +46,9 @@ def loadSeedData():
         ("regulations.statutelinkconfiguration.json", StatuteLinkConfiguration),
         ("file_manager.documenttype.json", DocumentType),
         ("file_manager.subject.json", Subject),
-        ("cmcs_regulations/fixtures/contenttypes.contenttype.json", ContentType),
-        ("cmcs_regulations/fixtures/auth.permission.json", Permission),
-        ("cmcs_regulations/fixtures/auth.group.json", Group),
+        # ("cmcs_regulations/fixtures/contenttypes.contenttype.json", ContentType),
+        # ("cmcs_regulations/fixtures/auth.permission.json", Permission),
+        # ("cmcs_regulations/fixtures/auth.group.json", Group),
     ]
 
     for fixture in reversed(fixtures):

--- a/solution/backend/common/functions.py
+++ b/solution/backend/common/functions.py
@@ -1,6 +1,4 @@
 
-from django.contrib.auth.models import Group, Permission
-from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 
 from file_manager.models import DocumentType, Subject


### PR DESCRIPTION
Resolves # hotfix

**Description-**

Dev seed data seems to have some conflictions with content type IDs which we use for admin  purposes.  This is preventing those possibly troublesome tables from being imported.

**This pull request changes...**

- Seed data for contenttypes and permissions will no longer be seeded.


