### PR TITLE
EREGCSC-2370 -- Move "Filter the subject list" into input field

### DIFF
--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -254,6 +254,7 @@ describe("Policy Repository", () => {
         cy.get("input#subjectReduce")
             .should("exist")
             .should("have.value", "")
+            .should("have.attr", "placeholder", "Filter the subject list")
             .type("21", { force: true });
         cy.get(`button[data-testid=clear-subject-filter]`).should("exist");
         cy.get("input#subjectReduce").should("have.value", "21");

--- a/solution/ui/regulations/css/scss/partials/_policy_repository.scss
+++ b/solution/ui/regulations/css/scss/partials/_policy_repository.scss
@@ -178,7 +178,12 @@
                 position: relative;
 
                 label[for="subjectReduce"] {
+                    position: absolute;
+                    left: 0.5rem;
+                    right: auto;
+                    color: #0009;
                     font-size: 14px;
+                    top: calc(50% - 0.625rem);
                 }
 
                 input#subjectReduce {
@@ -202,7 +207,7 @@
                 .subjects__filter-reset {
                     @include common-remove-btn-styles;
 
-                    top: 50%;
+                    top: calc(50% - 0.625rem);
                     right: -3px;
                     transform: translate(-50%);
                     position: absolute;

--- a/solution/ui/regulations/css/scss/partials/_policy_repository.scss
+++ b/solution/ui/regulations/css/scss/partials/_policy_repository.scss
@@ -177,15 +177,6 @@
                 flex-direction: column;
                 position: relative;
 
-                label[for="subjectReduce"] {
-                    position: absolute;
-                    left: 0.5rem;
-                    right: auto;
-                    color: #0009;
-                    font-size: 14px;
-                    top: calc(50% - 0.625rem);
-                }
-
                 input#subjectReduce {
                     @include filter-borders;
 

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
@@ -133,20 +133,11 @@ const filterResetClick = () => {
             </template>
             <template v-else>
                 <form @submit.prevent>
-                    <label
-                        for="subjectReduce"
-                        :style="{
-                            display: `${
-                                state.filter?.length > 0
-                                    ? 'none'
-                                    : 'inline-block'
-                            }`,
-                        }"
-                        >Filter the subject list</label
-                    >
                     <input
                         id="subjectReduce"
                         v-model="state.filter"
+                        aria-label="Filter the subject list"
+                        placeholder="Filter the subject list"
                         type="text"
                     />
                     <button

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectSelector.vue
@@ -133,7 +133,17 @@ const filterResetClick = () => {
             </template>
             <template v-else>
                 <form @submit.prevent>
-                    <label for="subjectReduce">Filter the subject list</label>
+                    <label
+                        for="subjectReduce"
+                        :style="{
+                            display: `${
+                                state.filter?.length > 0
+                                    ? 'none'
+                                    : 'inline-block'
+                            }`,
+                        }"
+                        >Filter the subject list</label
+                    >
                     <input
                         id="subjectReduce"
                         v-model="state.filter"


### PR DESCRIPTION
Resolves [EREGCSC-2370](https://jiraent.cms.gov/browse/EREGCSC-2370)

**Description**

Move explicit label into input as a placeholder to better prompt users to use the subject filter. Based on user research session.

**This pull request changes:**

- Removes explicit label and its associated styles
- adds label contents into input's `placeholder` attribute
- adds `aria-label` attribute for a11y
- asserts that `placeholder` attribute exists and is correct in e2e test suite

**Steps to manually verify this change:**

1. Visit policy repository on the experimental deployment
2. Make sure the subject filter input only has a placeholder and not an explicit label (compare to prod)

