### PR TITLE
EREGCSC-2354 -- only allow one subject to be selected at a time

### DIFF
--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -57,7 +57,7 @@ describe("Policy Repository", () => {
         cy.get(`button[data-testid=add-subject-2]`).click({
             force: true,
         });
-        cy.url().should("include", "/policy-repository?subjects=63&subjects=2");
+        cy.url().should("include", "/policy-repository?subjects=2");
     });
 
     it("should make a successful request to the content-search endpoint", () => {
@@ -73,7 +73,6 @@ describe("Policy Repository", () => {
     });
 
     it("loads the correct subject and search query when the URL is changed", () => {
-        cy.intercept("**/v3/content-search/?subjects=1&q=test**").as("qFiles");
         cy.viewport("macbook-15");
         cy.eregsLogin({ username, password });
         cy.visit("/policy-repository");
@@ -88,27 +87,18 @@ describe("Policy Repository", () => {
         cy.get(`button[data-testid=add-subject-2]`).click({
             force: true,
         });
-        cy.url().should("include", "/policy-repository?subjects=1&subjects=2");
+        cy.url().should("include", "/policy-repository?subjects=2");
         cy.get(`button[data-testid=remove-subject-2]`).should("exist");
 
         cy.get(`button[data-testid=add-subject-3]`).click({
             force: true,
         });
-        cy.url().should(
-            "include",
-            "/policy-repository?subjects=1&subjects=2&subjects=3"
-        );
+        cy.url().should("include", "/policy-repository?subjects=3");
         cy.get(`button[data-testid=remove-subject-3]`).should("exist");
 
         cy.go("back");
-        cy.url().should("include", "/policy-repository?subjects=1&subjects=2");
+        cy.url().should("include", "/policy-repository?subjects=2");
         cy.get(`button[data-testid=remove-subject-3]`).should("not.exist");
-
-        cy.get(`button[data-testid=remove-subject-2]`).click({
-            force: true,
-        });
-        cy.url().should("include", "/policy-repository?subjects=1");
-        cy.get(`button[data-testid=remove-subject-2]`).should("not.exist");
 
         cy.get("input#main-content")
             .should("be.visible")
@@ -116,10 +106,13 @@ describe("Policy Repository", () => {
         cy.get(".search-field .v-input__icon--append button").click({
             force: true,
         });
-        cy.url().should("include", "/policy-repository?subjects=1&q=test");
-        cy.wait("@qFiles").then((interception) => {
-            expect(interception.response.statusCode).to.eq(200);
+        cy.url().should("include", "/policy-repository?subjects=2&q=test");
+
+        cy.get(`button[data-testid=remove-subject-2]`).click({
+            force: true,
         });
+        cy.get(`button[data-testid=remove-subject-2]`).should("not.exist");
+        cy.url().should("include", "/policy-repository?q=test");
     });
 
     it("should display and fetch the correct subjects on load if they are included in URL", () => {
@@ -212,7 +205,7 @@ describe("Policy Repository", () => {
         cy.get("input#main-content").should("have.value", "");
     });
 
-    it("should display correct subject ID numbers in the URL if one is included in the URL on load and another one is added via the Subject Selector", () => {
+    it("should display correct subject ID number in the URL if one is included in the URL on load and different one is selected via the Subject Selector", () => {
         cy.viewport("macbook-15");
         cy.eregsLogin({ username, password });
         cy.visit("/policy-repository/?subjects=77");
@@ -222,11 +215,8 @@ describe("Policy Repository", () => {
             force: true,
         });
         cy.get(`button[data-testid=remove-subject-63]`).should("exist");
-        cy.get(`button[data-testid=remove-subject-77]`).should("exist");
-        cy.url().should(
-            "include",
-            "/policy-repository?subjects=77&subjects=63"
-        );
+        cy.get(`button[data-testid=remove-subject-77]`).should("not.exist");
+        cy.url().should("include", "/policy-repository?subjects=63");
     });
 
     it("should filter the subject list when a search term is entered into the subject filter", () => {

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
@@ -100,7 +100,7 @@ const subjectClick = (event) => {
         name: "policy-repository",
         query: {
             ...$route.query,
-            subjects: [...subjectsArray, event.currentTarget.dataset.id],
+            subjects: [subjectToAdd],
         },
     });
 };


### PR DESCRIPTION
Resolves [EREGCSC-2354](https://jiraent.cms.gov/browse/EREGCSC-2354)

**Description**

If I'm viewing a subject and choose another subject, replace the current materials with the new materials. (No other changes to persistence of search query, etc.)

**This pull request changes:**

- When clicking on a subject in the subject selector, the clicked subject overwrites any existing subject(s) in the URL
- Updates cypress tests to reflect this new reality

**Steps to manually verify this change...**

1. Visit the experimental deployment
2. Start clicking on subjects using the left sidebar's Subject Selector
3. There the subject you click should always replace the existing subject.  There should never be a time where two subjects are selected at once (unless you manually edit the URL to do so).

