### PR TITLE
EREGCSC-2339 Add content search headline

### DIFF
--- a/solution/backend/content_search/models.py
+++ b/solution/backend/content_search/models.py
@@ -41,7 +41,9 @@ class ContentIndexQuerySet(models.QuerySet):
                 search_query,
                 start_sel='<span class="search-highlight">',
                 stop_sel='</span>',
-                config='english'
+                min_words=30,
+                config='english',
+                fragment_delimiter='...'
             ),
             document_name_headline=SearchHeadline(
                 "doc_name_string",
@@ -49,7 +51,19 @@ class ContentIndexQuerySet(models.QuerySet):
                 start_sel="<span class='search-highlight'>",
                 stop_sel="</span>",
                 config='english',
-                highlight_all=True
+                min_words=30,
+                highlight_all=True,
+                fragment_delimiter='...'
+            ),
+            content_headline=SearchHeadline(
+                "content",
+                search_query,
+                start_sel="<span class='search-highlight'>",
+                stop_sel="</span>",
+                config='english',
+                min_words=30,
+                highlight_all=True,
+                fragment_delimiter='...'
             ),
         ).order_by('-rank')
 

--- a/solution/backend/content_search/serializers.py
+++ b/solution/backend/content_search/serializers.py
@@ -5,23 +5,6 @@ from common.serializers import DetailsSerializer
 from file_manager.serializers import DocumentTypeSerializer, SubjectSerializer
 
 
-class ContentSearchSerializer(DetailsSerializer, serializers.Serializer, ):
-    doc_name_string = serializers.CharField()
-    file_name_string = serializers.CharField()
-    date_string = serializers.DateField()
-    summary_string = serializers.CharField()
-    locations = serializers.SerializerMethodField()
-    document_type = DocumentTypeSerializer(many=False, read_only=True)
-    resource_type = serializers.CharField()
-    subjects = SubjectSerializer(many=True, read_only=True)
-    category = serializers.SerializerMethodField()
-    url = serializers.CharField()
-    # content_type = serializers.CharField()
-    # content_id = serializers.IntegerField()
-    document_name_headline = HeadlineField()
-    summary_headline = HeadlineField()
-
-
 class ContentListSerializer(DetailsSerializer, serializers.Serializer, ):
     doc_name_string = serializers.CharField()
     file_name_string = serializers.CharField()
@@ -33,8 +16,12 @@ class ContentListSerializer(DetailsSerializer, serializers.Serializer, ):
     subjects = SubjectSerializer(many=True, read_only=True)
     category = serializers.SerializerMethodField()
     url = serializers.CharField()
-    # content_type = serializers.CharField()
-    # content_id = serializers.IntegerField()
+
+
+class ContentSearchSerializer(ContentListSerializer, ):
+    document_name_headline = HeadlineField()
+    summary_headline = HeadlineField()
+    content_headline = HeadlineField()
 
 
 class ContentUpdateSerializer(serializers.Serializer):

--- a/solution/backend/content_search/tests/test_search.py
+++ b/solution/backend/content_search/tests/test_search.py
@@ -162,3 +162,12 @@ class SearchTest(TestCase):
         response = self.client.get(
             f"/v3/content-search/?resource-type=internal&q=test&subjects={self.subject1.id}&subjects={self.subject2.id}")
         self.check_exclusive_response(response, 0)
+
+    def test_content_search(self):
+        a = ContentIndex.objects.first()
+        a.content = "dummy dummy dummy"
+        a.save()
+        self.login()
+        response = self.client.get("/v3/content-search/?&q='dummy'")
+        data = get_paginated_data(response)
+        self.assertTrue("dummy" in data['results'][0]['content_headline'])


### PR DESCRIPTION
Resolves # EREGCSC-2339

**Description-**

Adds headline for content for contentsearch.
**This pull request changes...**

- A content field will be returned in the api for contentsearch.
- 
**Steps to manually verify this change...**

1. Make sure a value in the index has something for content.  Do a search for "dummy" on the policy repository api.
2. A piece of content with dummy will appear in the content search headline.

