### PR TITLE
EREGCSC-2371 -- Add Document Type labels to Policy Repo search results

### DIFF
--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -152,6 +152,16 @@ describe("Policy Repository", () => {
                 "span[data-testid=download-chip-d89af093-8975-4bcb-a747-abe346ebb274]"
             )
             .should("include.text", "Download MSG");
+        cy.get(".doc-type__label")
+            .eq(0)
+            .should("include.text", " Public ")
+            .find("i")
+            .should("have.class", "fa-users");
+        cy.get(".doc-type__label")
+            .eq(1)
+            .should("include.text", " Internal ")
+            .find("i")
+            .should("have.class", "fa-key");
 
         cy.checkAccessibility();
     });
@@ -271,8 +281,7 @@ describe("Policy Repository", () => {
 
         cy.checkAccessibility();
 
-        cy.get("input#subjectReduce")
-            .type("{enter}", { force: true });
+        cy.get("input#subjectReduce").type("{enter}", { force: true });
 
         cy.url().should("include", "/policy-repository?subjects=1");
 
@@ -420,5 +429,37 @@ describe("Policy Repository Search", () => {
         cy.wait("@queriedFiles").then((interception) => {
             expect(interception.response.statusCode).to.eq(200);
         });
+    });
+
+    it("should have the correct public/internal label", () => {
+        cy.intercept("**/v3/content-search/?q=test**", {
+            fixture: "policy-docs.json",
+        }).as("queriedFiles");
+        cy.viewport("macbook-15");
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/search",
+        });
+        cy.visit("/policy-repository/search");
+        cy.get("input#main-content")
+            .should("be.visible")
+            .type("test", { force: true });
+        cy.get(".search-field .v-input__icon--append button").click({
+            force: true,
+        });
+        cy.wait("@queriedFiles").then((interception) => {
+            expect(interception.response.statusCode).to.eq(200);
+        });
+        cy.get(".doc-type__label")
+            .eq(0)
+            .should("include.text", " Public ")
+            .find("i")
+            .should("have.class", "fa-users");
+        cy.get(".doc-type__label")
+            .eq(1)
+            .should("include.text", " Internal ")
+            .find("i")
+            .should("have.class", "fa-key");
     });
 });

--- a/solution/ui/regulations/css/scss/partials/_results_item.scss
+++ b/solution/ui/regulations/css/scss/partials/_results_item.scss
@@ -11,17 +11,29 @@
     line-height: 22px;
 }
 
+@mixin common-label-styles {
+    display: inline-block;
+    font-size: 11px;
+    width: fit-content;
+    margin-right: 5px;
+    border-radius: 3px;
+    padding: 2px 5px 3px;
+}
+
 .category-labels {
     margin-bottom: 5px;
 
+    .doc-type__label {
+        @include common-label-styles;
+
+        color: #FFF;
+        background: $mid_gray;
+    }
+
     .result-label {
-        display: inline-block;
-        font-size: 11px;
-        width: fit-content;
-        margin-right: 5px;
+        @include common-label-styles;
+
         background: #e3eef9;
-        border-radius: 3px;
-        padding: 2px 5px 3px;
 
         &.category-label {
             font-weight: 600;

--- a/solution/ui/regulations/css/scss/partials/_results_item.scss
+++ b/solution/ui/regulations/css/scss/partials/_results_item.scss
@@ -15,13 +15,14 @@
     display: inline-block;
     font-size: 11px;
     width: fit-content;
-    margin-right: 5px;
     border-radius: 3px;
     padding: 2px 5px 3px;
 }
 
 .category-labels {
-    margin-bottom: 5px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
 
     .doc-type__label {
         @include common-label-styles;
@@ -45,11 +46,7 @@
     margin-bottom: 24px;
 
     .category-labels {
-        margin-bottom: 4px;
-
-        .category-label {
-            margin-bottom: 4px;
-        }
+        margin-bottom: 8px;
     }
 
     &__context {
@@ -130,6 +127,10 @@
 
 // resources page has different styles
 .resources-content-container {
+    .result .category-labels {
+        margin-bottom: 12px;
+    }
+
     .related-sections {
         margin-bottom: 40px;
         color: $mid_gray;

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/CategoryLabel.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/CategoryLabel.vue
@@ -22,5 +22,3 @@ const labelClass = computed(() =>
         {{ name }}
     </div>
 </template>
-
-<style></style>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/CategoryLabel.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/CategoryLabel.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from "vue";
+import { computed } from "vue";
 
 const props = defineProps({
     name: {

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/DocTypeLabel.test.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/DocTypeLabel.test.js
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/vue";
+import { describe, it, expect } from "vitest";
+
+import DocTypeLabel from "./DocTypeLabel.vue";
+
+describe("Public/Private label", () => {
+    it("Renders a Public Label", async () => {
+        const wrapper = render(DocTypeLabel, {
+            props: {
+                iconType: "users",
+                docType: "External",
+            },
+        });
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it("Renders a Private Label", async () => {
+        const wrapper = render(DocTypeLabel, {
+            props: {
+                iconType: "key",
+                docType: "Internal",
+            },
+        });
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/DocTypeLabel.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/DocTypeLabel.vue
@@ -1,6 +1,4 @@
 <script setup>
-import { computed, ref } from "vue";
-
 const iconTypesDict = {
     "external": "users",
     "internal": "key",

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/DocTypeLabel.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/DocTypeLabel.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { computed, ref } from "vue";
+
+const iconTypesDict = {
+    "external": "users",
+    "internal": "key",
+};
+
+const props = defineProps({
+    iconType: {
+        type: String,
+        required: true,
+    },
+    docType: {
+        type: String,
+        required: true,
+    },
+});
+</script>
+
+<template>
+    <div class="doc-type__label">
+        <i :class="`fa fa-${iconTypesDict[iconType]}`"></i>
+        {{ docType }}
+    </div>
+</template>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/__snapshots__/DocTypeLabel.test.js.snap
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/__snapshots__/DocTypeLabel.test.js.snap
@@ -1,0 +1,163 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Public/Private label > Renders a Private Label 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <div
+        class="doc-type__label"
+      >
+        <i
+          class="fa fa-undefined"
+        />
+         Internal 
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="doc-type__label"
+    >
+      <i
+        class="fa fa-undefined"
+      />
+       Internal 
+    </div>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Public/Private label > Renders a Public Label 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <div
+        class="doc-type__label"
+      >
+        <i
+          class="fa fa-undefined"
+        />
+         External 
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="doc-type__label"
+    >
+      <i
+        class="fa fa-undefined"
+      />
+       External 
+    </div>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/DocumentTypeSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/DocumentTypeSelector.vue
@@ -98,7 +98,7 @@ onUnmounted(() => window.removeEventListener("resize", onPopState));
                             class="ds-c-label"
                             :for="`choice-list--1__choice--${index}`"
                         >
-                            <span class="">{{ DOCUMENT_TYPES_MAP[type] }}</span>
+                            <span class="">{{ DOCUMENT_TYPES_MAP[type] }} Resources</span>
                         </label>
                     </div>
                 </div>

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -7,7 +7,6 @@ import _isEmpty from "lodash/isEmpty";
 import { formatDate } from "utilities/filters";
 import {
     getFileNameSuffix,
-    DOCUMENT_TYPES,
     DOCUMENT_TYPES_MAP,
 } from "utilities/utils";
 

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -5,9 +5,14 @@ import { useRoute } from "vue-router/composables";
 import _isEmpty from "lodash/isEmpty";
 
 import { formatDate } from "utilities/filters";
-import { getFileNameSuffix } from "utilities/utils";
+import {
+    getFileNameSuffix,
+    DOCUMENT_TYPES,
+    DOCUMENT_TYPES_MAP,
+} from "utilities/utils";
 
 import CategoryLabel from "sharedComponents/results-item-parts/CategoryLabel.vue";
+import DocTypeLabel from "sharedComponents/results-item-parts/DocTypeLabel.vue";
 import RelatedSections from "sharedComponents/results-item-parts/RelatedSections.vue";
 import ResultsItem from "sharedComponents/ResultsItem.vue";
 
@@ -38,7 +43,7 @@ const needsBar = (item) =>
     item.doc_name_string;
 
 const resultLinkClasses = (doc) => ({
-    "external": doc.resource_type === "external",
+    external: doc.resource_type === "external",
     "document__link--search": !!$route?.query?.q,
 });
 
@@ -79,6 +84,11 @@ const resultLinkLabel = (item) => {
             class="doc-list__document"
         >
             <template #labels>
+                <DocTypeLabel
+                    v-if="!_isEmpty(doc.resource_type)"
+                    :icon-type="doc.resource_type"
+                    :doc-type="DOCUMENT_TYPES_MAP[doc.resource_type]"
+                />
                 <CategoryLabel
                     v-if="!_isEmpty(doc.document_type)"
                     :name="doc.document_type.name"

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -26,8 +26,8 @@ const EventCodes = {
 
 const DOCUMENT_TYPES = ["external", "internal"];
 const DOCUMENT_TYPES_MAP = {
-    external: "Public Resources",
-    internal: "Internal Resources",
+    external: "Public",
+    internal: "Internal",
 }
 
 const PARAM_MAP = {


### PR DESCRIPTION
Resolves [EREGCSC-2371](https://jiraent.cms.gov/browse/EREGCSC-2371)

**Description**

Before the Category and SubCategory labels, we need to add a new label that indicates if a result is an Internal document or a Public document.

**This pull request changes:**

- adds new `DocTypeLabel` Vue component and related styles
- slightly amends `DOCUMENTS_TYPE_MAP` to exclude the "resources" suffix so that it is more portable

**Steps to manually verify this change:**

1. Visit policy repository on experimental deployment and add some filters
2. Public documents should have a "Public" label with a "users" icon
3. Internal documents should have an "Internal" label with a "key" icon
4. Make sure it reasonably matches the labels on [this Figma comp](https://www.figma.com/file/D6uem0JreimXr433ttqKwR/Doc-type-filtering?node-id=30%3A20928&mode=dev)

