### PR TITLE
hotfix deployexperimental lambda perm fix

### DIFF
--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -188,7 +188,7 @@ resources:
                    Action:
                      - "lambda:InvokeFunction"
                    Resource:
-                     - "${self:custom.settings.text_extractor_arn}"       
+                     - "${ssm:/eregulations/textextractor-arn}"       
 
 plugins:
   - serverless-wsgi


### PR DESCRIPTION
Resolves # HOTFIX lambda resource

**Description-**

The text extractor arn is different on normal environments and needs to be the one for main dev.  Right now its trying to grab one that doesnt exist.

**This pull request changes...**

- the permission granted to the lambda is correct.

**Steps to manually verify this change...**

1. Deploy experimental builds properly

