### PR TITLE
EREGCSC-2221 Work around deprecation of Go runtime on Lambda

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -295,12 +295,6 @@ jobs:
         with:
           # Can be "open", "closed", or "all".  Defaults to "open".
           state: open
-      # Setup GO
-      - name: Setup Go
-        if: success() && steps.findPr.outputs.number
-        uses: actions/setup-go@v2
-        with:
-          go-version: "^1.16" # The Go version to download (if necessary) and use.
       # Configure AWS credentials for GitHub Actions
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2

--- a/solution/parser/ecfr-parser/Dockerfile
+++ b/solution/parser/ecfr-parser/Dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/provided:al2 as build
+
+# install compiler
+RUN yum install -y golang
+RUN go env -w GOPROXY=direct
+
+# build parser
+COPY . .
+WORKDIR fr-parser
+RUN go mod download
+RUN go build -tags lambda.norpc -o /main
+
+# copy artifacts to a clean image
+FROM public.ecr.aws/lambda/provided:al2
+COPY --from=build /main /main
+ENTRYPOINT [ "/main" ]

--- a/solution/parser/ecfr-parser/Dockerfile
+++ b/solution/parser/ecfr-parser/Dockerfile
@@ -6,7 +6,7 @@ RUN go env -w GOPROXY=direct
 
 # build parser
 COPY . .
-WORKDIR fr-parser
+WORKDIR ecfr-parser
 RUN go mod download
 RUN go build -tags lambda.norpc -o /main
 

--- a/solution/parser/fr-parser/Dockerfile
+++ b/solution/parser/fr-parser/Dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/provided:al2 as build
+
+# install compiler
+RUN yum install -y golang
+RUN go env -w GOPROXY=direct
+
+# build parser
+COPY . .
+WORKDIR fr-parser
+RUN go mod download
+RUN go build -tags lambda.norpc -o /main
+
+# copy artifacts to a clean image
+FROM public.ecr.aws/lambda/provided:al2
+COPY --from=build /main /main
+ENTRYPOINT [ "/main" ]

--- a/solution/parser/serverless-ecfr.yml
+++ b/solution/parser/serverless-ecfr.yml
@@ -3,7 +3,6 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
-  runtime: go1.x
   region: us-east-1
   iam:
     role: LambdaFunctionRole
@@ -15,25 +14,27 @@ provider:
     EREGS_API_URL_V3: ${self:custom.settings.eregs_url}
   deploymentBucket:
     blockPublicAccess: true
+  ecr:
+    images:
+      appimage:
+        path: .
+        file: ecfr-parser/Dockerfile
 
 custom:
   stage: ${opt:stage, self:provider.stage}
   settings:
     eregs_url: ${cf:cmcs-eregs-site-${self:custom.stage}.ServiceEndpoint}/v3/
-  go:
-    baseDir: ecfr-parser/
 
 functions:
   ecfr_parser:
-    handler: .
+    image:
+      name: appimage
     timeout: 900
     events:
       - schedule: cron(0 0 * * ? *)
 
 resources:
-
   Resources:
-
     LambdaFunctionRole:
       Type: AWS::IAM::Role
       Properties:
@@ -91,6 +92,3 @@ resources:
         Tags:
           - Key: "Name"
             Value: "ServerlessSecurityGroup"
-
-plugins:
-  - serverless-go-plugin

--- a/solution/parser/serverless-fr.yml
+++ b/solution/parser/serverless-fr.yml
@@ -23,8 +23,7 @@ provider:
 custom:
   stage: ${opt:stage, self:provider.stage}
   settings:
-    #eregs_url: ${cf:cmcs-eregs-site-${self:custom.stage}.ServiceEndpoint}/v3/
-    eregs_url: "https://godwin.io"
+    eregs_url: ${cf:cmcs-eregs-site-${self:custom.stage}.ServiceEndpoint}/v3/
 
 functions:
   fr_parser:

--- a/solution/parser/serverless-fr.yml
+++ b/solution/parser/serverless-fr.yml
@@ -3,7 +3,6 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
-  runtime: go1.x
   region: us-east-1
   iam:
     role: LambdaFunctionRole
@@ -15,25 +14,28 @@ provider:
     EREGS_API_URL_V3: ${self:custom.settings.eregs_url}
   deploymentBucket:
     blockPublicAccess: true
+  ecr:
+    images:
+      appimage:
+        path: .
+        file: fr-parser/Dockerfile
 
 custom:
   stage: ${opt:stage, self:provider.stage}
   settings:
-    eregs_url: ${cf:cmcs-eregs-site-${self:custom.stage}.ServiceEndpoint}/v3/
-  go:
-    baseDir: fr-parser/
+    #eregs_url: ${cf:cmcs-eregs-site-${self:custom.stage}.ServiceEndpoint}/v3/
+    eregs_url: "https://godwin.io"
 
 functions:
   fr_parser:
-    handler: .
+    image:
+      name: appimage
     timeout: 900
     events:
       - schedule: cron(0 2 * * ? *)
 
 resources:
-
   Resources:
-
     LambdaFunctionRole:
       Type: AWS::IAM::Role
       Properties:
@@ -91,6 +93,3 @@ resources:
         Tags:
           - Key: "Name"
             Value: "ServerlessSecurityGroup"
-
-plugins:
-  - serverless-go-plugin


### PR DESCRIPTION
Resolves #2221

**Description-**

Makes parsers use Docker instead of the deprecated Go runtime.

**This pull request changes...**

- Parsers now are built using Docker instead of relying on the deprecated Go runtime.

**Steps to manually verify this change...**

1. Verify deployment succeeded (including Go parsers steps)
2. Verify cypress tests passed
3. Check the experimental deploy and make sure regulation content exists (titles, parts, etc.)

