### PR TITLE
[Hotfix] Prevent submit on subject typeahead form input

### DIFF
--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -265,6 +265,11 @@ describe("Policy Repository", () => {
 
         cy.checkAccessibility();
 
+        cy.get("input#subjectReduce")
+            .type("{enter}", { force: true });
+
+        cy.url().should("include", "/policy-repository?subjects=1");
+
         cy.get(`button[data-testid=clear-subject-filter]`).click({
             force: true,
         });

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
@@ -125,7 +125,7 @@ const filterResetClick = () => {
                 </div>
             </template>
             <template v-else>
-                <form>
+                <form @submit.prevent>
                     <label for="subjectReduce">Filter the subject list</label>
                     <input id="subjectReduce" v-model="state.filter" type="text" />
                     <button


### PR DESCRIPTION
Resolves [bug found during usability session](https://macbis.dovetailapp.com/data/4Q3jRiivCOibNIGnbN6eMq#:v:h=40GrWiVxS6z4zD3ZWqwWlo&s=1) where pressing enter in the subject typeahead input refreshes the page and removes all query parameters.

**Description**

The subject typeahead filter is a form input.  Forms fire a `submit` event when enter is pressed in an input.  This `submit` event is not what we want -- it is refreshing the page when we don't want it to refresh the page.

**Steps to Reproduce**

1. Visit the [policy repository on `prod`](https://eregulations.cms.gov/policy-repository/)
2. type something into the subject typeahead filter input in the right sidebar
3. Press enter

Expected result: Nothing happens

Actual Result: The entire page reloads with all query/filter parameters removed from the url

**This pull request changes:**

- Adds `@submit.prevent` event modifier to the filter typeahead form

**Steps to manually verify this change...**

1. Visit experimental deployment
3. type something in subject typeahead input
4. Press enter.  Nothing should happen

