### PR TITLE
EREGCSC-2345-B Fix 500 error during content search

### DIFF
--- a/solution/backend/cmcs_regulations/settings/deploy.py
+++ b/solution/backend/cmcs_regulations/settings/deploy.py
@@ -2,8 +2,6 @@ from .base import * # noqa
 import os
 import re
 
-DEBUG = True
-
 default_database_values = {
     'ENGINE': 'django.db.backends.postgresql',
     'USER': os.environ.get('DB_USER', 'eregs'),

--- a/solution/backend/cmcs_regulations/settings/deploy.py
+++ b/solution/backend/cmcs_regulations/settings/deploy.py
@@ -2,6 +2,8 @@ from .base import * # noqa
 import os
 import re
 
+DEBUG = True
+
 default_database_values = {
     'ENGINE': 'django.db.backends.postgresql',
     'USER': os.environ.get('DB_USER', 'eregs'),

--- a/solution/backend/common/serializers/mix.py
+++ b/solution/backend/common/serializers/mix.py
@@ -10,14 +10,14 @@ class DetailsSerializer(serializers.Serializer):
     @extend_schema_field(MetaLocationSerializer.many(True))
     def get_locations(self, obj):
         if self.context['request'].GET.get("location_details") == 'true':
-            return AbstractLocationPolymorphicSerializer(obj.locations.all(), many=True).data
+            return AbstractLocationPolymorphicSerializer(many=True).to_representation(obj.locations.all())
         return serializers.PrimaryKeyRelatedField(read_only=True, many=True).to_representation(obj.locations.all())
 
     @extend_schema_field(MetaCategorySerializer.many(False))
     def get_category(self, obj):
         if self.context['request'].GET.get("category_details") == 'true':
             if obj.category:
-                return AbstractCategoryPolymorphicSerializer(obj.category).data
+                return AbstractCategoryPolymorphicSerializer().to_representation(obj.category)
             elif obj.upload_category:
-                return AbstractRepositoryCategoryPolymorphicSerializer(obj.upload_category).data
+                return AbstractRepositoryCategoryPolymorphicSerializer().to_representation(obj.upload_category)
         return serializers.PrimaryKeyRelatedField(read_only=True).to_representation(obj)

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -16,7 +16,7 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 from common.api import OpenApiQueryParameter
 from common.functions import establish_client, get_tokens_for_user
 from common.mixins import PAGINATION_PARAMS, OptionalPaginationMixin
-from file_manager.models import DocumentType, Subject
+from file_manager.models import AbstractRepoCategory, DocumentType, Subject
 from resources.models import AbstractCategory, AbstractLocation
 from resources.views.mixins import LocationExplorerViewSetMixin
 
@@ -79,6 +79,8 @@ class ContentSearchViewset(LocationExplorerViewSetMixin, OptionalPaginationMixin
         doc_type_prefetch = DocumentType.objects.all()
         subjects_prefetch = Subject.objects.all()
         category_prefetch = AbstractCategory.objects.all().select_subclasses().select_related("subcategory__parent")
+        repo_category_prefetch = AbstractRepoCategory.objects.all().select_subclasses()\
+                                                     .select_related("repositorysubcategory__parent")
 
         # If they are not authenticated they csan only get 'external' documents
         if not request.user.is_authenticated or resource_type == 'external':
@@ -92,7 +94,8 @@ class ContentSearchViewset(LocationExplorerViewSetMixin, OptionalPaginationMixin
             Prefetch("locations", queryset=locations_prefetch),
             Prefetch("subjects", queryset=subjects_prefetch),
             Prefetch("category", queryset=category_prefetch),
-            Prefetch("document_type", queryset=doc_type_prefetch)).distinct()
+            Prefetch("document_type", queryset=doc_type_prefetch),
+            Prefetch("upload_category", queryset=repo_category_prefetch)).distinct()
         if search_query:
             query = query.search(search_query)
         else:

--- a/solution/backend/file_manager/serializers/groupings.py
+++ b/solution/backend/file_manager/serializers/groupings.py
@@ -57,7 +57,7 @@ class RepositorySubCategorySerializer(RepositoryCategorySerializer):
     @extend_schema_field(RepositoryCategorySerializer)
     def get_parent(self, obj):
         if self.context.get("parent_details", True):
-            return RepositoryCategorySerializer(obj.parent).data
+            return RepositoryCategorySerializer().to_representation(obj.parent)
         return serializers.PrimaryKeyRelatedField(read_only=True).to_representation(obj.parent)
 
 


### PR DESCRIPTION
Resolves #2345

**Description-**

The v3 content-search endpoint was failing with a 500 error if an uploaded file was assigned to a category. The cause of this was twofold:

1. Repository categories were not prefetched with `select_subclasses()`, causing the type to be `AbstractRepoCategory`.
2. When passed to the relevant polymorphic serializer, the use of `Serializer(object).data` caused a failure because the parent serializer was returning "Serializer not available" (due to `object` being an `AbstractRepoCategory`), which was not serializable as a _dict_. Instead, using `Serializer().to_representation(object)` allows for arbitrary data types.

**This pull request changes...**

- These issues are resolved.

**Steps to manually verify this change...**

1. Upload a file (with a name or description) to the admin panel of the experimental deploy.
2. Assign a category or sub-category to it.
3. Go to the content search page and search for the name or description you added.
4. Verify the results load properly.
5. Additionally, visit `https://9sqva39it4.execute-api.us-east-1.amazonaws.com/dev1124/v3/content-search/?q=X&location_details=true&category_details=true` and replace `X` with a word from your name/description to see the raw API results and verify that it looks appropriate.

