### PR TITLE
EREGCSC-2252-B Fix attachment extraction for zip, eml, and msg files

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -81,7 +81,7 @@ jobs:
       deployextractor: false
     runs-on: ubuntu-20.04
     # Change to true if you want to create text extractor for your experimental deploy.
-    if: false
+    if: true
     steps:
       # Checkout the code
       - name: Checkout
@@ -119,7 +119,7 @@ jobs:
     outputs:
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
     runs-on: ubuntu-20.04
-    needs: [deploy-static] #[deploy-static, deploy-text-extractor]
+    needs: [deploy-static, deploy-text-extractor]
     steps:
       # Checkout the code
       - name: Checkout

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -85,8 +85,8 @@ custom:
     DB_NAME: ${self:custom.stage}
     USERNAME: eregsuser
     ALLOWED_HOST: '.amazonaws.com'
-    #text_extractor_arn: ${cf:text-extractor-${self:custom.stage}.TextDashextractorLambdaFunctionQualifiedArn}
-    text_extractor_arn: ''
+    text_extractor_arn: ${cf:text-extractor-${self:custom.stage}.TextDashextractorLambdaFunctionQualifiedArn}
+    #text_extractor_arn: ''
   cloudfrontInvalidate:
     - distributionId: ${cf:cmcs-eregs-static-assets-${self:custom.stage}.CloudFrontDistributionId}
       items:
@@ -196,7 +196,7 @@ resources:
                      - "lambda:InvokeFunction"
                    Resource:
                      - "${ssm:/eregulations/textextractor-arn}"
-                     # - "${self:custom.settings.text_extractor_arn}" # Extractor created by the environment
+                     - "${self:custom.settings.text_extractor_arn}" # Extractor created by the environment
 
 
 plugins:

--- a/solution/text-extractor/extractors/email.py
+++ b/solution/text-extractor/extractors/email.py
@@ -1,4 +1,5 @@
 import email
+import logging
 from tempfile import NamedTemporaryFile
 
 from .exceptions import (
@@ -6,6 +7,8 @@ from .exceptions import (
     ExtractorInitException,
 )
 from .extractor import Extractor
+
+logger = logging.getLogger(__name__)
 
 
 class EmailExtractor(Extractor):
@@ -33,15 +36,17 @@ class EmailExtractor(Extractor):
             file.write(message.get_payload(decode=True))
             file.close()
 
+            text = ""
+
             try:
                 extractor = Extractor.get_extractor(file_type, self.config)
                 text = extractor.extract(file.name)
             except ExtractorInitException as e:
-                raise ExtractorException(f"failed to initialize extractor for attachment \"{file_name}\": {str(e)}")
+                logger.log(logging.ERROR, "Failed to initialize extractor for attachment \"%s\": %s", file_name, str(e))
             except ExtractorException as e:
-                raise ExtractorException(f"failed to extract text for attachment \"{file_name}\": {str(e)}")
+                logger.log(logging.ERROR, "Failed to extract text for attachment \"%s\": %s", file_name, str(e))
             except Exception as e:
-                raise ExtractorException(f"extracting text for attachment \"{file_name}\" failed unexpectedly: {str(e)}")
+                logger.log(logging.ERROR, "Extracting text for attachment \"%s\" failed unexpectedly: %s", file_name, str(e))
 
             return f" {file_name} {text}"
 

--- a/solution/text-extractor/extractors/email.py
+++ b/solution/text-extractor/extractors/email.py
@@ -42,11 +42,11 @@ class EmailExtractor(Extractor):
                 extractor = Extractor.get_extractor(file_type, self.config)
                 text = extractor.extract(file.name)
             except ExtractorInitException as e:
-                logger.log(logging.ERROR, "Failed to initialize extractor for attachment \"%s\": %s", file_name, str(e))
+                logger.log(logging.WARN, "Failed to initialize extractor for attachment \"%s\": %s", file_name, str(e))
             except ExtractorException as e:
-                logger.log(logging.ERROR, "Failed to extract text for attachment \"%s\": %s", file_name, str(e))
+                logger.log(logging.WARN, "Failed to extract text for attachment \"%s\": %s", file_name, str(e))
             except Exception as e:
-                logger.log(logging.ERROR, "Extracting text for attachment \"%s\" failed unexpectedly: %s", file_name, str(e))
+                logger.log(logging.WARN, "Extracting text for attachment \"%s\" failed unexpectedly: %s", file_name, str(e))
 
             return f" {file_name} {text}"
 

--- a/solution/text-extractor/extractors/outlook.py
+++ b/solution/text-extractor/extractors/outlook.py
@@ -46,7 +46,7 @@ class OutlookExtractor(Extractor):
             if attachment.type == "data":
                 body += self._handle_data(attachment)
             elif attachment.type == "msg":
-                body += self._handle_msg(attachment.data)
+                body += self._handle_message(attachment.data)
         return body
 
     def extract(self, file_path: str) -> str:

--- a/solution/text-extractor/extractors/outlook.py
+++ b/solution/text-extractor/extractors/outlook.py
@@ -32,11 +32,11 @@ class OutlookExtractor(Extractor):
                 extractor = Extractor.get_extractor(file_type, self.config)
                 body += extractor.extract(file.name)
             except ExtractorInitException as e:
-                logger.log(logging.ERROR, "Failed to initialize extractor for attachment \"%s\": %s", file_name, str(e))
+                logger.log(logging.WARN, "Failed to initialize extractor for attachment \"%s\": %s", file_name, str(e))
             except ExtractorException as e:
-                logger.log(logging.ERROR, "Failed to extract text for attachment \"%s\": %s", file_name, str(e))
+                logger.log(logging.WARN, "Failed to extract text for attachment \"%s\": %s", file_name, str(e))
             except Exception as e:
-                logger.log(logging.ERROR, "Extracting text for attachment \"%s\" failed unexpectedly: %s", file_name, str(e))
+                logger.log(logging.WARN, "Extracting text for attachment \"%s\" failed unexpectedly: %s", file_name, str(e))
 
             return body
 

--- a/solution/text-extractor/extractors/outlook.py
+++ b/solution/text-extractor/extractors/outlook.py
@@ -1,3 +1,4 @@
+import logging
 from tempfile import NamedTemporaryFile
 
 import extract_msg
@@ -7,6 +8,8 @@ from .exceptions import (
     ExtractorInitException,
 )
 from .extractor import Extractor
+
+logger = logging.getLogger(__name__)
 
 
 class OutlookExtractor(Extractor):
@@ -32,10 +35,10 @@ class OutlookExtractor(Extractor):
                     text = extractor.extract(file.name)
                     body += f" {file_name} {text}"
                 except ExtractorInitException as e:
-                    raise ExtractorException(f"failed to initialize extractor for attachment \"{file_name}\": {str(e)}")
+                    logger.log(logging.ERROR, "Failed to initialize extractor for attachment \"%s\": %s", file_name, str(e))
                 except ExtractorException as e:
-                    raise ExtractorException(f"failed to extract text for attachment \"{file_name}\": {str(e)}")
+                    logger.log(logging.ERROR, "Failed to extract text for attachment \"%s\": %s", file_name, str(e))
                 except Exception as e:
-                    raise ExtractorException(f"extracting text for attachment \"{file_name}\" failed unexpectedly: {str(e)}")
+                    logger.log(logging.ERROR, "Extracting text for attachment \"%s\" failed unexpectedly: %s", file_name, str(e))
 
         return body

--- a/solution/text-extractor/extractors/outlook.py
+++ b/solution/text-extractor/extractors/outlook.py
@@ -40,7 +40,7 @@ class OutlookExtractor(Extractor):
 
             return body
 
-    def _handle_msg(self, message: extract_msg.message.Message) -> str:
+    def _handle_message(self, message: extract_msg.message.Message) -> str:
         body = message.body
         for attachment in message.attachments:
             if attachment.type == "data":

--- a/solution/text-extractor/extractors/outlook.py
+++ b/solution/text-extractor/extractors/outlook.py
@@ -30,10 +30,11 @@ class OutlookExtractor(Extractor):
                 file.write(attachment.data)
                 file.close()
 
+                body += f" {file_name} "
+
                 try:
                     extractor = Extractor.get_extractor(file_type, self.config)
-                    text = extractor.extract(file.name)
-                    body += f" {file_name} {text}"
+                    body += extractor.extract(file.name)
                 except ExtractorInitException as e:
                     logger.log(logging.ERROR, "Failed to initialize extractor for attachment \"%s\": %s", file_name, str(e))
                 except ExtractorException as e:

--- a/solution/text-extractor/extractors/outlook.py
+++ b/solution/text-extractor/extractors/outlook.py
@@ -15,31 +15,44 @@ logger = logging.getLogger(__name__)
 class OutlookExtractor(Extractor):
     file_types = ("msg",)
 
+    def _handle_data(self, attachment: extract_msg.attachment.Attachment) -> str:
+        file_name = attachment.longFilename
+        if not file_name:
+            logger.log(logging.WARN, "A data attachment failed to extract because it has no filename.")
+            return ""
+        file_type = file_name.lower().split('.')[-1]
+
+        with NamedTemporaryFile(delete=False) as file:
+            file.write(attachment.data)
+            file.close()
+
+            body = f" {file_name} "
+
+            try:
+                extractor = Extractor.get_extractor(file_type, self.config)
+                body += extractor.extract(file.name)
+            except ExtractorInitException as e:
+                logger.log(logging.ERROR, "Failed to initialize extractor for attachment \"%s\": %s", file_name, str(e))
+            except ExtractorException as e:
+                logger.log(logging.ERROR, "Failed to extract text for attachment \"%s\": %s", file_name, str(e))
+            except Exception as e:
+                logger.log(logging.ERROR, "Extracting text for attachment \"%s\" failed unexpectedly: %s", file_name, str(e))
+
+            return body
+
+    def _handle_msg(self, message: extract_msg.message.Message) -> str:
+        body = message.body
+        for attachment in message.attachments:
+            if attachment.type == "data":
+                body += self._handle_data(attachment)
+            elif attachment.type == "msg":
+                body += self._handle_msg(attachment.data)
+        return body
+
     def extract(self, file_path: str) -> str:
         try:
             msg = extract_msg.openMsg(file_path)
         except Exception as e:
             raise ExtractorException(f"msg file failed to extract: {str(e)}")
 
-        body = msg.body
-        for attachment in msg.attachments:
-            file_name = attachment.longFilename
-            file_type = file_name.lower().split('.')[-1]
-
-            with NamedTemporaryFile(delete=False) as file:
-                file.write(attachment.data)
-                file.close()
-
-                body += f" {file_name} "
-
-                try:
-                    extractor = Extractor.get_extractor(file_type, self.config)
-                    body += extractor.extract(file.name)
-                except ExtractorInitException as e:
-                    logger.log(logging.ERROR, "Failed to initialize extractor for attachment \"%s\": %s", file_name, str(e))
-                except ExtractorException as e:
-                    logger.log(logging.ERROR, "Failed to extract text for attachment \"%s\": %s", file_name, str(e))
-                except Exception as e:
-                    logger.log(logging.ERROR, "Extracting text for attachment \"%s\" failed unexpectedly: %s", file_name, str(e))
-
-        return body
+        return self._handle_message(msg)

--- a/solution/text-extractor/extractors/tests/fixtures/eml_pdf_expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/eml_pdf_expected.txt
@@ -1,0 +1,75 @@
+   Contents of email. I've attached a public memo in PDF and a public Word doc=
+ument.
+   IN-21-0009 - Sufficiency Memo.pdf   SMC Certification Request Letter Template.docx [Insert state letter head]		MES SMC
+
+
+
+Edward Dolly
+Director, Division of State Systems
+Centers for Medicare & Medicaid Services
+7500 Security Boulevard, Mail Stop S2-22-16
+Baltimore, Maryland 21244-1850
+
+
+
+Dear Director Dolly,
+
+
+
+The [State name], [Department name] is pleased to request certification of its [MMIS/E&E/HIE/EVV/PDMP] module(s) retroactive to [date]. [State] intends to claim federal financial participation (FFP) at the 75-percent matching rate for operation of the [name of module(s)] in accordance with the approved Cost Allocation Plan commencing with the implementation of the [name of module(s)] on [date]. In accordance, we hereby provide assurance that:
+
+
+
+The [MMIS/E&E/HIE/EVV/PDMP] module(s) meets the requirements of 42 CFR 433.117 for all periods for which the 75-percent FFP is being claimed.
+
+The [MMIS/E&E/HIE/EVV/PDMP] modules(s) have been assessed by the state and are ready for CMS evaluation.
+
+The system is routinely backed up.
+
+The [MMIS/E&E/HIE/EVV/PDMP] module(s) generates up-to-date and accurate Transformed Medicaid Statistical Information System (T-MSIS) data, and data quality issues are meeting the targets for Outcomes Based Assessment (OBA) critical priority Data Quality checks, high priority Data Quality checks, and the expenditure data content category.
+
+The [MMIS/E&E/HIE/EVV/PDMP] module(s) exercises appropriate security and privacy controls over the system in accordance with 45 CFR Part 164, P.L. 104-191, HIPAA of 1996, and 1902(a)(7) of the Social Security Act as further interpreted in regulations at 42 CFR 431.300 to 307.
+
+The system is ready for CMS certification, based on the systems performance in demonstrating achievement of outcomes. 
+
+
+
+[State] officially accepted the [MMIS/E&E/HIE/EVV/PDMP] module(s) as fully operational on [date]. Enclosed is a copy of the system acceptance letter addressed to the system developer, [name of developer].
+
+
+
+Also attached is the SMC Intake Form. This Intake Form demonstrates that [MMIS/E&E/HIE/EVV/PDMP] module(s) is ready for the CMS final certification review.
+
+
+
+[Include any additional, state-specific information, such as mention of state-specific criteria or resolution of previously identified issues.]
+
+
+
+We respectfully propose that the SMC Certification Review take place on [date]. The state contact person for matters involved in scheduling and completing the certification review is [name], who can be reached at [phone] or by electronic mail at [email address].
+
+
+
+							Sincerely,
+
+
+
+
+
+
+
+							[Name]
+
+							[Title]
+
+
+
+
+
+Attachments:  [Attachment name]
+
+		     [Attachment name]
+
+
+
+	CC: 	[Names, titles]

--- a/solution/text-extractor/extractors/tests/test_email.py
+++ b/solution/text-extractor/extractors/tests/test_email.py
@@ -7,7 +7,6 @@ import magic
 from extractors import (
     EmailExtractor,
     Extractor,
-    ExtractorException,
 )
 
 from . import FileComparisonMixin
@@ -72,5 +71,9 @@ class TestEmailExtractor(unittest.TestCase, FileComparisonMixin):
 
     def test_extract_failure(self):
         with patch('botocore.client.BaseClient._make_api_call', new=mock_make_api_call_failure):
-            with self.assertRaises(ExtractorException):
-                self._test_file_type("eml", self.CONFIG)
+            extractor = Extractor.get_extractor("eml", self.CONFIG)
+            output = extractor.extract("extractors/tests/fixtures/eml_sample.eml")
+            with open("extractors/tests/fixtures/eml_pdf_expected.txt", "rb") as f:
+                expected = f.read().decode()
+            self.assertEqual(output, expected)
+

--- a/solution/text-extractor/extractors/tests/test_email.py
+++ b/solution/text-extractor/extractors/tests/test_email.py
@@ -76,4 +76,3 @@ class TestEmailExtractor(unittest.TestCase, FileComparisonMixin):
             with open("extractors/tests/fixtures/eml_pdf_expected.txt", "rb") as f:
                 expected = f.read().decode()
             self.assertEqual(output, expected)
-

--- a/solution/text-extractor/extractors/zip.py
+++ b/solution/text-extractor/extractors/zip.py
@@ -32,12 +32,12 @@ class ZipExtractor(Extractor):
                         text = extractor.extract(file_path)
                         full_text += f" {file_name} {text}"
                     except ExtractorInitException as e:
-                        logger.log(logging.ERROR, "Failed to initialize extractor for zipped file \"%s\": %s", file_name, str(e))
+                        logger.log(logging.WARN, "Failed to initialize extractor for zipped file \"%s\": %s", file_name, str(e))
                     except ExtractorException as e:
-                        logger.log(logging.ERROR, "Failed to extract text for zipped file \"%s\": %s", file_name, str(e))
+                        logger.log(logging.WARN, "Failed to extract text for zipped file \"%s\": %s", file_name, str(e))
                     except Exception as e:
                         logger.log(
-                            logging.ERROR,
+                            logging.WARN,
                             "Extracting text for zipped file \"%s\" failed unexpectedly: %s",
                             file_name,
                             str(e),

--- a/solution/text-extractor/extractors/zip.py
+++ b/solution/text-extractor/extractors/zip.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import zipfile
 from tempfile import TemporaryDirectory
@@ -7,6 +8,8 @@ from .exceptions import (
     ExtractorInitException,
 )
 from .extractor import Extractor
+
+logger = logging.getLogger(__name__)
 
 
 class ZipExtractor(Extractor):
@@ -29,10 +32,15 @@ class ZipExtractor(Extractor):
                         text = extractor.extract(file_path)
                         full_text += f" {file_name} {text}"
                     except ExtractorInitException as e:
-                        raise ExtractorException(f"failed to initialize extractor for attachment \"{file_name}\": {str(e)}")
+                        logger.log(logging.ERROR, "Failed to initialize extractor for zipped file \"%s\": %s", file_name, str(e))
                     except ExtractorException as e:
-                        raise ExtractorException(f"failed to extract text for attachment \"{file_name}\": {str(e)}")
+                        logger.log(logging.ERROR, "Failed to extract text for zipped file \"%s\": %s", file_name, str(e))
                     except Exception as e:
-                        raise ExtractorException(f"extracting text for attachment \"{file_name}\" failed unexpectedly: {str(e)}")
+                        logger.log(
+                            logging.ERROR,
+                            "Extracting text for zipped file \"%s\" failed unexpectedly: %s",
+                            file_name,
+                            str(e),
+                        )
 
         return full_text

--- a/solution/text-extractor/text_extractor.py
+++ b/solution/text-extractor/text_extractor.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from tempfile import TemporaryDirectory
 
@@ -15,8 +16,11 @@ from .extractors import (
     ExtractorInitException,
 )
 
+logger = logging.getLogger(__name__)
 
-def lambda_response(status_code: int, message: str) -> dict:
+
+def lambda_response(status_code: int, message: str, loglevel: int) -> dict:
+    logging.log(loglevel, message)
     return {
         "statusCode": status_code,
         "headers": {"Content-Type": "application/json"},

--- a/solution/text-extractor/text_extractor.py
+++ b/solution/text-extractor/text_extractor.py
@@ -19,13 +19,21 @@ from .extractors import (
 logger = logging.getLogger(__name__)
 
 
-def lambda_response(status_code: int, message: str, loglevel: int) -> dict:
+def lambda_response(status_code: int, loglevel: int, message: str) -> dict:
     logging.log(loglevel, message)
     return {
         "statusCode": status_code,
         "headers": {"Content-Type": "application/json"},
         "body": json.dumps({"message": message}),
     }
+
+
+def lambda_success(message: str) -> dict:
+    return lambda_response(200, logging.INFO, message)
+
+
+def lambda_failure(status_code: int, message: str) -> dict:
+    return lambda_response(status_code, logging.ERROR, message)
 
 
 def handler(event: dict, context: dict) -> dict:
@@ -37,7 +45,7 @@ def handler(event: dict, context: dict) -> dict:
         try:
             config = json.loads(event["body"])
         except Exception:
-            return lambda_response(400, "Unable to parse body as JSON.")
+            return lambda_failure(400, "Unable to parse body as JSON.")
 
     # Retrieve required arguments
     try:
@@ -46,7 +54,7 @@ def handler(event: dict, context: dict) -> dict:
         post_url = config["post_url"]
         token = config["token"]
     except KeyError:
-        return lambda_response(400, "You must include 'id', 'uri', 'token', and 'post_url' in the request body.")
+        return lambda_failure(400, "You must include 'id', 'uri', 'token', and 'post_url' in the request body.")
 
     with TemporaryDirectory() as temp_dir:
         # Retrieve the file
@@ -55,27 +63,27 @@ def handler(event: dict, context: dict) -> dict:
             backend = FileBackend.get_backend(backend_type, config)
             file = backend.get_file(temp_dir, uri)
         except BackendInitException as e:
-            return lambda_response(500, f"Failed to initialize backend: {str(e)}")
+            return lambda_failure(500, f"Failed to initialize backend: {str(e)}")
         except BackendException as e:
-            return lambda_response(500, f"Failed to retrieve file: {str(e)}")
+            return lambda_failure(500, f"Failed to retrieve file: {str(e)}")
         except Exception as e:
-            return lambda_response(500, f"Backend unexpectedly failed: {str(e)}")
+            return lambda_failure(500, f"Backend unexpectedly failed: {str(e)}")
 
         try:
             file_type = uri.lower().split('.')[-1]
         except Exception as e:
-            return lambda_response(500, f"Failed to determine file type: {str(e)}")
+            return lambda_failure(500, f"Failed to determine file type: {str(e)}")
 
         # Run extractor
         try:
             extractor = Extractor.get_extractor(file_type, config)
             text = extractor.extract(file)
         except ExtractorInitException as e:
-            return lambda_response(500, f"Failed to initialize text extractor: {str(e)}")
+            return lambda_failure(500, f"Failed to initialize text extractor: {str(e)}")
         except ExtractorException as e:
-            return lambda_response(500, f"Failed to extract text: {str(e)}")
+            return lambda_failure(500, f"Failed to extract text: {str(e)}")
         except Exception as e:
-            return lambda_response(500, f"Extractor unexpectedly failed: {str(e)}")
+            return lambda_failure(500, f"Extractor unexpectedly failed: {str(e)}")
 
         # Strip unneeded data out of the extracted text
         text = re.sub(r'[\n\s]+', ' ', text).strip()
@@ -95,9 +103,9 @@ def handler(event: dict, context: dict) -> dict:
             )
             resp.raise_for_status()
         except requests.exceptions.RequestException as e:
-            return lambda_response(500, f"Failed to POST results: {str(e)}")
+            return lambda_failure(500, f"Failed to POST results: {str(e)}")
         except Exception as e:
-            return lambda_response(500, f"POST unexpectedly failed: {str(e)}")
+            return lambda_failure(500, f"POST unexpectedly failed: {str(e)}")
 
         # Return success code
-        return lambda_response(200, f"Function exited normally. {resp.content}")
+        return lambda_success(f"Function exited normally. {resp.content}")


### PR DESCRIPTION
Resolves #2252

**Description-**

Text extractor was failing for some files with other files contained within them. This PR fixes it.

**This pull request changes...**

- Attachment files that fail to extract will not cause the entire extractor lambda to fail.
- Failures are instead logged to Cloudwatch. (using Python logging library)
- Added support for Outlook "msg" files that contain embedded "msg" data. Previously this would cause a failure because this embedded data lacks a filename.
- Lambda return message is also logged to Cloudwatch.

**Follow up work**

- We need more fixture files to find edge cases with these types of files. We can't use policy repo files since they may contain sensitive information including private email addresses etc. So we need someone with Outlook to create test files for us.
- Need to add support for RTF and HTML formatted "eml" files. These _should_ be uploaded currently, but they will not have a message body unless a plain text version is also embedded, which it often is (but not necessarily always!)

**Steps to manually verify this change...**

1. Verify unit tests pass
2. Try uploading a zip file with 1 supported file type (e.g. docx) and 1 unsupported file type (e.g. png), and verify the docx is still extracted.
3. Do the same with eml and msg, if feasible. You may find examples containing unsupported files in the policy repository, or contact me for help.
4. Find a msg file with embedded msg data and ensure both emails extract properly. Contact me if you need help finding a file to test with.

