### PR TITLE
Extractor conditonal deploy

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -80,7 +80,7 @@ jobs:
       deployextractor: false
     runs-on: ubuntu-20.04
     # Change to true if you want to create text extractor for your experimental deploy.
-    if: false
+    if: true
     steps:
       # Checkout the code
       - name: Checkout

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -81,7 +81,7 @@ jobs:
       deployextractor: false
     runs-on: ubuntu-20.04
     # Change to true if you want to create text extractor for your experimental deploy.
-    if: true
+    if: false
     steps:
       # Checkout the code
       - name: Checkout
@@ -119,7 +119,7 @@ jobs:
     outputs:
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
     runs-on: ubuntu-20.04
-    needs: [deploy-static, deploy-text-extractor]
+    needs: [deploy-static] #[deploy-static, deploy-text-extractor]
     steps:
       # Checkout the code
       - name: Checkout

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  DEPLOY_TEXT_EXTRACTOR: true
+
 permissions:
   id-token: write
   contents: read
@@ -80,7 +83,7 @@ jobs:
       deployextractor: false
     runs-on: ubuntu-20.04
     # Change to true if you want to create text extractor for your experimental deploy.
-    if: true
+    if: $DEPLOY_TEXT_EXTRACTOR
     steps:
       # Checkout the code
       - name: Checkout

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -73,41 +73,44 @@ jobs:
           npm install
           serverless deploy --stage dev${PR}
           popd
-  # deploy-text-extractor:
-  #   environment:
-  #     name: "dev"
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     # Checkout the code
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: true
-  #     # Find the PR number.  This is not always trivial which is why this uses an existign action
-  #     - name: Find PR number
-  #       uses: jwalton/gh-find-current-pr@v1
-  #       id: findPr
-  #       with:
-  #         # Can be "open", "closed", or "all".  Defaults to "open".
-  #         state: open
-  #     # Configure AWS credentials for GitHub Actions
-  #     - name: Configure AWS credentials for GitHub Actions
-  #       uses: aws-actions/configure-aws-credentials@v2
-  #       with:
-  #         role-to-assume: $#{{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
-  #         aws-region: us-east-1
-  #     # Deploy the text extractor lambda to AWS
-  #     - name: Deploy text extractor lambda
-  #       id: deploy-text-extractor
-  #       i#f: success() && steps.findPr.outputs.number
-  #       env:
-  #         PR: $#{{ steps.findPr.outputs.pr }}
-  #         RUN_ID: $#{{ github.run_id }}
-  #       run: |
-  #         pushd solution/text-extractor
-  #         npm install serverless -g
-  #         serverless deploy --stage dev${PR}
-  #         popd
+  deploy-text-extractor:
+    environment:
+      name: "dev"
+    env:
+      deployextractor: false
+    runs-on: ubuntu-20.04
+    if: false
+    steps:
+      # Checkout the code
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      # Find the PR number.  This is not always trivial which is why this uses an existign action
+      - name: Find PR number
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        with:
+          # Can be "open", "closed", or "all".  Defaults to "open".
+          state: open
+      # Configure AWS credentials for GitHub Actions
+      - name: Configure AWS credentials for GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: $#{{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+      # Deploy the text extractor lambda to AWS
+      - name: Deploy text extractor lambda
+        id: deploy-text-extractor
+        if: success() && steps.findPr.outputs.number
+        env:
+          PR: ${{ steps.findPr.outputs.pr }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          pushd solution/text-extractor
+          npm install serverless -g
+          serverless deploy --stage dev${PR}
+          popd
   deploy-django:
     environment:
       name: "dev"

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: $#{{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1
       # Deploy the text extractor lambda to AWS
       - name: Deploy text extractor lambda

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -79,6 +79,7 @@ jobs:
     env:
       deployextractor: false
     runs-on: ubuntu-20.04
+    # Change to true if you want to create text extractor for your experimental deploy.
     if: false
     steps:
       # Checkout the code
@@ -117,7 +118,7 @@ jobs:
     outputs:
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
     runs-on: ubuntu-20.04
-    needs: [deploy-static, ] #[deploy-static, deploy-text-extractor]
+    needs: [deploy-static, deploy-text-extractor]
     steps:
       # Checkout the code
       - name: Checkout

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-env:
-  DEPLOY_TEXT_EXTRACTOR: true
 
 permissions:
   id-token: write
@@ -83,7 +81,7 @@ jobs:
       deployextractor: false
     runs-on: ubuntu-20.04
     # Change to true if you want to create text extractor for your experimental deploy.
-    if: $DEPLOY_TEXT_EXTRACTOR
+    if: true
     steps:
       # Checkout the code
       - name: Checkout

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -70,18 +70,20 @@ jobs:
           serverless invoke --config ./serverless-experimental.yml --function drop_database --stage dev${PR}
           ~/work/cmcs-eregulations/cmcs-eregulations/.github/workflows/delete_cloudformation_stacks.sh cmcs-eregs-site-dev${PR} $PR "./serverless-experimental.yml"
           popd
-      # - name: remove text-extractor lambda
-      #   env:
-          # PR: $#{{ github.event.number }}
-      #     RUN_ID: $#{{ github.run_id }}
-      #   run: |
-      #     pushd solution/text-extractor
-      #     npm install serverless -g
-      #     npm install
-      #     serverless remove --stage dev${PR}
-      #     popd
+      - name: remove text-extractor lambda
+        if: success() || failure()
+        env:
+          PR: ${{ github.event.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          pushd solution/text-extractor
+          npm install serverless -g
+          npm install
+          serverless remove --stage dev${PR}
+          popd
       # Remove the static assets
       - name: remove static assets
+        if: success() || failure()
         env:
           PR: ${{ github.event.number }}
           RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -64,7 +64,6 @@ jobs:
         run: |
           pushd solution/backend
           npm install serverless -g
-          npm install
           serverless invoke --config ./serverless-experimental.yml --function empty_bucket --stage dev${PR}
           # remove the database if its there.
           serverless invoke --config ./serverless-experimental.yml --function drop_database --stage dev${PR}
@@ -78,7 +77,6 @@ jobs:
         run: |
           pushd solution/text-extractor
           npm install serverless -g
-          npm install
           serverless remove --stage dev${PR}
           popd
       # Remove the static assets

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -47,8 +47,9 @@ provider:
     OIDC_OP_USER_ENDPOINT: ${ssm:/eregulations/oidc/user_endpoint}
     DEPLOY_NUMBER: ${env:RUN_ID}
     EUA_FEATUREFLAG: ${ssm:/eregulations/eua/featureflag}
-    # Used for when you want to deploy your own
+    # This text extractor is for an experimental deploy if one is made.
     TEXT_EXTRACTOR_ARN: ${self:custom.settings.text_extractor_arn}
+    # This text extractor is the "main dev" extractor.  Used if one is not created in experimental.
     TEXTRACT_ARN: ${ssm:/eregulations/textextractor-arn}
   vpc:
     securityGroupIds:

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -192,7 +192,7 @@ resources:
                      - "lambda:InvokeFunction"
                    Resource:
                      - "${ssm:/eregulations/textextractor-arn}"
-                     - "${self:custom.settings.text_extractor_arn}" # Extractor created by the environment
+                     - "${opt:${self:custom.settings.text_extractor_arn, ${ssm:/eregulations/textextractor-arn}}" # Extractor created by the environment
 
 
 plugins:

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -192,7 +192,7 @@ resources:
                      - "lambda:InvokeFunction"
                    Resource:
                      - "${ssm:/eregulations/textextractor-arn}"
-                     - "${opt:${self:custom.settings.text_extractor_arn}, ${ssm:/eregulations/textextractor-arn}}" # Extractor created by the environment
+                     - ${opt:"${self:custom.settings.text_extractor_arn}", "${ssm:/eregulations/textextractor-arn}"} # Extractor created by the environment
 
 
 plugins:

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -48,7 +48,7 @@ provider:
     DEPLOY_NUMBER: ${env:RUN_ID}
     EUA_FEATUREFLAG: ${ssm:/eregulations/eua/featureflag}
     # Used for when you want to deploy your own
-    # TEXT_EXTRACTOR_ARN: ${self:custom.settings.text_extractor_arn}
+    TEXT_EXTRACTOR_ARN: ${self:custom.settings.text_extractor_arn}
     TEXTRACT_ARN: ${ssm:/eregulations/textextractor-arn}
   vpc:
     securityGroupIds:
@@ -82,7 +82,7 @@ custom:
     DB_NAME: ${self:custom.stage}
     USERNAME: eregsuser
     ALLOWED_HOST: '.amazonaws.com'
-    # text_extractor_arn: ${cf:text-extractor-${self:custom.stage}.TextDashextractorLambdaFunctionQualifiedArn}
+    text_extractor_arn: ${cf:text-extractor-${self:custom.stage}.TextDashextractorLambdaFunctionQualifiedArn}
   cloudfrontInvalidate:
     - distributionId: ${cf:cmcs-eregs-static-assets-${self:custom.stage}.CloudFrontDistributionId}
       items:
@@ -192,7 +192,7 @@ resources:
                      - "lambda:InvokeFunction"
                    Resource:
                      - "${ssm:/eregulations/textextractor-arn}"
-                    #  - "${self:custom.settings.text_extractor_arn}" # Extractor created by the environment
+                     - "${self:custom.settings.text_extractor_arn}" # Extractor created by the environment
 
 
 plugins:

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -82,7 +82,7 @@ custom:
     DB_NAME: ${self:custom.stage}
     USERNAME: eregsuser
     ALLOWED_HOST: '.amazonaws.com'
-    text_extractor_arn: ${cf:text-extractor-${self:custom.stage}.TextDashextractorLambdaFunctionQualifiedArn}
+    text_extractor_arn: ${opt:cf:text-extractor-${self:custom.stage}.TextDashextractorLambdaFunctionQualifiedArn, ''}
   cloudfrontInvalidate:
     - distributionId: ${cf:cmcs-eregs-static-assets-${self:custom.stage}.CloudFrontDistributionId}
       items:

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -192,7 +192,7 @@ resources:
                      - "lambda:InvokeFunction"
                    Resource:
                      - "${ssm:/eregulations/textextractor-arn}"
-                     - "${opt:${self:custom.settings.text_extractor_arn, ${ssm:/eregulations/textextractor-arn}}" # Extractor created by the environment
+                     - "${opt:${self:custom.settings.text_extractor_arn}, ${ssm:/eregulations/textextractor-arn}}" # Extractor created by the environment
 
 
 plugins:


### PR DESCRIPTION
Resolves # None.  An idea I came up with

**Description-**
Its very annoying working with the text extractor.  Commenting and uncommenting out code on deploy is tedious and just awful.  A much simpler solution is to have a conditional on a github action that determines if it should run.  
On line 84 on deploy-experimental it just has if: false. Change it to if: true if you want a text extractor.
Then on line 122 change the needs to be the commented out portion.  Needs cant actually be a conditional. Thanks github.


**Steps to manually verify this change...**

1. The intieal deployment deploys sucessfully.
2. Change the deploy to true for deploying the text extractor on line 84 and on 122 change it to needs: [deploy-static, deploy-text-extractor]
3. A text extractor will deploy to the experimental.
4. Closing the PR will conditionally delete the text extractor based on if one exist.

Notes.  Once a text extractor is deployed you can no longer revert back without closing the PR.  The way cloud formation looks up the extractor arn, it will find it until the extractor is deleted in aws.

