### PR TITLE
EREGCSC-2267 Sanitize filenames

### DIFF
--- a/solution/backend/file_manager/admin.py
+++ b/solution/backend/file_manager/admin.py
@@ -59,7 +59,7 @@ class UploadedFileAdmin(BaseAdmin):
         path = form.cleaned_data.get("file_path")
         if path:
             file_name, extension = path._name.split('.')
-            obj.file_name = f"{slugify(file_name).replace('-', ' ')}.{extension}"
+            obj.file_name = f"{slugify(file_name)}.{extension}"
             self.upload_file(path, obj)
         super().save_model(request, obj, form, change)
 

--- a/solution/backend/file_manager/admin.py
+++ b/solution/backend/file_manager/admin.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.text import slugify
 
 from common.functions import establish_client
 from content_search.functions import add_to_index
@@ -54,16 +55,11 @@ class UploadedFileAdmin(BaseAdmin):
         "subjects": lambda: Subject.objects.all()
     }
 
-    # Will remove any characters from file names we do not want in it.
-    # Commas in file names causes issues in chrome on downloads since we rename the file.
-    def clean_file_name(self, name):
-        name = name.replace(',', '')
-        return name
-
     def save_model(self, request, obj, form, change):
         path = form.cleaned_data.get("file_path")
         if path:
-            obj.file_name = self.clean_file_name(path._name)
+            file_name, extension = path._name.split('.')
+            obj.file_name = f"{slugify(file_name).replace('-', ' ')}.{extension}"
             self.upload_file(path, obj)
         super().save_model(request, obj, form, change)
 


### PR DESCRIPTION
Resolves # EREGCSC-2267 Sanitize file names

**Description-**

We want to make sure filenames dont have weird characters in it.  Before we only did commas but now we are just adding a slew of them
**This pull request changes...**

- Use djangos slugify to clean out characters. https://docs.djangoproject.com/en/4.2/ref/utils/#django.utils.text.slugify

**Steps to manually verify this change...**

1. Log into the admin panel.
2. Upload a file with a bunch of weird characters. Quotes, underscores, hyphens etc.
3. Characters will be cleaned out after saving.  Should be mostly alphanumeric.

