### PR TITLE
EREGCSC-update-allowed-hosts

### DIFF
--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -25,7 +25,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get("SECRET_KEY", 'django-insecure-u!&%t$qxa23zn1f*-+4pngd(p=nl_m3()+v839+fa=06y9(*)n')
 
 
-ALLOWED_HOSTS = [os.environ.get('ALLOWED_HOST'), 'localhost', 'regulations-pilot.cms.gov']
+ALLOWED_HOSTS = [os.environ.get('ALLOWED_HOST'), 'localhost', 'regulations-pilot.cms.gov', 'eregultions.cms.gov']
 
 # Application definition
 


### PR DESCRIPTION
Resolves #[EREGCSC-2257](https://jiraent.cms.gov/browse/EREGCSC-2257)

**Description-**
We recently introduced a new domain, 'eregulations.cms.gov,' into our system and configured our API Gateway to accommodate it. However, we encountered an error in our AWS logs that reads: "ERROR Invalid HTTP_HOST header: 'eregulations.cms.gov.' The resolution to this issue involves adding 'eregulations.cms.gov' to the list of allowed hosts in our Django settings file, which, in our case, is 'base.py.' This adjustment will enable our application to properly handle requests from the 'eregulations.cms.gov' domain.

**This pull request changes...**
- base.py

**Steps to manually verify this change...**
This may not be easy to verify if it fixes the issue till we push to prod. But we should check make sure it does not impact the current behavior. Recommend to visit experimental link, click around ensure the site is up and running. 

All tests should pass.


