### PR TITLE
EREGCSC-2372 -- Make item styling in repository more like combined search results

### DIFF
--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -271,8 +271,8 @@ describe("Policy Repository", () => {
 
         cy.get("input#subjectReduce")
             .should("exist")
-            .should("have.value", "")
-            .should("have.attr", "placeholder", "Filter the subject list")
+            .and("have.value", "")
+            .and("have.attr", "placeholder", "Filter the subject list")
             .type("21", { force: true });
         cy.get(`button[data-testid=clear-subject-filter]`).should("exist");
         cy.get("input#subjectReduce").should("have.value", "21");

--- a/solution/ui/regulations/css/scss/partials/_policy_repository.scss
+++ b/solution/ui/regulations/css/scss/partials/_policy_repository.scss
@@ -324,11 +324,11 @@
     .doc__list {
         .search-results-count {
             padding: 0 1rem;
+            margin-bottom: 2rem;
         }
 
         .doc-list__document {
-            padding: 0.75rem 1rem;
-            border-bottom: 1px solid $border_color;
+            padding: 0 1rem;
             position: relative;
 
             a.edit-button {

--- a/solution/ui/regulations/css/scss/partials/_policy_repository.scss
+++ b/solution/ui/regulations/css/scss/partials/_policy_repository.scss
@@ -349,12 +349,12 @@
                     display: block;
                 }
 
-                &--view {
-                    font-size: $font-size-sm;
-                }
-
                 &--search {
                     font-weight: 400;
+                }
+
+                &--view {
+                    font-size: $font-size-sm;
                 }
             }
 

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -128,16 +128,14 @@ const resultLinkLabel = (item) => {
                 >
             </template>
             <template #link>
-                <h3>
-                    <a
-                        :href="getUrl(doc)"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="document__link document__link--filename"
-                        :class="resultLinkClasses(doc)"
-                        v-html="resultLinkLabel(doc)"
-                    ></a>
-                </h3>
+                <a
+                    :href="getUrl(doc)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="document__link document__link--filename"
+                    :class="resultLinkClasses(doc)"
+                    v-html="resultLinkLabel(doc)"
+                ></a>
             </template>
             <template #snippet>
                 <div


### PR DESCRIPTION
Resolves [EREGCSC-2372](https://jiraent.cms.gov/browse/EREGCSC-2372)

**Description**

Small style changes to tweak the look of Policy Repository result items

**This pull request changes:**

- Remove `h3`
- Small stype tweaks
- use `and` alias in e2e test when chaining `should`s after first `should`

**Steps to manually verify this change:**

1. Visit experimental deployment
2. Make sure the changes outlined in [JIRA story](https://jiraent.cms.gov/browse/EREGCSC-2372) match the associated styles in the [Figma comp](https://www.figma.com/file/cKtR3bsPaVXFs6qfE64FZm/Usability-test?node-id=58%3A31465&mode=dev)

