### PR TITLE
hotfix - max words limit

### DIFF
--- a/solution/backend/content_search/models.py
+++ b/solution/backend/content_search/models.py
@@ -42,7 +42,7 @@ class ContentIndexQuerySet(models.QuerySet):
                 start_sel='<span class="search-highlight">',
                 stop_sel='</span>',
                 min_words=50,
-                max_words=400,
+                max_words=51,
                 config='english',
                 fragment_delimiter='...'
             ),
@@ -62,7 +62,7 @@ class ContentIndexQuerySet(models.QuerySet):
                 stop_sel="</span>",
                 config='english',
                 min_words=50,
-                max_words=400,
+                max_words=51,
                 fragment_delimiter='...'
             ),
         ).order_by('-rank')


### PR DESCRIPTION
Resolves # Hotfix- max words up to 400!

**Description-**

Max words is at 400 right now.  Needs to be less.  lowering max words to 51.  Max has to be more than min which is 50.

**This pull request changes...**

- Lowers max words from 400 to 51.

**Steps to manually verify this change...**

1. https://pv4sk34lu6.execute-api.us-east-1.amazonaws.com/dev1080/policy-repository?q=covid no long descriptions will appear.
2. https://pv4sk34lu6.execute-api.us-east-1.amazonaws.com/dev1080/policy-repository?q=document no long snippets will appear.

