### PR TITLE
[HOTFIX]  Policy Result citation link fix

### DIFF
--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -113,6 +113,14 @@ describe("Policy Repository", () => {
         });
         cy.get(`button[data-testid=remove-subject-1]`).should("exist");
         cy.get(`button[data-testid=remove-subject-2]`).should("exist");
+        cy.get(".related-sections")
+            .first()
+            .find(".related-section-link")
+            .first()
+            .find("a")
+            .should("have.attr", "href")
+            .and("not.include", "undefined")
+            .and("include", "/42/430/5#430-5");
         cy.checkAccessibility();
     });
 

--- a/solution/ui/e2e/cypress/fixtures/policy-docs.json
+++ b/solution/ui/e2e/cypress/fixtures/policy-docs.json
@@ -6,19 +6,20 @@
         "summary": "This is a test of the ABP broadcasting system",
         "locations": [
             {
-                "id": 1359,
+                "id": 959,
                 "title": 42,
-                "part": 400,
+                "part": 430,
                 "type": "section",
-                "section_id": 203,
-                "parent": 1356
+                "section_id": 5,
+                "parent": 955
             },
             {
-                "id": 1355,
+                "id": 850,
                 "title": 42,
-                "part": 400,
-                "type": "subpart",
-                "subpart_id": "A"
+                "part": 430,
+                "type": "section",
+                "section_id": 10,
+                "parent": 960
             }
         ],
         "document_type": {

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -21,6 +21,7 @@ const props = defineProps({
 });
 
 const apiUrl = inject("apiUrl");
+const base = inject("base");
 
 const getDownloadUrl = (uid) => `${apiUrl}file-manager/files/${uid}`;
 </script>
@@ -74,6 +75,7 @@ const getDownloadUrl = (uid) => `${apiUrl}file-manager/files/${uid}`;
             </template>
             <template #sections>
                 <RelatedSections
+                    :base="base"
                     :item="doc"
                     :parts-last-updated="partsLastUpdated"
                     label="Related Regulation Citation"


### PR DESCRIPTION
Resolves bug where Policy Repository result item does not properly link to the regulation section

**Description:**

When the Results Item was refactored a few stories ago, changes were made to how the `baseUrl` for API calls is injected into the appropriate components.  

Previously, `base` was provided in the `PolicyRepository.vue` view and injected directly into the `RelatedSections.vue` component.

Now, `RelatedSections.vue` and all of the `ResultItem`'s child components are controlled components that only accept passed in props from a parent.  Injected parameters (via provide/inject) are injected to the closest "container" ancestor and then passed in to the controlled child components.

**This pull request changes:**

- Injects `base` where needed
- Passes `base` into `RelatedSections.vue` as a prop

**Steps to manually verify this change:**

1. New Cypress test passes
2. Open [experimental deployment](https://7mwziby21b.execute-api.us-east-1.amazonaws.com/dev999) and make sure Related Sections links work for Policy Repo, Search, and Resources results items.

