### PR TITLE
[Hotfix] Search page resources external link style regression

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -54,6 +54,15 @@
 
             .resources-results-content {
                 @include common-results-styles;
+
+                .result {
+                    &__link {
+                        a {
+                            text-decoration: none;
+                            display: block;
+                        }
+                    }
+                }
             }
 
             .search-results-count {


### PR DESCRIPTION
Resolves regression involving external link icon on the Resources results on the combined search page.

See this link: https://eregulations.cms.gov/search/?q=%22Electronic%20Visit%20Verification%22

**Description:**

When styling the policy repository results and adding the Download File chip, some styles leaked into the Combined Search page's Resources column and the external link icon was out of place:

![Screenshot 2023-11-10 at 11 17 20 AM](https://github.com/Enterprise-CMCS/cmcs-eregulations/assets/1651907/a5d9210b-1b0f-4aaf-814d-516776221d9f)

The description of the result item would also become split unexpectedly.

![Screenshot 2023-11-10 at 11 18 52 AM](https://github.com/Enterprise-CMCS/cmcs-eregulations/assets/1651907/88a4926f-750c-4e60-aa74-464afe9dc703)


**This pull request changes...**

- Tweaks resources page result item style so that it is not affected by Policy Repository style

**Steps to manually verify this change...**

1. Visit the [experimental deployment's Search Page using the same query string as used in the prod link above](https://p8okdwd1j7.execute-api.us-east-1.amazonaws.com/dev1047/search/?q=%22Electronic%20Visit%20Verification%22).
2. Ensure that the external link icon is not misplaced (compare to the external link icon found in the results on the Resources page)
3. Ensure that item descriptions are not split. (see attached screenshots to find the result item with which to compare)

