### PR TITLE
Hotfix approved only index

### DIFF
--- a/solution/backend/content_search/functions.py
+++ b/solution/backend/content_search/functions.py
@@ -44,6 +44,9 @@ def update_index(content_index, content):
         )
         new_index.save()
     elif isinstance(content, SupplementalContent) or isinstance(content, FederalRegisterDocument):
+        if not content.approved:
+            content_index.delete()
+            return
         new_index = ContentIndex(
             category=content.category,
             url=content.url,
@@ -95,6 +98,8 @@ def add_to_index(content):
         )
         content_index.save()
     elif isinstance(content, SupplementalContent) or isinstance(content, FederalRegisterDocument):
+        if not content.approved:
+            return
         content_index = ContentIndex(
             category=content.category,
             url=content.url,

--- a/solution/backend/content_search/tests/test_functions.py
+++ b/solution/backend/content_search/tests/test_functions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from content_search.functions import add_to_index
+from content_search.functions import add_to_index, check_index
 from content_search.models import ContentIndex
 from file_manager.models import UploadedFile
 from resources.models import FederalRegisterDocument, SupplementalContent
@@ -8,6 +8,11 @@ from resources.models import FederalRegisterDocument, SupplementalContent
 
 def add_supplemental_content():
     sup, _ = SupplementalContent.objects.get_or_create(name="valid", url="valid.doc",)
+    add_to_index(sup)
+    return sup
+
+def add_supplemental_content_unapproved():
+    sup, _ = SupplementalContent.objects.get_or_create(name="valid", url="valid.doc", approved=False)
     add_to_index(sup)
     return sup
 
@@ -81,6 +86,10 @@ def test_index_update():
     file_index = ContentIndex.objects.get(file=up)
     assert file_index.doc_name_string == 'updated'
     assert file_index.content == 'content is here'
+    si.approved = False
+    add_to_index(si)
+    file_index = check_index(si)
+    assert file_index is None
     clean_up()
 
 

--- a/solution/backend/content_search/tests/test_functions.py
+++ b/solution/backend/content_search/tests/test_functions.py
@@ -11,6 +11,7 @@ def add_supplemental_content():
     add_to_index(sup)
     return sup
 
+
 def add_supplemental_content_unapproved():
     sup, _ = SupplementalContent.objects.get_or_create(name="valid", url="valid.doc", approved=False)
     add_to_index(sup)

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -1,5 +1,5 @@
 
-from django.db.models import Prefetch
+from django.db.models import F, Prefetch
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 from rest_framework.response import Response
@@ -82,6 +82,8 @@ class ContentSearchViewset(LocationExplorerViewSetMixin, OptionalPaginationMixin
             Prefetch("document_type", queryset=doc_type_prefetch)).distinct()
         if search_query:
             query = query.search(search_query)
+        else:
+            query = query.order_by(F('date_string').desc(nulls_last=True), F('doc_name_string').asc(nulls_last=True))
         if paginate:
             query = self.paginate_queryset(query)
         context = self.get_serializer_context()

--- a/solution/backend/index_resources.py
+++ b/solution/backend/index_resources.py
@@ -13,6 +13,6 @@ def handler(event, context):
     from file_manager.models import UploadedFile
     from resources.models import FederalRegisterDocument, SupplementalContent
 
-    index_group(SupplementalContent.objects.all())
-    index_group(FederalRegisterDocument.objects.all())
+    index_group(SupplementalContent.objects.filter(approved=True))
+    index_group(FederalRegisterDocument.objects.filter(approved=True))
     index_group(UploadedFile.objects.all())


### PR DESCRIPTION
Resolves # Issue regarding non approved content in the index

**Description-**

This will make it so only approved FRDocs and supplemental content are indexed.  If a piece is marked to false, it will remove it from the index.
**This pull request changes...**

- Anything not approved will not appear in the index.

**Steps to manually verify this change...**

1. Click this link and you should get no results
https://3mkeajv1n1.execute-api.us-east-1.amazonaws.com/dev1011/v3/content-search/?q=bibbity

2. In the admin go to the supplemental content with the name of bibbity and switch it to approved.
3. redo the search and it will return just that piece of content
4. Switch it back to not approved and redo the search
5. It will now no longer appear in the search


