### PR TITLE
EREGCSC-2344 -- External link icon on Public policy repository repo links

### DIFF
--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -141,12 +141,15 @@ describe("Policy Repository", () => {
         cy.get(".result__link")
             .eq(0)
             .find("a")
-            .should("not.include.text", "Download");
+            .should("not.include.text", "Download")
+            .and("have.class", "external");
         cy.get(".result__link")
             .eq(1)
             .should("include.text", "Download")
+            .find("a")
+            .should("not.have.class", "external")
             .find(
-                "a span[data-testid=download-chip-d89af093-8975-4bcb-a747-abe346ebb274]"
+                "span[data-testid=download-chip-d89af093-8975-4bcb-a747-abe346ebb274]"
             )
             .should("include.text", "Download MSG");
 

--- a/solution/ui/regulations/css/scss/partials/_policy_repository.scss
+++ b/solution/ui/regulations/css/scss/partials/_policy_repository.scss
@@ -341,6 +341,10 @@
             .document__link {
                 text-decoration: none;
 
+                &.external {
+                    display: block;
+                }
+
                 &--view {
                     font-size: $font-size-sm;
                 }

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -37,7 +37,8 @@ const needsBar = (item) =>
     item.date_string &&
     item.doc_name_string;
 
-const resultLinkClasses = () => ({
+const resultLinkClasses = (doc) => ({
+    "external": doc.resource_type === "external",
     "document__link--search": !!$route?.query?.q,
 });
 


### PR DESCRIPTION
Resolves [ERERGCSC-2344](https://jiraent.cms.gov/browse/EREGCSC-2344)

**Description**

External documents on the Policy Repository page (the Public documents) are external resources that, when clicked, take the user away from eRegs.  As such, these links should have the [external link icon](https://d147x1jcgm8uq1.cloudfront.net/images/external-link.svg) appended at the end to indicate to the user that they will leave eRegs if the click the link.

**This pull request changes:**

- Adds `external` class to Policy Repository result items if they have a document type of "external"
- Tweaks style so that the external link icons appear inline with the link
- Adds a few Cypress assertions to ensure the `external` class is only applied where expected

**Steps to manually verify this change:**

1. Visit [experimental deployment](https://p4hsokying.execute-api.us-east-1.amazonaws.com/dev1059) and navigate to the Policy Repository
2. Make sure all Public document links have an external link icon at the end of the link and all Internal document links do not

