### PR TITLE
EREGCSC-2322-Fix login to redirect correctly

### DIFF
--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -69,6 +69,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'mozilla_django_oidc.middleware.SessionRefresh',
     'csp.middleware.CSPMiddleware',
     'regulations.middleware.JsonErrors',
     'regulations.middleware.NoIndex',

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -69,7 +69,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'mozilla_django_oidc.middleware.SessionRefresh',
     'csp.middleware.CSPMiddleware',
     'regulations.middleware.JsonErrors',
     'regulations.middleware.NoIndex',

--- a/solution/backend/cmcs_regulations/templates/admin/login.html
+++ b/solution/backend/cmcs_regulations/templates/admin/login.html
@@ -15,24 +15,13 @@
                 margin-top: 15px;
                 display: flex;
                 justify-content: center;
-
-                form#eua_login_form input {
-                    background-color: transparent !important;
-                    text-decoration: underline;
-                    color: #046791;
-                    padding: initial;
-                }
             }
         </style>
     {% endblock %}
    {{ block.super }}
    {% if EUA_FEATUREFLAG %}
       <div class="okta_login_container">
-        Or Login With &nbsp;
-        <form id="eua_login_form" method="get" action="{% url 'oidc_authentication_init' %}">
-          <input type="hidden" name="next" value="{{ next }}" />
-          <input type="submit" value="EUA">
-        </form>
+        Or Login With &nbsp;<a href="{% url 'oidc_authentication_init' %}?next={{ next }}">EUA</a>
       </div>
    {% endif %}
    {% if form.errors %}

--- a/solution/backend/cmcs_regulations/templates/admin/login.html
+++ b/solution/backend/cmcs_regulations/templates/admin/login.html
@@ -15,13 +15,24 @@
                 margin-top: 15px;
                 display: flex;
                 justify-content: center;
+
+                form#eua_login_form input {
+                    background-color: transparent !important;
+                    text-decoration: underline;
+                    color: #046791;
+                    padding: initial;
+                }
             }
         </style>
     {% endblock %}
    {{ block.super }}
    {% if EUA_FEATUREFLAG %}
       <div class="okta_login_container">
-        Or Login With &nbsp;<a href="{% url 'oidc_authentication_init' %}">EUA</a>
+        Or Login With &nbsp;
+        <form id="eua_login_form" method="get" action="{% url 'oidc_authentication_init' %}">
+          <input type="hidden" name="next" value="{{ next }}" />
+          <input type="submit" value="EUA">
+        </form>
       </div>
    {% endif %}
    {% if form.errors %}


### PR DESCRIPTION
Resolves # EREGCSC-2322

**Description-**
When a user sings in to eua after authentication they should be redirected to where they were going. 

**This pull request changes...**
login.html to pass the hidden value for next so that mozilla_django_oidc knows where to redirect the user back to after authentication. 

- expected change 1

**Steps to manually verify this change...**

1. visit /policy-repository
2. sign in using eua
3. notice you are redirected to /policy-repository
4. logout

1. visit /admin
2. sign in using eua
3. notice you are redirected to /admin 

