### PR TITLE
EREGCSC-2351 -- Tooltip for subject chip with full name

### DIFF
--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -190,6 +190,9 @@ describe("Policy Repository", () => {
             "include",
             "/policy-repository?type=internal&subjects=3&q=test"
         );
+        cy.get(`a[data-testid=add-subject-chip-4]`)
+            .should("have.attr", "title")
+            .and("include", "Adult Day Health");
         cy.get(`a[data-testid=add-subject-chip-4]`).click({
             force: true,
         });

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectChip.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectChip.vue
@@ -8,12 +8,17 @@ const props = defineProps({
         type: String,
         required: true,
     },
+    title: {
+        type: String,
+        required: true,
+    },
 });
 </script>
 
 <template>
     <router-link
         class="subject__chip"
+        :title="title"
         :data-testid="`add-subject-chip-${subjectId}`"
         :to="{
             name: 'policy-repository',

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectChips.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectChips.vue
@@ -19,6 +19,7 @@ const props = defineProps({
             :key="subject.id + 'x' + i"
             :subject-id="subject.id"
             :subject-name="getSubjectName(subject)"
+            :title="subject.full_name"
         />
     </div>
 </template>


### PR DESCRIPTION
Resolves [EREGCSC-2351](https://jiraent.cms.gov/browse/EREGCSC-2351)

**Description**

The subject chips underneath each internal Policy Document item should have a `title` attribute that contains the full name of the subject, so when users hover over the chip with their cursor, it acts like a tooltip.  This is useful for chips that display the short name or the abbreviated name; the full name always exists, and it can add clarity and context as a tooltip.

**This pull request changes:**

- Passes `subject.full_name` into `SubjectChip.vue` as `title` prop, and then uses that prop as the `title` attribute for each subject chip.

**Steps to manually verify this change:**

1. Visit the [experimental deployment](https://1uc01wqwla.execute-api.us-east-1.amazonaws.com/dev1064) and go to the policy repository
2. Filter by internal documents.  
   - If there are no internal documents, visit the admin panel and upload one.  Be sure to add subjects.
   - If there are internal documents but they do not have subjects, visit the admin panel and add subjects to one of the uploaded files.
3. Hover your cursor over the subject chip
4. After a few seconds you should see a small tooltip containing the full name of the subject.  
   - Note: This is a browser-specific implementation, so different browsers may style and display `title` differently. 

