### PR TITLE
EREGCSC-2480 -- Snippet display logic III

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.test.js
@@ -123,9 +123,9 @@ describe("getResultLinkText", () => {
 });
 
 describe("getResultSnippet", () => {
-    it("is internal and has a summary_headline with a search result", async () => {
+    it("is internal and has a content_headline and summary_headline with a search result", async () => {
         expect(PolicyResults.getResultSnippet(MOCK_RESULTS[1])).toBe(
-            "...this <span class='search-highlight'>is</span> a summary headline..."
+            "...this <span class='search-highlight'>is</span> a content headline..."
         );
     });
     it("is internal and has a summary_headline WITHOUT a search result", async () => {
@@ -133,9 +133,9 @@ describe("getResultSnippet", () => {
             "this is a summary headline"
         );
     });
-    it("is internal and has a summary_string but NOT a summary_headline", async () => {
+    it("is internal and has a content_headline and a summary_string but NOT a summary_headline", async () => {
         expect(PolicyResults.getResultSnippet(MOCK_RESULTS[6])).toBe(
-            "this is a summary string"
+            "...this <span class='search-highlight'>is</span> a content headline..."
         );
     });
     it("is internal and does NOT have a summary_headline or _string, but has a content_headline with a search result", async () => {

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -36,7 +36,7 @@ const getResultLinkText = (item) => {
 const showResultSnippet = (item) => {
     if (
         item.resource_type === "internal" &&
-        (item.summary_headline || item.summary_string || item.content_headline)
+        (item.content_headline || item.summary_headline || item.summary_string)
     )
         return true;
 
@@ -49,12 +49,15 @@ const getResultSnippet = (item) => {
     let snippet;
 
     if (item.resource_type === "internal") {
-        if (item.summary_headline) {
+        if (
+            item.content_headline &&
+            item.content_headline.includes("search-highlight")
+        ) {
+            snippet = addSurroundingEllipses(item.content_headline);
+        } else if (item.summary_headline) {
             snippet = addSurroundingEllipses(item.summary_headline);
         } else if (item.summary_string) {
             snippet = item.summary_string;
-        } else if (item.content_headline) {
-            snippet = addSurroundingEllipses(item.content_headline);
         }
 
         return snippet;

--- a/solution/ui/regulations/package-lock.json
+++ b/solution/ui/regulations/package-lock.json
@@ -11,7 +11,7 @@
         "@fortawesome/fontawesome-free": "^5.15.3",
         "@vitejs/plugin-vue2": "^2.3.1",
         "@vue/test-utils": "^1.3.5",
-        "export-from-json": "^1.6.0",
+        "export-from-json": "^1.7.4",
         "flush-promises": "^1.0.2",
         "localforage": "^1.10.0",
         "lodash": "^4.17.21",
@@ -14287,9 +14287,9 @@
       "dev": true
     },
     "node_modules/export-from-json": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/export-from-json/-/export-from-json-1.6.0.tgz",
-      "integrity": "sha512-DLHwOGYeGnATM6tOMOWgs9dbzCjO+DwO3YGaha2R6kmLCE5iL8dz5sOywWeJs4P1rhxpdaVILKhCB4mUrTbbGg=="
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/export-from-json/-/export-from-json-1.7.4.tgz",
+      "integrity": "sha512-FjmpluvZS2PTYyhkoMfQoyEJMfe2bfAyNpa5Apa6C9n7SWUWyJkG/VFnzERuj3q9Jjo3iwBjwVsDQ7Z7sczthA=="
     },
     "node_modules/express": {
       "version": "4.18.2",
@@ -38707,9 +38707,9 @@
       }
     },
     "export-from-json": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/export-from-json/-/export-from-json-1.6.0.tgz",
-      "integrity": "sha512-DLHwOGYeGnATM6tOMOWgs9dbzCjO+DwO3YGaha2R6kmLCE5iL8dz5sOywWeJs4P1rhxpdaVILKhCB4mUrTbbGg=="
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/export-from-json/-/export-from-json-1.7.4.tgz",
+      "integrity": "sha512-FjmpluvZS2PTYyhkoMfQoyEJMfe2bfAyNpa5Apa6C9n7SWUWyJkG/VFnzERuj3q9Jjo3iwBjwVsDQ7Z7sczthA=="
     },
     "express": {
       "version": "4.18.2",


### PR DESCRIPTION
Resolves [EREGCSC-2480](https://jiraent.cms.gov/browse/EREGCSC-2480)

**Description**

When deciding what to display in the text snippet section of a Results Item on the Policy Repository, the logic should be reordered to the following:

`item.content_headline || item.summary_headline || item.summary_string`

In other words: if there is a match on the extracted content of a document, it should be displayed as the snippet.  Handwritten summary text should never be displayed instead of `content_headline` text.

**This pull request changes:**

- Reorders snippet display logic
- Updates unit tests

**Steps to manually verify this change:**

1. Visit [experimental deployment](https://6ns3sdhttb.execute-api.us-east-1.amazonaws.com/dev1148)
2. Make sure an internal document has been uploaded, it has a summary, and its index has been populated.
     - Example file: [Slam Dunk](https://6ns3sdhttb.execute-api.us-east-1.amazonaws.com/dev1148/admin/file_manager/uploadedfile/1/change/)
3. Visit the Policy Repository and display only Internal documents.
     - You should see "Slam Dunk" and its summary
4. Search for "AdChoices"
     - Even though there is a summary, the matched `content_headline` is displayed.
5. Compare this behavior to `prod`, where summary text is displayed instead of matched `content_headline` text.

