### PR TITLE
Textract ARN hotfix

### DIFF
--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -229,7 +229,8 @@ USE_LOCAL_TEXTRACT = False
 # The first text extractor is if it was created by serverless.  If it wasnt then it will use the
 # text extractor who's arn you provide in the docker file.
 
-TEXTRACT_ARN = os.environ.get("TEXT_EXTRACTOR_ARN", os.environ.get('TEXTRACT_ARN', '')) # noqa
+TEXT_EXTRACTOR_ARN = os.environ.get("TEXT_EXTRACTOR_ARN", '')
+TEXTRACT_ARN = os.environ.get('TEXTRACT_ARN', '')
 
 CORS_ALLOWED_ORIGINS = [
     "http://localhost:8081",

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -183,8 +183,12 @@ class InvokeTextExtractorViewset(APIView):
             )
             resp.raise_for_status()
         else:
+            if settings.TEXT_EXTRACTOR_ARN:
+                textract_arn = settings.TEXT_EXTRACTOR_ARN
+            else:
+                textract_arn = settings.TEXTRACT_ARN
             lambda_client = establish_client('lambda')
-            resp = lambda_client.invoke(FunctionName=settings.TEXTRACT_ARN,
+            resp = lambda_client.invoke(FunctionName=textract_arn,
                                         InvocationType='Event',
                                         Payload=json.dumps(json_object))
         return Response(data={'response': resp})


### PR DESCRIPTION
Resolves # Textract ARN not being picked up properly

**Description-**
The default for textract arn should be dev unless one is being created by the environment.  The conditional for working on it is changed to pull in both at deployent
**This pull request changes...**

The logic for the textextractor arn being pulled in correctly.  Now it pulls both so it will just check if the value is blank or not.

- Default of using textetractor for dev works fine.

**Steps to manually verify this change...**

1. Upload a file into the s3 bucket through the admin page. https://sif8c3kmp9.execute-api.us-east-1.amazonaws.com/dev1103/admin/
2. Get content of the file. 
3. Should use the dev text extractor.
