### PR TITLE
EREGCSC-2295 Add sort count to subjects

### DIFF
--- a/solution/backend/file_manager/serializers.py
+++ b/solution/backend/file_manager/serializers.py
@@ -20,14 +20,19 @@ class SubjectSerializer(serializers.Serializer):
     full_name = serializers.CharField()
     short_name = serializers.CharField()
     abbreviation = serializers.CharField()
-    uploads = serializers.SerializerMethodField()
-    external_resources = serializers.SerializerMethodField()
 
-    def get_uploads(self, obj):
-        return obj.uploads.count()
 
-    def get_external_resources(self, obj):
-        return obj.resources.count()
+class SubjectDetailsSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    full_name = serializers.CharField()
+    short_name = serializers.CharField()
+    abbreviation = serializers.CharField()
+    content = serializers.SerializerMethodField()
+    internal_content = serializers.IntegerField()
+    external_content = serializers.IntegerField()
+
+    def get_content(self, obj):
+        return obj.content.count()
 
     class Meta:
         model = Subject

--- a/solution/backend/file_manager/serializers.py
+++ b/solution/backend/file_manager/serializers.py
@@ -20,6 +20,14 @@ class SubjectSerializer(serializers.Serializer):
     full_name = serializers.CharField()
     short_name = serializers.CharField()
     abbreviation = serializers.CharField()
+    uploads = serializers.SerializerMethodField()
+    external_resources = serializers.SerializerMethodField()
+
+    def get_uploads(self, obj):
+        return obj.uploads.count()
+
+    def get_external_resources(self, obj):
+        return obj.resources.count()
 
     class Meta:
         model = Subject

--- a/solution/backend/file_manager/tests/fixtures/sample_supplemental.json
+++ b/solution/backend/file_manager/tests/fixtures/sample_supplemental.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "Test Supplemental 1",
+        "url": "www.test.gov",
+        "date": "2023-01-01",
+        "description": "This is a test supplemental content containing test information"
+    },
+    {
+        "name": "We didnt start fire",
+        "url": "music.com",
+        "date": "2019-05-12",
+        "description": "But the worlds been burning since the worlds been turning"
+    },
+    {
+        "name": "Into the unknown",
+        "url": "frozen.com",
+        "date": "2020-02-29",
+        "description": "The cold doesnt bother me anyway"
+    }
+]

--- a/solution/backend/file_manager/tests/test_urls.py
+++ b/solution/backend/file_manager/tests/test_urls.py
@@ -73,6 +73,6 @@ class SubjectTest(TestCase):
         response = self.client.get("/v3/file-manager/subjects")
         data = json.loads(json.dumps(response.data))
         self.assertEqual(data[0]['uploads'], 0)
-        self.assertEqual(data[0]['external_resources'], 6)
+        self.assertEqual(data[0]['external_resources'], 3)
         self.assertEqual(data[1]['uploads'], 3)
-        self.assertEqual(data[1]['external_resources'], 3)
+        self.assertEqual(data[1]['external_resources'], 6)

--- a/solution/backend/file_manager/tests/test_urls.py
+++ b/solution/backend/file_manager/tests/test_urls.py
@@ -7,6 +7,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 from rest_framework.test import APIClient
 
+from content_search.functions import index_group
 from file_manager.models import Subject, UploadedFile
 from resources.models import FederalRegisterDocument, SupplementalContent
 
@@ -50,7 +51,6 @@ class SubjectTest(TestCase):
         self.clean_up()
         self.subject1 = Subject.objects.create(full_name='test')
         self.subject2 = Subject.objects.create(full_name='test2')
-        print(self.subject1.id)
         with open("content_search/tests/fixtures/sample_supplemental.json", "r") as f:
             for i, data in enumerate(json.load(f)):
                 file = SupplementalContent.objects.create(**data)
@@ -68,11 +68,22 @@ class SubjectTest(TestCase):
                 file = UploadedFile.objects.create(**data)
                 file.subjects.set([self.subject2])
                 file.save()
+        index_group(SupplementalContent.objects.all())
+        index_group(FederalRegisterDocument.objects.all())
+        index_group(UploadedFile.objects.all())
 
     def test_get_subject_list(self):
         response = self.client.get("/v3/file-manager/subjects")
         data = json.loads(json.dumps(response.data))
-        self.assertEqual(data[0]['uploads'], 0)
-        self.assertEqual(data[0]['external_resources'], 3)
-        self.assertEqual(data[1]['uploads'], 3)
-        self.assertEqual(data[1]['external_resources'], 6)
+        self.assertEqual(data[0]['internal_content'], 0)
+        self.assertEqual(data[0]['external_content'], 3)
+        self.assertEqual(data[1]['internal_content'], 3)
+        self.assertEqual(data[1]['external_content'], 6)
+
+    def test_get_subject_list_by_query(self):
+        response = self.client.get("/v3/file-manager/subjects?q=fire")
+        data = json.loads(json.dumps(response.data))
+        self.assertEqual(data[0]['internal_content'], 0)
+        self.assertEqual(data[0]['external_content'], 1)
+        self.assertEqual(data[1]['internal_content'], 1)
+        self.assertEqual(data[1]['external_content'], 1)


### PR DESCRIPTION
Resolves # EREGCSC-2295

**Description-**
To easily list how many resources are associated to a subject we want the endpoint to reveal in a count how many are related to the subject.  There are two fields added that will list the counts:
external_resources
uploads
**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change

Go into swagger.
make sure you have resources of internal and external assigned to some subjects.
Call the subjects endpoint.  
Uploads field will relfect how many internal_resources are associated to the subject.
external_resources will refer to how many abstract resources are assigned to the subect.

New unit test will pass.
