### PR TITLE
HOTFIX - fix the logout redirect link

### DIFF
--- a/solution/backend/regulations/logout.py
+++ b/solution/backend/regulations/logout.py
@@ -4,7 +4,7 @@ from django.conf import settings
 def eua_logout(request):
     id_token = request.session.get('oidc_id_token')
     # get the domain url from the request and add /login to the end
-    logout_redirect_url = request.build_absolute_uri('/') + settings.STAGE_ENV + '/logout'
+    logout_redirect_url = request.build_absolute_uri('/') + settings.STAGE_ENV + '/login'
 
     # In the local environment where there is no STAGE_ENV, handle the possibility of //logout
     logout_redirect_url = logout_redirect_url.replace('//login', '/login').replace('/prod', '')


### PR DESCRIPTION
Resolves #hotfix for logout not redirecting correctly

**Description-**
on production when logging out it is redirecting to localhost:8000 
**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. login to https://5trxu4mf3i.execute-api.us-east-1.amazonaws.com/dev1141/policy-repository, then log out. Ensure that the page is redirected correctly. 
2. visit https://5trxu4mf3i.execute-api.us-east-1.amazonaws.com/dev1141/login/ make sure that is correct. 


