### PR TITLE
Hotfix:  All of content is being returned

### DIFF
--- a/solution/backend/content_search/models.py
+++ b/solution/backend/content_search/models.py
@@ -62,7 +62,6 @@ class ContentIndexQuerySet(models.QuerySet):
                 stop_sel="</span>",
                 config='english',
                 min_words=30,
-                highlight_all=True,
                 fragment_delimiter='...'
             ),
         ).order_by('-rank')

--- a/solution/text-extractor/serverless.yml
+++ b/solution/text-extractor/serverless.yml
@@ -102,7 +102,7 @@ resources:
                        - ""
                        - - "arn:aws:s3:::"
                          - "Ref" : "ServerlessDeploymentBucket"
-                     - "arn:aws:s3:::file-repo-eregs-${self:custom.stage}/*"
+                     - "arn:aws:s3:::file-repo-eregs-${self:custom.stage}*"
 
     ServerlessSecurityGroup:
       Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
Resolves # HOTFIX

**Description-**

Removed hightlight all from content_headline.  Was returning the full content and ignoring minimum words

**This pull request changes...**

- All of content wont be returned on content_headline.


