### PR TITLE
[Hotfix] Remove text extractor from VPC

### DIFF
--- a/solution/text-extractor/serverless.yml
+++ b/solution/text-extractor/serverless.yml
@@ -4,16 +4,6 @@ provider:
   name: aws
   iam:
     role: LambdaFunctionRole
-  logs:
-    restApi:
-      level: INFO
-      roleManagedExternally: true
-  vpc:
-    securityGroupIds:
-      - !Ref ServerlessSecurityGroup
-    subnetIds:
-      - ${ssm:/account_vars/vpc/subnets/private/a/id}
-      - ${ssm:/account_vars/vpc/subnets/private/b/id}
   deploymentBucket:
     blockPublicAccess: true
   ecr:


### PR DESCRIPTION
Resolves #n/a

**Description-**

This PR should permanently fix the "out of IPs" error we receive when having more than a couple deploys of the text extractor.

**This pull request changes...**

- Removes the text extractor from the private VPCs.
- Removes REST API logging since we aren't using that anyway.

**Steps to manually verify this change...**

1. Verify this PR deploys.
2. Go through the normal steps to extract a random supported file on the experimental deploy (admin -> uploaded files -> upload a file -> "Get content" -> refresh until "index populated" is populated). This check makes sure that removing the text extractor from the VPC doesn't impede its functionality (like S3 access).

