### PR TITLE
[Hotfix] Extra newlines in reg search result section names

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -48,6 +48,10 @@
 
                     &__link {
                         margin-bottom: 4px;
+
+                        a {
+                            display: block;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Resolves issue on `prod`

**Description**

From Slack: "Looks like extra newlines have sometimes slipped into our formatting of reg search result section names"

This regression was introduced in [EREGCSC-2293](https://jiraent.cms.gov/browse/EREGCSC-2293): using flexbox with a gap for results items is not working well with the reg text results on the search page.

**This pull request changes:**

- Adds `display: block` to `.result__link a` when on the search page to override flexbox styles on the reg text column of the search page only

**Steps to manually verify this change...**

1. Search for "direction" on prod and compare the left column search results to screenshot in a comment below.  This is the bug -- there is extra spacing between the wrapped lines of the reg result section name
2. [Search for "direction" on experimental deployment](https://3m8xzxxq79.execute-api.us-east-1.amazonaws.com/dev1125/search/?q=direction).  Ensure that there is no extra spacing between the wrapped lines of the reg result section name

