### PR TITLE
EREGCSC-2506 -- Remove "search these resources" button in reader view sidebar

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/sidebar_right.html
+++ b/solution/backend/regulations/templates/regulations/partials/sidebar_right.html
@@ -13,9 +13,6 @@
             api-url="{{ API_BASE }}"
             title="{{ title }}"
             part="{{ reg_part }}"
-            resources-url="{% url 'resources' %}"
-            :resource-display=true
-            :sections="{{ node_list.sections }}"
             :subparts="{{ node_list.subparts }}"
         >
             <template #login-banner>

--- a/solution/ui/e2e/cypress/e2e/part.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/part.spec.cy.js
@@ -49,6 +49,7 @@ describe("Part View", () => {
         cy.get("#433-51-title").should("be.visible");
         cy.get(".latest-version").should("exist");
         cy.get("#subpart-resources-heading").contains("433.51 Resources");
+        cy.get(".resources_btn_container").should("not.exist");
 
         cy.get(".right-sidebar").should("be.visible", "display", "none");
 

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
@@ -13,13 +13,6 @@
         </a>
         <h2 id="subpart-resources-heading">{{ activePart }} Resources</h2>
         <slot name="login-banner"></slot>
-        <div v-if="resourceDisplay" class="resource_btn_container">
-            <a
-                :href="resourceLink"
-                class="default-btn action-btn search_resource_btn"
-                >Search These Resources</a
-            >
-        </div>
         <slot name="public-label"></slot>
         <div class="supplemental-content-container">
             <supplemental-content-category
@@ -75,11 +68,6 @@ export default {
             required: false,
             default: "",
         },
-        resourcesUrl: {
-            type: String,
-            required: false,
-            default: "",
-        },
         title: {
             type: String,
             required: true,
@@ -88,22 +76,12 @@ export default {
             type: String,
             required: true,
         },
-        sections: {
-            type: Array,
-            required: false,
-            default: () => [],
-        },
         subparts: {
             type: Array,
             required: false,
             default() {
                 return [];
             },
-        },
-        resourceDisplay: {
-            type: Boolean,
-            required: false,
-            default: false,
         },
     },
 
@@ -118,41 +96,15 @@ export default {
     },
 
     computed: {
-        params_array() {
-            return [
-                ["sections", this.sections],
-                ["subparts", this.subparts],
-            ];
-        },
-
         activePart() {
             if (this.selectedPart !== undefined) {
                 return this.selectedPart;
             }
             return `Subpart ${this.subparts[0]}`;
         },
-
-        resourceLink() {
-            let qString = `${this.resourcesUrl}?title=${this.title}&part=${this.part}`;
-
-            if (this.activePart.includes("Subpart")) {
-                qString = `${qString}&subpart=${this.part}-${this.params_array[1][1]}`;
-                const sections = `${this.part}-${this.sections.join(
-                    `,${this.part}-`
-                )}`;
-                return `${qString}&section=${sections}`;
-            }
-            const selection = this.activePart.split(" ")[1].replace(".", "-");
-            return `${qString}&section=${selection}`;
-        },
     },
 
     watch: {
-        sections() {
-            this.categories = [];
-            this.isFetching = true;
-            this.fetchContent();
-        },
         subparts() {
             this.categories = [];
             this.isFetching = true;
@@ -293,10 +245,6 @@ export default {
 </script>
 
 <style lang="scss">
-.resource_btn_container {
-    padding: 5px 12px 5px 0px;
-}
-
 .search_resource_btn {
     width: fit-content;
     line-height: 18px;


### PR DESCRIPTION
Resolves [EREGCSC-2506](https://jiraent.cms.gov/browse/EREGCSC-2506)

**Description**

When looking at a regulation reading page (subpart page), there should no longer be a button in the sidebar for "search these resources".

**This pull request changes:**

- Removes Search Resources button from `SupplementalContent` Vue component
- Removes associated props and methods that are no longer necessary
- Updates cypress test to assert that button no longer exists

**Steps to manually verify this change:**

1. Visit the reader view on the experimental deployment
   - Ex: [42 CFR 433 Subpart A](https://8gn42hd15j.execute-api.us-east-1.amazonaws.com/dev1156/42/433/Subpart-A/2024-01-01/)
3. The right sidebar should no longer contain a "Search These Resources" button
4. Compare to same subpart/section on `prod`, which should still have the button

