### PR TITLE
EREGCSC-2465-B Fix rtf extraction failure and add tests

### DIFF
--- a/solution/text-extractor/test_text_extractor.py
+++ b/solution/text-extractor/test_text_extractor.py
@@ -1,0 +1,49 @@
+import unittest
+import json
+
+from text_extractor import clean_output, get_config
+
+
+class TextExtractorTestCase(unittest.TestCase):
+    def test_clean_output(self):
+        text = "Hello   \n  \n\n world \0 \t\r \x00"
+        expected = "Hello world"
+        output = clean_output(text)
+        self.assertEqual(output, expected)
+
+    def test_clean_output_all_unicode(self):
+        text = "".join(chr(ch) for ch in range(0x0000, 0x0020))  # String containing all control characters
+        output = clean_output(text)
+        self.assertEqual(output, "")
+
+    def test_get_config_normal_invocation(self):
+        body = {
+            "hello": "world",
+            "x": 1,
+        }
+
+        event = {
+            "body": json.dumps(body),
+            "something": "else",
+        }
+
+        output = get_config(event)
+        self.assertEqual(output, body)
+
+    def test_get_config_json_failure(self):
+        event = {
+            "body": "{this: is, invalid: json,\}",
+            "something": "else",
+        }
+
+        with self.assertRaises(Exception):
+            get_config(event)
+
+    def test_get_config_direct_invocation(self):
+        event = {
+            "param1": "value1",
+            "param2": 0,
+        }
+
+        output = get_config(event)
+        self.assertEqual(output, event)

--- a/solution/text-extractor/test_text_extractor.py
+++ b/solution/text-extractor/test_text_extractor.py
@@ -1,5 +1,5 @@
-import unittest
 import json
+import unittest
 
 from text_extractor import clean_output, get_config
 
@@ -32,7 +32,7 @@ class TextExtractorTestCase(unittest.TestCase):
 
     def test_get_config_json_failure(self):
         event = {
-            "body": "{this: is, invalid: json,\}",
+            "body": "{this: is, invalid: json,}",
             "something": "else",
         }
 

--- a/solution/text-extractor/test_utils.py
+++ b/solution/text-extractor/test_utils.py
@@ -1,10 +1,19 @@
 import json
+import logging
 import unittest
 
-from text_extractor import clean_output, get_config
+from utils import (
+    clean_output,
+    get_config,
+    lambda_failure,
+    lambda_response,
+    lambda_success,
+)
+
+logging.disable(logging.CRITICAL)
 
 
-class TextExtractorTestCase(unittest.TestCase):
+class UtilsTestCase(unittest.TestCase):
     def test_clean_output(self):
         text = "Hello   \n  \n\n world \0 \t\r \x00"
         expected = "Hello world"
@@ -47,3 +56,19 @@ class TextExtractorTestCase(unittest.TestCase):
 
         output = get_config(event)
         self.assertEqual(output, event)
+
+    def test_lambda_response(self):
+        output = lambda_response(100, logging.ERROR, "Hello world")
+        self.assertEqual(output, {
+            "statusCode": 100,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({"message": "Hello world"}),
+        })
+
+    def test_lambda_success(self):
+        output = lambda_success("Hello world")
+        self.assertEqual(output["statusCode"], 200)
+
+    def test_lambda_failure(self):
+        output = lambda_failure(400, "Hello world")
+        self.assertEqual(output["statusCode"], 400)

--- a/solution/text-extractor/text_extractor.py
+++ b/solution/text-extractor/text_extractor.py
@@ -1,20 +1,23 @@
-import json
 import logging
 import os
-import re
-import unicodedata
 
 import requests
 
-from backends import (
+from .backends import (
     BackendException,
     BackendInitException,
     FileBackend,
 )
-from extractors import (
+from .extractors import (
     Extractor,
     ExtractorException,
     ExtractorInitException,
+)
+from .utils import (
+    clean_output,
+    get_config,
+    lambda_failure,
+    lambda_success,
 )
 
 # Initialize the root logger. All other loggers will automatically inherit from this one.
@@ -26,41 +29,6 @@ formatter = logging.Formatter('[%(levelname)s] [%(name)s] [%(asctime)s] %(messag
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
-
-
-def lambda_response(status_code: int, loglevel: int, message: str) -> dict:
-    logging.log(loglevel, message)
-    return {
-        "statusCode": status_code,
-        "headers": {"Content-Type": "application/json"},
-        "body": json.dumps({"message": message}),
-    }
-
-
-def lambda_success(message: str) -> dict:
-    return lambda_response(200, logging.INFO, message)
-
-
-def lambda_failure(status_code: int, message: str) -> dict:
-    return lambda_response(status_code, logging.ERROR, message)
-
-
-def get_config(event: dict) -> dict:
-    logger.info("Retrieving Lambda event dictionary.")
-    if "body" not in event:
-        # Assume we are invoked directly
-        logger.debug("No 'body' key present in event, assuming direct invocation.")
-        return event
-    else:
-        try:
-            return json.loads(event["body"])
-        except Exception as e:
-            raise Exception(f"unable to parse body as JSON: {str(e)}")
-
-
-def clean_output(text: str) -> str:
-    text = "".join(ch if not unicodedata.category(ch).lower().startswith("c") else " " for ch in text)
-    return re.sub(r"\s+", " ", text).strip()
 
 
 def handler(event: dict, context: dict) -> dict:

--- a/solution/text-extractor/text_extractor.py
+++ b/solution/text-extractor/text_extractor.py
@@ -50,7 +50,7 @@ def get_config(event: dict) -> dict:
     if "body" not in event:
         # Assume we are invoked directly
         logger.debug("No 'body' key present in event, assuming direct invocation.")
-        return event        
+        return event
     else:
         try:
             return json.loads(event["body"])
@@ -113,7 +113,7 @@ def handler(event: dict, context: dict) -> dict:
         return lambda_failure(500, f"Extractor unexpectedly failed: {str(e)}")
 
     # Strip control characters and unneeded data out of the extracted text
-    text = strip_output(text)
+    text = clean_output(text)
 
     # Send result to eRegs
     logger.info("Sending extracted text to POST URL.")

--- a/solution/text-extractor/utils.py
+++ b/solution/text-extractor/utils.py
@@ -1,0 +1,41 @@
+import json
+import logging
+import re
+import unicodedata
+
+logger = logging.getLogger(__name__)
+
+
+def lambda_response(status_code: int, loglevel: int, message: str) -> dict:
+    logging.log(loglevel, message)
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({"message": message}),
+    }
+
+
+def lambda_success(message: str) -> dict:
+    return lambda_response(200, logging.INFO, message)
+
+
+def lambda_failure(status_code: int, message: str) -> dict:
+    return lambda_response(status_code, logging.ERROR, message)
+
+
+def get_config(event: dict) -> dict:
+    logger.info("Retrieving Lambda event dictionary.")
+    if "body" not in event:
+        # Assume we are invoked directly
+        logger.debug("No 'body' key present in event, assuming direct invocation.")
+        return event
+    else:
+        try:
+            return json.loads(event["body"])
+        except Exception as e:
+            raise Exception(f"unable to parse body as JSON: {str(e)}")
+
+
+def clean_output(text: str) -> str:
+    text = "".join(ch if not unicodedata.category(ch).lower().startswith("c") else " " for ch in text)
+    return re.sub(r"\s+", " ", text).strip()


### PR DESCRIPTION
Resolves #2465

**Description-**

Extraction was failing for some files because unicode control characters were not being stripped from the output text. This is a valid string in Python, but when uploaded to eRegs it would cause a 500 error because some of these control characters can't be stored in the database (for example `\0`).

**This pull request changes...**

- Strips control characters from output text. (Done after text extraction itself is complete, but before uploading.)
- Wrote unit tests for this functionality and also config retrieval.
- Moved some function from `text_extractor.py` to `utils.py` to avoid import errors during unit testing.

**Steps to manually verify this change...**

1. Ensure unit tests pass.
2. Go to the JIRA ticket and download the 2 RTF files that failed to extract (listed in the ticket's comments).
3. Upload them to the experimental deploy's admin panel ("Uploaded files").
4. "Get Content" for both of these files, the click the back button.
5. Ensure that after some time, "Index populated" will show an extracted text excerpt.

