### PR TITLE
EREGCSC-2330 -- Fix unexpected subjects [BUGFIX]

### DIFF
--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -39,8 +39,9 @@ describe("Policy Repository", () => {
         cy.visit("/policy-repository");
         cy.url().should("include", "/policy-repository/");
         cy.get("#loginIndicator").should("be.visible");
-        cy.get(".subj-toc__list li[data-testid=subject-toc-li-63] a")
-            .scrollIntoView();
+        cy.get(
+            ".subj-toc__list li[data-testid=subject-toc-li-63] a"
+        ).scrollIntoView();
         cy.get(".subj-toc__list li[data-testid=subject-toc-li-63] a")
             .should("have.text", " Managed Care ")
             .click({ force: true });
@@ -140,6 +141,23 @@ describe("Policy Repository", () => {
         cy.checkAccessibility();
     });
 
+    it("should display correct subject ID numbers in the URL if one is included in the URL on load and another one is added via the Subject Selector", () => {
+        cy.viewport("macbook-15");
+        cy.eregsLogin({ username, password });
+        cy.visit("/policy-repository/?subjects=77");
+        cy.url().should("include", "/policy-repository/?subjects=77");
+        cy.get(`button[data-testid=remove-subject-77]`).should("exist");
+        cy.get("button[data-testid=add-subject-63]").click({
+            force: true,
+        });
+        cy.get(`button[data-testid=remove-subject-63]`).should("exist");
+        cy.get(`button[data-testid=remove-subject-77]`).should("exist");
+        cy.url().should(
+            "include",
+            "/policy-repository?subjects=77&subjects=63"
+        );
+    });
+
     it("should display and fetch the correct search query on load if it is included in URL", () => {
         cy.intercept("**/v3/content-search/?q=test**").as("qFiles");
         cy.viewport("macbook-15");
@@ -189,22 +207,22 @@ describe("Policy Repository", () => {
         cy.get(".doc-type__toggle fieldset > div")
             .eq(0)
             .find("input")
-            .uncheck({force: true});
+            .uncheck({ force: true });
         cy.url().should("include", "/policy-repository?type=internal");
         cy.get(".subj-toc__container").should("not.exist");
         cy.get(".doc-type__toggle fieldset > div")
             .eq(1)
             .find("input")
-            .uncheck({force: true});
+            .uncheck({ force: true });
         cy.get(".subj-toc__container").should("exist");
         cy.get(".doc-type__toggle fieldset > div")
             .eq(0)
             .find("input")
-            .check({force: true});
+            .check({ force: true });
         cy.get(".doc-type__toggle fieldset > div")
             .eq(1)
             .find("input")
-            .check({force: true});
+            .check({ force: true });
         cy.url().should("include", "/policy-repository?type=all");
     });
 

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { useRouter, useRoute } from "vue-router/composables";
 
+import _isArray from "lodash/isArray";
+
 import { getSubjectName } from "utilities/filters";
 
 const props = defineProps({
@@ -15,15 +17,16 @@ const $route = useRoute();
 
 const subjectClick = (event) => {
     const subjects = $route?.query?.subjects ?? [];
+    const subjectsArray = _isArray(subjects) ? subjects : [subjects];
     const subjectToAdd = event.target.dataset.id;
 
-    if (subjects.includes(subjectToAdd)) return;
+    if (subjectsArray.includes(subjectToAdd)) return;
 
     $router.push({
         name: "policy-repository",
         query: {
             ...$route.query,
-            subjects: [...subjects, event.target.dataset.id],
+            subjects: [...subjectsArray, event.target.dataset.id],
         },
     });
 };

--- a/solution/ui/regulations/eregs-vite/src/views/PolicyRepository.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/PolicyRepository.vue
@@ -173,9 +173,6 @@ const selectedParams = reactive({
 const addSelectedParams = (paramArgs) => {
     const { id, name, type } = paramArgs;
 
-    // early return if the param is already selected
-    if (selectedParams.paramString.includes(`${type}=${id}`)) return;
-
     // update paramString that is used as reactive prop for watch
     if (selectedParams.paramString) {
         selectedParams.paramString += `&${type}=${id}`;


### PR DESCRIPTION
Resolves [EREGCSC-2330](https://jiraent.cms.gov/browse/EREGCSC-2330)

**Description:**

If you follow a link to a subject with a multi-digit ID number and then add another subject, you end up with unexpected subjects selected.

**Steps to reproduce:**

1. Visit the `prod` site using a link that already has a subject with a multi-digit id selected.  
   - Ex: https://eregulations.cms.gov/policy-repository/?subjects=219
2. Add another subject by clicking on any subject in the Subject Selector in the sidebar
   - Ex: Access to Services (id: 3)

**Expected result:**
- `&subjects=3` is appended to the end of the URL and the URL should look something like: `https://eregulations.cms.gov/policy-repository/?subjects=219&subjects=3`

**Actual result:**
- `?subjects=219` is split into `?subjects=2&subjects=1&subjects=9` and the URL looks like `https://eregulations.cms.gov/policy-repository?subjects=2&subjects=1&subjects=9&subjects=3`

**This pull request changes:**

- Adds guard in Subject Selector to ensure `subjects` pulled from route are in an array before pushing them back into route
- Adds Cypress test to validate changes

**Steps to manually verify this change:**

1. Visit experimental deployment with a link that already has a subject selected.  
   - Ex: https://sk1tquh5za.execute-api.us-east-1.amazonaws.com/dev1020/policy-repository/?subjects=78
2. Add another subject
3. URL should look like `https://sk1tquh5za.execute-api.us-east-1.amazonaws.com/dev1020/policy-repository?subjects=78&subjects=2`
4. All Cypress tests pass

