### PR TITLE
install findutils that installs xargs

### DIFF
--- a/solution/text-extractor/Dockerfile
+++ b/solution/text-extractor/Dockerfile
@@ -15,6 +15,9 @@ RUN pip install -r /proxy/requirements.txt
 # Will be overridden locally
 COPY text-extractor ${LAMBDA_TASK_ROOT}/app
 
+# Install findutils which provides xargs
+RUN yum install -y findutils
+
 # Install binary dependencies
 RUN xargs yum install -y < app/packages.txt
 


### PR DESCRIPTION
Resolves #textract Dockerfile bug

**Description-**
Currently on prod textract dockerfile is failing with this error:
ERROR: failed to solve: process "/bin/sh -c xargs yum install -y < app/packages.txt" did not complete successfully: exit code: 127

Solution: Install findutils which installs xargs
**This pull request changes...**

- expected change 1
solution/text-extractor/Dockerfile

**Steps to manually verify this change...**

see if it deploys to dev. 

