### PR TITLE
[Hotfix] Revert CMS Design System back to v2.5

### DIFF
--- a/solution/ui/regulations/package.json
+++ b/solution/ui/regulations/package.json
@@ -16,7 +16,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@cmsgov/design-system": "^2.13.0",
+    "@cmsgov/design-system": "^2.5.0",
     "@fortawesome/fontawesome-free": "^5.15.3",
     "@vitejs/plugin-vue2": "^2.2.0",
     "@vue/test-utils": "^1.3.5",


### PR DESCRIPTION
Resolves regression introduced with updated version of CMS Design System

**Description**
[Snyk created a Pull Request](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1042) that bumped CMS Design System's NPM package from v2.5.0 to 2.13.0.  This was merged into `main` before it was discovered that it introduced a regression where the focus styles (outline and background) were changed and did not always look good.

**This pull request changes:**

- Reverts CMS Design System package version to 2.5.0

**Steps to manually verify this change:**

1. Tab around the homepage and make sure the focus styles aren't pink outlines and sometimes white backgrounds

