### PR TITLE
updated environment value and action version

### DIFF
--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: ["prod"]
+        environment: ["prod-security-hub"]
       fail-fast: false
     environment:
       name: ${{ matrix.environment }}

--- a/.github/workflows/snyk-test.yml
+++ b/.github/workflows/snyk-test.yml
@@ -45,16 +45,15 @@ jobs:
         - name: use the custom github  action to parse Snyk output
           uses: Enterprise-CMCS/macfc-security-scan-report@v2.7.4
           with:
-              jira-username: ${{ secrets.JIRA_USERNAME }}
-              jira-token: ${{ secrets.JIRA_TOKEN}}
+              jira-token: ${{ secrets.JIRA_TOKEN_FOR_SNYK}}
               jira-host: ${{ secrets.JIRA_HOST }}
               jira-project-key: 'EREGCSC'
               jira-issue-type: 'Bug'
               jira-labels: 'eRegs,snyk'
               jira-title-prefix: '[EREGCSC] - Snyk :'
-              is_jira_enterprise: true
+              is_jira_enterprise: 'true'
               jira-custom-field-key-value: '{ "customfield_10100": "EREGCSC-1989" }'
-              #assign-jira-ticket-to: ''
+              assign-jira-ticket-to: 'G6W5'
               scan-output-path: 'snyk_output.txt'
               scan-type: 'snyk'
               

--- a/.github/workflows/snyk-test.yml
+++ b/.github/workflows/snyk-test.yml
@@ -46,13 +46,14 @@ jobs:
           uses: Enterprise-CMCS/macfc-security-scan-report@v2.7.4
           with:
               jira-username: ${{ secrets.JIRA_USERNAME }}
-              jira-token: ${{ secrets.JIRA_TOKEN_AT }}
-              jira-host: ${{ secrets.JIRA_HOST_NAME }}
+              jira-token: ${{ secrets.JIRA_TOKEN}}
+              jira-host: ${{ secrets.JIRA_HOST }}
               jira-project-key: 'EREGCSC'
               jira-issue-type: 'Bug'
               jira-labels: 'eRegs,snyk'
               jira-title-prefix: '[EREGCSC] - Snyk :'
               is_jira_enterprise: true
+              jira-custom-field-key-value: '{ "customfield_10100": "EREGCSC-1989" }'
               #assign-jira-ticket-to: ''
               scan-output-path: 'snyk_output.txt'
               scan-type: 'snyk'

--- a/.github/workflows/snyk-test.yml
+++ b/.github/workflows/snyk-test.yml
@@ -43,7 +43,7 @@ jobs:
             SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           
         - name: use the custom github  action to parse Snyk output
-          uses: Enterprise-CMCS/macfc-security-scan-report@v2.7.0
+          uses: Enterprise-CMCS/macfc-security-scan-report@v2.7.4
           with:
               jira-username: ${{ secrets.JIRA_USERNAME }}
               jira-token: ${{ secrets.JIRA_TOKEN_AT }}


### PR DESCRIPTION
Resolves #

**Description-**

Configured a new Environment in GitHub [prod-security-hub](https://github.com/Enterprise-CMCS/cmcs-eregulations/settings/environments/1673789773/edit) to allow the nightly security hub to jira integration workflow to run successfully with out manual approval
Created OIDC AWS IAM role in prod account with a limited permission (permission only to Security Hub) and configured it in the new environment as a secret 
For Security hub workflow changed the environmental value under matrix to  ["prod-security-hub"]
Also configured jira credential as a secret in the new environment 
Updated snyk security scan workflow action to Enterprise-CMCS/macfc-security-scan-report@v2.7.4


**Steps to manually verify this change...**

1. steps to view and verify change
For snyk test workflow 
under On:
add 
push:
    branches: [ security-hub-update ]
and change if: github.event_name == 'schedule' > if: github.event_name == 'push'

2. for security hub workflow 
under On:
add  
push:
    branches: [ security-hub-update ]
right under runs-on:
add if: github.event_name == 'push'

save the files and push 
and verify the run under actions tab






