### PR TITLE
EREGCSC-2416 - Secret cleanup test

### DIFF
--- a/.github/workflows/snyk-test.yml
+++ b/.github/workflows/snyk-test.yml
@@ -1,6 +1,8 @@
 name: Snyk Scan and Report
 
 on:
+  push:
+    branches: [ secretCleanupTest ]
   pull_request:
     branches: [ main ]
   schedule:
@@ -13,7 +15,7 @@ jobs:
   snyk_run:
     name: Snyk Run (for PR)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     
     steps:
       - name: Check out repository
@@ -30,7 +32,7 @@ jobs:
   snyk_nightly_run:  
       name: Snyk Nightly Run (for nightly cron with JIRA)
       runs-on: ubuntu-latest
-      if: github.event_name == 'schedule'
+      if: github.event_name == 'push'
       steps:
         - name: Check out repository
           uses: actions/checkout@v3
@@ -45,7 +47,7 @@ jobs:
         - name: use the custom github  action to parse Snyk output
           uses: Enterprise-CMCS/macfc-security-scan-report@v2.7.4
           with:
-              jira-token: ${{ secrets.JIRA_TOKEN_FOR_SNYK}}
+              jira-token: ${{ secrets.JIRA_TOKEN}}
               jira-host: ${{ secrets.JIRA_HOST }}
               jira-project-key: 'EREGCSC'
               jira-issue-type: 'Bug'

--- a/.github/workflows/snyk-test.yml
+++ b/.github/workflows/snyk-test.yml
@@ -1,8 +1,6 @@
 name: Snyk Scan and Report
 
 on:
-  push:
-    branches: [ secretCleanupTest ]
   pull_request:
     branches: [ main ]
   schedule:
@@ -15,7 +13,7 @@ jobs:
   snyk_run:
     name: Snyk Run (for PR)
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     
     steps:
       - name: Check out repository
@@ -32,7 +30,7 @@ jobs:
   snyk_nightly_run:  
       name: Snyk Nightly Run (for nightly cron with JIRA)
       runs-on: ubuntu-latest
-      if: github.event_name == 'push'
+      if: github.event_name == 'schedule'
       steps:
         - name: Check out repository
           uses: actions/checkout@v3

--- a/SnykReadMe.md
+++ b/SnykReadMe.md
@@ -101,7 +101,7 @@ snyk_nightly_run:
           uses: Enterprise-CMCS/macfc-security-scan-report@v2.7.4
           with:
               jira-token: ${{ secrets.JIRA_TOKEN }}
-              jira-host: ${{ secrets.JIRA_HOST_NAME }}
+              jira-host: ${{ secrets.JIRA_HOST }}
               jira-project-key: 'EREGCSC'
               jira-issue-type: 'Bug'
               jira-labels: 'eRegs,snyk'

--- a/SnykReadMe.md
+++ b/SnykReadMe.md
@@ -24,14 +24,13 @@ Create JIRA Service account by following the instruction here: https://confluenc
 
 GitHub Service account by following the instruction here: https://confluenceent.cms.gov/pages/viewpage.action?spaceKey=MDSO&title=GitHub+Guide
 
-Once the jira service account is created, you will be provided the Username and Password. Then login to jira with that account, go to the upper right where the account icon is and click it. Then click "Profile" and the profile page should load up. Then on the left, there is a navigation bar where you click "Personal Access Tokens". On the left side, there is a blue "Create token" button that you click. Then provide a unique token name and also decide if you want auto expiry or never expires. Then you can also choose how long before the token expires. Then click "create". Then a page loads with the secret value that you should copy and then hit next. Now you have the authentication token and username.
+Once the jira service account is created, you will be provided the Username and Password. Then login to jira with that account, go to the upper right where the account icon is and click it. Then click "Profile" and the profile page should load up. Then on the left, there is a navigation bar where you click "Personal Access Tokens". On the left side, there is a blue "Create token" button that you click. Then provide a unique token name and also decide if you want auto expiry or never expires. Then you can also choose how long before the token expires. Then click "create". Then a page loads with the secret value that you should copy and then hit next. Now you have the authentication token.
 
-Go back to github and go to the secrets page and create secrets to store the Jira Username, Personal Access Token, and Jira Host name. The Username is the service account ID, the PAT is the token just created in the last step, and the Host name is the first part of the jira url up to ".gov" without the "https://". For example, the homepage URL for eRegs Jira is "https://jiraent.cms.gov/projects/EREGCSC/summary". However, the host name is just "jiraent.cms.gov". Below is the variables and their descriptions:
+Go back to github and go to the secrets page and create secrets to store the Personal Access Token and Jira Host name. The PAT is the token just created in the last step, and the Host name is the first part of the jira url up to ".gov" without the "https://". For example, the homepage URL for eRegs Jira is "https://jiraent.cms.gov/projects/EREGCSC/summary". However, the host name is just "jiraent.cms.gov". Below is the variables and their descriptions:
 
 ```
-    jira-username: This secret needs to hold the email address of the Jira Service Account.
-    jira-token: This secret needs to hold the PAT value of the Jira Service Account.
-    jira-host: The Jira Domain- EX. "jirarent.cms.gov".
+    JIRA_TOKEN: This secret needs to hold the PAT value of the Jira Service Account.
+    JIRA_HOST: The Jira Domain- EX. "jirarent.cms.gov".
 ```
 
 # Current Implementation
@@ -76,7 +75,7 @@ snyk_run:
 
 The last section is for the cron job. This is activated at the time specified above and then runs the snyk scan again. If there are still findings, there is a bug created in jira as shown with the action call at the end. This allows there to be bugs in a pull request and allows the day to get them fixed. If there is no fix made, then the bug is created to notify the user of the issue. 
 The variables for ticket creation that can be modified are as follows: 
--	Username, token, host, project-key, and is_jira_enterprise should NOT be touched. They are static for this project.
+-	Token, host, project-key, and is_jira_enterprise should NOT be touched. They are static for this project.
 -	Jira-issue-type: this is set to bug since most of the issues found will fall under that. However, this can be changed to any type of work item be it a user story, task, etc.
 -	Jira-labels: This can be anything you want. It was set to eRegs and snyk to denote all of these bugs as  belonging to the eRegs project and from the snyk scan.
 -	Jira-title-prefix: This is the prefix given to the ticket name so that it is also easily identifiable as a snyk bug. This can also be changed to anything.
@@ -99,10 +98,9 @@ snyk_nightly_run:
             SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           
         - name: use the custom github  action to parse Snyk output
-          uses: Enterprise-CMCS/macfc-security-scan-report@v2.7.0
+          uses: Enterprise-CMCS/macfc-security-scan-report@v2.7.4
           with:
-              jira-username: ${{ secrets.JIRA_USERNAME }}
-              jira-token: ${{ secrets.JIRA_TOKEN_AT }}
+              jira-token: ${{ secrets.JIRA_TOKEN }}
               jira-host: ${{ secrets.JIRA_HOST_NAME }}
               jira-project-key: 'EREGCSC'
               jira-issue-type: 'Bug'


### PR DESCRIPTION
Resolves #[EREGCSC-2416](https://jiraent.cms.gov/browse/EREGCSC-2416)

**Description-**
Just finishing off the secret cleanup effort by updating the Snyk Workflow to use the same JIRA variables as the SecHub Workflow so that there can be less Jira secrets in all the environments as well as in the general section.

**This pull request changes...**
the Snyk workflow to reflect the secret name changes as well as the Snyk ReadMe to do the same.

**Steps to manually verify this change...**
Verify in the Snyk workflow that the jira token name was changed from JIRA_TOKEN_FOR_SNYK to JIRA_TOKEN.

In the Readme, Verify the same name change for the token and also the HOST secret name was changed to JIRA_HOST. Also the Username references were removed as Username is no longer used.

