### PR TITLE
[HOTFIX] Clicking ToC and then adding subjects

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
@@ -14,7 +14,7 @@ const $router = useRouter();
 const $route = useRoute();
 
 const subjectClick = (event) => {
-    const subjects = $route.query.subjects ?? [];
+    const subjects = $route?.query?.subjects ?? [];
     const subjectToAdd = event.target.dataset.id;
 
     if (subjects.includes(subjectToAdd)) return;

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectTOC.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectTOC.vue
@@ -29,7 +29,7 @@ const subjectsLength = computed(() => props.policyDocSubjects.results.length);
                     <router-link
                         :to="{
                             name: 'policy-repository',
-                            query: { subjects: subject.id.toString() },
+                            query: { subjects: [subject.id.toString()] },
                         }"
                     >
                         <div


### PR DESCRIPTION
Resolves issue on production

**Description:**

The flow to reproduce this bug consistently:
1. Visit `/policy-repository`
2. Click on a subject near or at the Table of Contents (so the subject ID has more than one digit. ex: 190)
3. Add more subjects using the sidebar subject selector
4. More subjects will appear selected than the two you've selected

**This pull request changes:**

- ToC click will push a string wrapped in an array into router state instead of just a string

**Steps to manually verify this change:**

1. Follow reproduction steps above and ensure only two subjects are selected, and that they're the correct two subjects

