### PR TITLE
[HOTFIX] Clicking ToC and then adding subjects

### DIFF
--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -45,7 +45,7 @@ provider:
     OIDC_OP_USER_ENDPOINT: ${ssm:/eregulations/oidc/user_endpoint}
     DEPLOY_NUMBER: ${env:RUN_ID}
     EUA_FEATUREFLAG: ${ssm:/eregulations/eua/featureflag}
-    TEXT_EXTRACTOR_ARN: ${self:custom.settings.text_extractor_arn}
+    #TEXT_EXTRACTOR_ARN: ${self:custom.settings.text_extractor_arn}
   vpc:
     securityGroupIds:
       - ${ssm:/eregulations/aws/securitygroupid}
@@ -78,7 +78,7 @@ custom:
     DB_NAME: ${self:custom.stage}
     USERNAME: eregsuser
     ALLOWED_HOST: '.amazonaws.com'
-    text_extractor_arn: ${cf:text-extractor-${self:custom.stage}.TextDashextractorLambdaFunctionQualifiedArn}
+    #text_extractor_arn: ${cf:text-extractor-${self:custom.stage}.TextDashextractorLambdaFunctionQualifiedArn}
   cloudfrontInvalidate:
     - distributionId: ${cf:cmcs-eregs-static-assets-${self:custom.stage}.CloudFrontDistributionId}
       items:

--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -39,11 +39,16 @@ describe("Policy Repository", () => {
         cy.visit("/policy-repository");
         cy.url().should("include", "/policy-repository/");
         cy.get("#loginIndicator").should("be.visible");
-        cy.get(".subj-toc__list li:nth-child(1) a")
-            .should("be.visible")
-            .should("have.text", " ABP  Alternative Benefit Plan ")
+        cy.get(".subj-toc__list li[data-testid=subject-toc-li-77] a")
+            .scrollIntoView();
+        cy.get(".subj-toc__list li[data-testid=subject-toc-li-77] a")
+            .should("have.text", " Nutrition ")
             .click({ force: true });
-        cy.url().should("include", "/policy-repository?subjects=2");
+        cy.url().should("include", "/policy-repository?subjects=77");
+        cy.get(`button[data-testid=add-subject-2]`).click({
+            force: true,
+        });
+        cy.url().should("include", "/policy-repository?subjects=77&subjects=2");
     });
 
     it("should make a successful request to the content-search endpoint", () => {

--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -39,16 +39,16 @@ describe("Policy Repository", () => {
         cy.visit("/policy-repository");
         cy.url().should("include", "/policy-repository/");
         cy.get("#loginIndicator").should("be.visible");
-        cy.get(".subj-toc__list li[data-testid=subject-toc-li-77] a")
+        cy.get(".subj-toc__list li[data-testid=subject-toc-li-63] a")
             .scrollIntoView();
-        cy.get(".subj-toc__list li[data-testid=subject-toc-li-77] a")
-            .should("have.text", " Nutrition ")
+        cy.get(".subj-toc__list li[data-testid=subject-toc-li-63] a")
+            .should("have.text", " Managed Care ")
             .click({ force: true });
-        cy.url().should("include", "/policy-repository?subjects=77");
+        cy.url().should("include", "/policy-repository?subjects=63");
         cy.get(`button[data-testid=add-subject-2]`).click({
             force: true,
         });
-        cy.url().should("include", "/policy-repository?subjects=77&subjects=2");
+        cy.url().should("include", "/policy-repository?subjects=63&subjects=2");
     });
 
     it("should make a successful request to the content-search endpoint", () => {

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
@@ -14,7 +14,7 @@ const $router = useRouter();
 const $route = useRoute();
 
 const subjectClick = (event) => {
-    const subjects = $route.query.subjects ?? [];
+    const subjects = $route?.query?.subjects ?? [];
     const subjectToAdd = event.target.dataset.id;
 
     if (subjects.includes(subjectToAdd)) return;

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectTOC.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectTOC.vue
@@ -29,7 +29,7 @@ const subjectsLength = computed(() => props.policyDocSubjects.results.length);
                     <router-link
                         :to="{
                             name: 'policy-repository',
-                            query: { subjects: subject.id.toString() },
+                            query: { subjects: [subject.id.toString()] },
                         }"
                     >
                         <div

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectTOC.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectTOC.vue
@@ -25,6 +25,7 @@ const subjectsLength = computed(() => props.policyDocSubjects.results.length);
                     v-for="subject in policyDocSubjects.results"
                     :key="subject.id"
                     class="subj-toc__li"
+                    :data-testid="`subject-toc-li-${subject.id}`"
                 >
                     <router-link
                         :to="{


### PR DESCRIPTION
Resolves issue on production where wrong data type is being pushed into router state. A string is being treated as an array, which is splitting the string into characters when updating the route's query params.

**Description:**

The flow to reproduce this bug consistently:
1. Visit `/policy-repository`
2. Click on a subject near or at the bottom of the Table of Contents (so the subject ID has a high number with more than one digit. ex: 190)
3. Add one more subject using the sidebar subject selector

Expected result:
Two subjects will be selected

Actual result:
Three or more subjects will be selected

**This pull request changes:**

- ToC click will push a string wrapped in an array into router state instead of just a string so all existing functionality will work as expected
- Adds Cypress test to validate the fix

**Steps to manually verify this change:**

1. Follow reproduction steps above and ensure only two subjects are selected, and that they're the correct two subjects
2. Make sure new e2e test passes