### PR TITLE
hotfix-update the logout url to remove the subdomain "prod" out of the url.

### DIFF
--- a/solution/backend/regulations/logout.py
+++ b/solution/backend/regulations/logout.py
@@ -7,7 +7,7 @@ def eua_logout(request):
     logout_redirect_url = request.build_absolute_uri('/') + settings.STAGE_ENV + '/logout'
 
     # In the local environment where there is no STAGE_ENV, handle the possibility of //logout
-    logout_redirect_url = logout_redirect_url.replace('//logout', '/logout')
+    logout_redirect_url = logout_redirect_url.replace('//logout', '/logout').replace('/prod', '')
 
     if id_token is not None:
         # Use the id_token as needed in the logout request...


### PR DESCRIPTION
Resolves #hotfix for logout eua session

**Description-**
when deployed to prod the logout redirect url adds prod in the url which does not match with what okta is configured. To fix it we remove the word prod out of that url

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

test pass then on prod check that the logout works

