### PR TITLE
EREGCSC-2519 -- Remove "View More" buttons on homepage

### DIFF
--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -69,8 +69,6 @@ Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
                     <div class="resources__container">
                         <recent-resources
                             api-url={{ API_BASE }}
-                            resource-link='{% url 'resources' %}'
-                            fr-doc-link='{% url 'resources' %}?resourceCategory={{ fr_docs_category_name }}'
                         />
                     </div>
                     <div class="policy-materials__container">

--- a/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
@@ -189,12 +189,7 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
             });
         cy.get(".resources__container")
             .contains("View More Guidance")
-            .click({ force: true });
-        cy.url().should(
-            "eq",
-            Cypress.config().baseUrl +
-                "/resources/?resourceCategory=State%20Medicaid%20Director%20Letter%20%28SMDL%29,State%20Health%20Official%20%28SHO%29%20Letter,CMCS%20Informational%20Bulletin%20%28CIB%29,Frequently%20Asked%20Questions%20%28FAQs%29,Associate%20Regional%20Administrator%20%28ARA%29%20Memo,State%20Medicaid%20Manual%20%28SMM%29&sort=newest"
-        );
+            .should("not.exist");
     });
 
     it("has grouped FR docs in Related Rules tab", () => {
@@ -233,12 +228,7 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
 
         cy.get(".resources__container")
             .contains("View More Changes")
-            .click({ force: true });
-        cy.url().should(
-            "eq",
-            Cypress.config().baseUrl +
-                `/resources/?resourceCategory=Proposed%20and%20Final%20Rules`
-        );
+            .should("not.exist");
     });
 
     it("Sets the label as Final, when correction and withdraw are both set to false", () => {

--- a/solution/ui/regulations/eregs-component-lib/src/components/RecentResources.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/RecentResources.vue
@@ -11,14 +11,6 @@ export default {
             type: String,
             required: true,
         },
-        resourceLink: {
-            type: String,
-            required: true,
-        },
-        frDocLink: {
-            type: String,
-            required: true,
-        },
     },
 
     async created() {
@@ -46,12 +38,6 @@ export default {
         };
     },
 
-    computed: {
-        moreGuidanceLink() {
-            return `${this.resourceLink}?resourceCategory=${this.categoryNames}&sort=newest`;
-        },
-    },
-
     components: {
         RecentChangesContainer,
     },
@@ -74,9 +60,6 @@ export default {
                     :categories="categories"
                     type="supplemental"
                 ></RecentChangesContainer>
-                <a :href="moreGuidanceLink" class="action-btn default-btn link-btn"
-                    >View More Guidance</a
-                >
             </v-tab-item>
             <v-tab-item>
                 <p class="recent-rules-descriptive-text">
@@ -86,9 +69,6 @@ export default {
                     :api-url="apiUrl"
                     type="rules"
                 ></RecentChangesContainer>
-                <a :href="frDocLink" class="action-btn default-btn link-btn"
-                    >View More Changes</a
-                >
             </v-tab-item>
         </v-tabs-items>
     </div>


### PR DESCRIPTION
Resolves [EREGCSC-2519](https://jiraent.cms.gov/browse/EREGCSC-2519)

**Description**

On the homepage, under the "Recent Subregulatory Guidance" and "Recent Rules" tabs, we have "View More Guidance" and "View More Changes" buttons that go to the resources page (pre-filtered). We're working to retire the resources page, so let's remove these buttons.

**This pull request changes:**

- Removes button markup and related props/methods from `RecentResources` Vue component
- Updates Django template to no longer pass in unnecessary props
- Updates `homepage` e2e test suite to assert that these buttons no longer exist

**Steps to manually verify this change:**

1. Visit the experimental deployment
2. Make sure there are no "View More" buttons at the bottom of the main content column

