### PR TITLE
EREGCSC-1562 - Fixed the indentation on Slack integration step

### DIFF
--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -37,6 +37,6 @@ jobs:
           #assign-jira-ticket-to: VU6Q
           #auto-close: false
       - name: Alert Slack On Failure
-          if: failure()
-          run: |
-            curl -X POST -H 'Content-type: application/json' --data '{"text": "Failure completing Syncing Security Hub and Jira.","blocks":[{"type": "section","text":{"type": "mrkdwn","text": "The nightly scheduled Job: https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/runs/${{ github.run_id  }} to Sync Security Hub and Jira has failed to complete successfully "}}]}' ${{ secrets.DEV_BOTS_SLACK_WEBHOOK }}
+        if: failure()
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data '{"text": "Failure completing Syncing Security Hub and Jira.","blocks":[{"type": "section","text":{"type": "mrkdwn","text": "The nightly scheduled Job: https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/runs/${{ github.run_id  }} to Sync Security Hub and Jira has failed to complete successfully "}}]}' ${{ secrets.DEV_BOTS_SLACK_WEBHOOK }}


### PR DESCRIPTION
Followup to PR #972 to resolve [EREGCSC-1562](https://jiraent.cms.gov/browse/EREGCSC-1562)

**Description**

Fixed the indentation that was creating an error and failing the Slack notification step in Sync Security Hub and Jira workflows.

**This pull request adds**

Corrected syntax

**Steps to manually verify this change**

Verify line 40-42 indentation is correct.

See also the manual verification steps from PR #972.