### PR TITLE
EREGCSC-2410 -- Updated snippet ellipses logic

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -81,7 +81,7 @@ jobs:
       deployextractor: false
     runs-on: ubuntu-20.04
     # Change to true if you want to create text extractor for your experimental deploy.
-    if: false
+    if: true
     steps:
       # Checkout the code
       - name: Checkout

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -81,7 +81,7 @@ jobs:
       deployextractor: false
     runs-on: ubuntu-20.04
     # Change to true if you want to create text extractor for your experimental deploy.
-    if: true
+    if: false
     steps:
       # Checkout the code
       - name: Checkout

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.test.js
@@ -100,7 +100,7 @@ describe("getResultLinkText", () => {
 describe("getResultSnippet", () => {
     it("is internal and has a summary_headline", async () => {
         expect(PolicyResults.getResultSnippet(MOCK_RESULTS[1])).toBe(
-            "...this is a summary headline..."
+            "this is a summary headline"
         );
     });
     it("is internal and does NOT have a summary_headline or _string, but has a content_headline", async () => {

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.test.js
@@ -6,12 +6,12 @@ const MOCK_RESULTS = [
     {
         resource_type: "internal",
         doc_name_string: "this is a document name string",
-        document_name_headline: "this is a document name headline",
+        document_name_headline: "this <span class='search-highlight'>is</span> a document name headline",
         summary_string: null,
         summary_headline: null,
         file_name_string: "index_zero.docx",
         content_string: "this is a content string",
-        content_headline: "this is a content headline",
+        content_headline: "this <span class='search-highlight'>is</span> a content headline",
         url: "url",
     },
     {
@@ -19,10 +19,10 @@ const MOCK_RESULTS = [
         doc_name_string: "this is a document name string",
         document_name_headline: "this is a document name headline",
         summary_string: "this is a summary string",
-        summary_headline: "this is a summary headline",
+        summary_headline: "this <span class='search-highlight'>is</span> a summary headline",
         file_name_string: "index_one.docx",
         content_string: "this is a content string",
-        content_headline: "this is a content headline",
+        content_headline: "this <span class='search-highlight'>is</span> a content headline",
         url: "url",
     },
     {
@@ -37,10 +37,10 @@ const MOCK_RESULTS = [
     {
         resource_type: "external",
         summary_string: "this is a summary string",
-        summary_headline: "this is a summary headline",
+        summary_headline: "this <span class='search-highlight'>is</span> a summary headline",
         file_name_string: "index_three.docx",
         content_string: "this is a content string",
-        content_headline: "this is a content headline",
+        content_headline: "this <span class='search-highlight'>is</span> a content headline",
         url: "url",
     },
     {
@@ -55,7 +55,7 @@ const MOCK_RESULTS = [
     {
         resource_type: "external",
         summary_string: "this is a summary string",
-        summary_headline: "this is a summary headline",
+        summary_headline: "this <span class='search-highlight'>is</span> a summary headline",
         file_name_string: "index_five.docx",
         url: "url",
     },
@@ -67,10 +67,37 @@ const MOCK_RESULTS = [
         summary_headline: null,
         file_name_string: "index_six.docx",
         content_string: "this is a content string",
+        content_headline: "this <span class='search-highlight'>is</span> a content headline",
+        url: "url",
+    },
+    {
+        resource_type: "internal",
+        doc_name_string: "this is a document name string",
+        document_name_headline: "this is a document name headline",
+        summary_string: "this is a summary string",
+        summary_headline: "this is a summary headline",
+        file_name_string: "index_seven.docx",
+        content_string: "this is a content string",
         content_headline: "this is a content headline",
         url: "url",
     },
 ];
+
+describe("addSurroundingEllipses", () => {
+    it("adds ellipses to the beginning and end of a string", async () => {
+        expect(
+            PolicyResults.addSurroundingEllipses(
+                "this <span class='search-highlight'>is</span> a string"
+            )
+        ).toBe("...this <span class='search-highlight'>is</span> a string...");
+    });
+
+    it("does NOT add ellipses to the beginning and end of a string", async () => {
+        expect(PolicyResults.addSurroundingEllipses("this is a string")).toBe(
+            "this is a string"
+        );
+    });
+});
 
 describe("getFileTypeButton", () => {
     it("is a DOCX file", async () => {
@@ -97,7 +124,7 @@ describe("getResultLinkText", () => {
     });
     it("is external and has a summary_headline", async () => {
         expect(PolicyResults.getResultLinkText(MOCK_RESULTS[3])).toBe(
-            "<span class='result__link--label'>this is a summary headline</span>"
+            "<span class='result__link--label'>this <span class='search-highlight'>is</span> a summary headline</span>"
         );
     });
     it("is external and does NOT have a summary_headline", async () => {
@@ -108,9 +135,14 @@ describe("getResultLinkText", () => {
 });
 
 describe("getResultSnippet", () => {
-    it("is internal and has a summary_headline", async () => {
+    it("is internal and has a summary_headline with a search result", async () => {
         expect(PolicyResults.getResultSnippet(MOCK_RESULTS[1])).toBe(
-            "...this is a summary headline..."
+            "...this <span class='search-highlight'>is</span> a summary headline..."
+        );
+    });
+    it("is internal and has a summary_headline WITHOUT a search result", async () => {
+        expect(PolicyResults.getResultSnippet(MOCK_RESULTS[7])).toBe(
+            "this is a summary headline"
         );
     });
     it("is internal and has a summary_string but NOT a summary_headline", async () => {
@@ -118,9 +150,9 @@ describe("getResultSnippet", () => {
             "this is a summary string"
         );
     });
-    it("is internal and does NOT have a summary_headline or _string, but has a content_headline", async () => {
+    it("is internal and does NOT have a summary_headline or _string, but has a content_headline with a search result", async () => {
         expect(PolicyResults.getResultSnippet(MOCK_RESULTS[0])).toBe(
-            "...this is a content headline..."
+            "...this <span class='search-highlight'>is</span> a content headline..."
         );
     });
 });

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.test.js
@@ -1,4 +1,3 @@
-import { render } from "@testing-library/vue";
 import { describe, it, expect } from "vitest";
 
 import PolicyResults from "./PolicyResults.vue";
@@ -60,6 +59,17 @@ const MOCK_RESULTS = [
         file_name_string: "index_five.docx",
         url: "url",
     },
+    {
+        resource_type: "internal",
+        doc_name_string: "this is a document name string",
+        document_name_headline: "this is a document name headline",
+        summary_string: "this is a summary string",
+        summary_headline: null,
+        file_name_string: "index_six.docx",
+        content_string: "this is a content string",
+        content_headline: "this is a content headline",
+        url: "url",
+    },
 ];
 
 describe("getFileTypeButton", () => {
@@ -100,7 +110,12 @@ describe("getResultLinkText", () => {
 describe("getResultSnippet", () => {
     it("is internal and has a summary_headline", async () => {
         expect(PolicyResults.getResultSnippet(MOCK_RESULTS[1])).toBe(
-            "this is a summary headline"
+            "...this is a summary headline..."
+        );
+    });
+    it("is internal and has a summary_string but NOT a summary_headline", async () => {
+        expect(PolicyResults.getResultSnippet(MOCK_RESULTS[6])).toBe(
+            "this is a summary string"
         );
     });
     it("is internal and does NOT have a summary_headline or _string, but has a content_headline", async () => {

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -14,6 +14,14 @@ import ResultsItem from "sharedComponents/ResultsItem.vue";
 
 import SubjectChips from "./SubjectChips.vue";
 
+const addSurroundingEllipses = (str) => {
+    if (!str) return "";
+
+    if (str.includes("search-highlight")) return `...${str}...`;
+
+    return str;
+};
+
 const getResultLinkText = (item) => {
     let linkText;
     if (item.resource_type === "internal") {
@@ -55,11 +63,11 @@ const getResultSnippet = (item) => {
 
     if (item.resource_type === "internal") {
         if (item.summary_headline) {
-            snippet = `...${item.summary_headline}...`;
+            snippet = addSurroundingEllipses(item.summary_headline);
         } else if (item.summary_string) {
             snippet = item.summary_string;
         } else if (item.content_headline) {
-            snippet = `...${item.content_headline}...`;
+            snippet = addSurroundingEllipses(item.content_headline);
         }
 
         return snippet;
@@ -67,7 +75,7 @@ const getResultSnippet = (item) => {
 
     if (item.resource_type === "external") {
         if (item.content_headline) {
-            snippet = `...${item.content_headline}...`;
+            snippet = addSurroundingEllipses(item.content_headline);
         } else if (item.content_string) {
             snippet = item.content_string;
         }
@@ -77,6 +85,7 @@ const getResultSnippet = (item) => {
 };
 
 export default {
+    addSurroundingEllipses,
     getFileTypeButton,
     getResultLinkText,
     getResultSnippet,

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -52,16 +52,26 @@ const showResultSnippet = (item) => {
 
 const getResultSnippet = (item) => {
     let snippet;
+
     if (item.resource_type === "internal") {
-        snippet =
-            item.summary_headline ||
-            item.summary_string ||
-            item.content_headline;
-    } else {
-        snippet = item.content_headline || item.content_string;
+        if (item.summary_headline || item.summary_string) {
+            snippet = item.summary_headline || item.summary_string;
+        } else if (item.content_headline) {
+            snippet = `...${item.content_headline}...`;
+        }
+
+        return snippet;
     }
 
-    return `...${snippet}...`;
+    if (item.resource_type === "external") {
+        if (item.content_headline) {
+            snippet = `...${item.content_headline}...`;
+        } else if (item.content_string) {
+            snippet = item.content_string;
+        }
+    }
+
+    return snippet;
 };
 
 export default {
@@ -69,7 +79,7 @@ export default {
     getResultLinkText,
     getResultSnippet,
     showResultSnippet,
-}
+};
 </script>
 
 <script setup>
@@ -105,7 +115,6 @@ const resultLinkClasses = (doc) => ({
     external: doc.resource_type === "external",
     "document__link--search": !!$route?.query?.q,
 });
-
 </script>
 
 <template>

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -54,8 +54,10 @@ const getResultSnippet = (item) => {
     let snippet;
 
     if (item.resource_type === "internal") {
-        if (item.summary_headline || item.summary_string) {
-            snippet = item.summary_headline || item.summary_string;
+        if (item.summary_headline) {
+            snippet = `...${item.summary_headline}...`;
+        } else if (item.summary_string) {
+            snippet = item.summary_string;
         } else if (item.content_headline) {
             snippet = `...${item.content_headline}...`;
         }


### PR DESCRIPTION
Resolves [EREGCSC-2410](https://jiraent.cms.gov/browse/EREGCSC-2410)

**Description:**

Ellipses need to be visible when the displayed text snippet is taken from a search result match and no other times.

**This pull request changes:**

- Adds ellipses surrounding `summary_headline` and `content_headline` entries when displayed 

**Steps to manually verify this change:**

1. Visit [experimental deployment](https://otqgrzx0h2.execute-api.us-east-1.amazonaws.com/dev1112)
2. Upload docs and populate indices for some internal and external documents
3. Search against those indices, as well as against keywords in item summaries
4. Ensure that only snippets based on text searches are surrounded by ellipses

