### PR TITLE
EREGCSC-2267 sanitize file names

### DIFF
--- a/solution/backend/file_manager/admin.py
+++ b/solution/backend/file_manager/admin.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.text import slugify
 
 from common.functions import establish_client
 from content_search.functions import add_to_index

--- a/solution/backend/file_manager/admin.py
+++ b/solution/backend/file_manager/admin.py
@@ -79,8 +79,6 @@ class UploadedFileAdmin(BaseAdmin):
     def save_related(self, request, form, formsets, change):
         super().save_related(request, form, formsets, change)
         add_to_index(form.instance)
-    # Will remove any characters from file names we do not want in it.
-    # Commas in file names causes issues in chrome on downloads since we rename the file.
 
     def upload_file(self, file, obj):
         key = obj.get_key()

--- a/solution/backend/file_manager/tests/test_admin.py
+++ b/solution/backend/file_manager/tests/test_admin.py
@@ -12,4 +12,3 @@ def test_extension():
     file_name = "random:;/!? .xls"
     clean_name = admin.clean_file_name('', file_name)
     assert clean_name == 'random.xls'
-

--- a/solution/backend/file_manager/tests/test_admin.py
+++ b/solution/backend/file_manager/tests/test_admin.py
@@ -1,0 +1,15 @@
+from file_manager.admin import UploadedFileAdmin
+
+
+def test_extension():
+    file_name = 'blah.txt'
+    admin = UploadedFileAdmin
+    clean_name = admin.clean_file_name('', file_name)
+    file_name = 'weird name with "quotations".doc'
+    assert clean_name == 'blah.txt'
+    clean_name = admin.clean_file_name('', file_name)
+    assert clean_name == 'weird name with quotations.doc'
+    file_name = "random:;/!? .xls"
+    clean_name = admin.clean_file_name('', file_name)
+    assert clean_name == 'random.xls'
+


### PR DESCRIPTION
Resolves # EREGCSC-2267

**Description-**

Sanitize file names was working a little  weird with the django library in place so we are doing a more custom solution.

Certain characters will be removed from file names on a small list.  This is similar to the previous method we used.
**This pull request changes...**

- File name sanitation

**Steps to manually verify this change...**

1. Upload a file name with 'bad' characters to the file repository.  Try things like semicolons, exclamation points, *, ?, commas.  windows doesnt let you put these in there.  Try with any of the characters in this list. ";", "!", "?", "*", ":", ",", '"', '“', "'", r'/', '\\', '-'

After uploading the file on upload it will remove those characters in the file name.

new unit test pass.