### PR TITLE
EREGCSC-2461 -- Use new category/subcategory model on repository

### DIFF
--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -492,6 +492,60 @@ describe("Policy Repository", () => {
         cy.url().should("include", "/resources");
     });
 
+    it("should have the correct labels for public and internal documents", () => {
+        cy.intercept("**/v3/content-search/?q=test**", {
+            fixture: "policy-docs.json",
+        }).as("queriedFiles");
+        cy.viewport("macbook-15");
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
+        cy.visit("/policy-repository/");
+        cy.get("input#main-content")
+            .should("be.visible")
+            .type("test", { force: true });
+        cy.get(".search-field .v-input__icon--append button").click({
+            force: true,
+        });
+        cy.wait("@queriedFiles").then((interception) => {
+            expect(interception.response.statusCode).to.eq(200);
+        });
+
+        // Public doc
+        cy.get(".category-labels")
+            .eq(0)
+            .find(".doc-type__label")
+            .should("include.text", " Public ")
+            .find("i")
+            .should("have.class", "fa-users");
+        cy.get(".category-labels")
+            .eq(0)
+            .find(".category-label")
+            .should("include.text", " Subregulatory Guidance ");
+        cy.get(".category-labels")
+            .eq(0)
+            .find(".subcategory-label")
+            .should("include.text", "CMCS Informational Bulletin (CIB)");
+
+        // Internal doc
+        cy.get(".category-labels")
+            .eq(1)
+            .find(".doc-type__label")
+            .should("include.text", " Internal ")
+            .find("i")
+            .should("have.class", "fa-key");
+        cy.get(".category-labels")
+            .eq(1)
+            .find(".category-label")
+            .should("include.text", "TestCat");
+        cy.get(".category-labels")
+            .eq(1)
+            .find(".subcategory-label")
+            .should("include.text", "TestSubCat");
+    });
+
     it("returns you to the custom eua login page when you log out", () => {
         cy.viewport("macbook-15");
         cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
@@ -545,7 +599,7 @@ describe("Policy Repository Search", () => {
         });
     });
 
-    it("should have the correct public/internal label", () => {
+    it("should have the correct labels for public and internal documents", () => {
         cy.intercept("**/v3/content-search/?q=test**", {
             fixture: "policy-docs.json",
         }).as("queriedFiles");
@@ -565,15 +619,37 @@ describe("Policy Repository Search", () => {
         cy.wait("@queriedFiles").then((interception) => {
             expect(interception.response.statusCode).to.eq(200);
         });
-        cy.get(".doc-type__label")
+
+        // Public doc
+        cy.get(".category-labels")
             .eq(0)
+            .find(".doc-type__label")
             .should("include.text", " Public ")
             .find("i")
             .should("have.class", "fa-users");
-        cy.get(".doc-type__label")
+        cy.get(".category-labels")
+            .eq(0)
+            .find(".category-label")
+            .should("include.text", " Subregulatory Guidance ");
+        cy.get(".category-labels")
+            .eq(0)
+            .find(".subcategory-label")
+            .should("include.text", "CMCS Informational Bulletin (CIB)");
+
+        // Internal doc
+        cy.get(".category-labels")
             .eq(1)
+            .find(".doc-type__label")
             .should("include.text", " Internal ")
             .find("i")
             .should("have.class", "fa-key");
+        cy.get(".category-labels")
+            .eq(1)
+            .find(".category-label")
+            .should("include.text", "TestCat");
+        cy.get(".category-labels")
+            .eq(1)
+            .find(".subcategory-label")
+            .should("include.text", "TestSubCat");
     });
 });

--- a/solution/ui/e2e/cypress/fixtures/policy-docs.json
+++ b/solution/ui/e2e/cypress/fixtures/policy-docs.json
@@ -141,7 +141,22 @@
                     "abbreviation": null
                 }
             ],
-            "category": {},
+            "category": {
+                "id": 2,
+                "name": "TestSubCat",
+                "description": "",
+                "order": 0,
+                "show_if_empty": false,
+                "type": "repositorysubcategory",
+                "parent": {
+                    "id": 1,
+                    "name": "TestCat",
+                    "description": "This is a test category.  It may have child subcategories.",
+                    "order": 0,
+                    "show_if_empty": false,
+                    "type": ""
+                }
+            },
             "url": "d89af093-8975-4bcb-a747-abe346ebb274",
             "document_name_headline": "[Mock] Cypress Fixture",
             "summary_headline": "This is the summary.  Rubber <span class=\"search-highlight\">baby</span> buggy bumper"

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -168,15 +168,15 @@ const resultLinkClasses = (doc) => ({
                     <CategoryLabel
                         v-if="!_isEmpty(doc.category)"
                         :name="
-                            doc.category.parent
-                                ? doc.category.parent.name
-                                : doc.category.name
+                            doc.category?.parent
+                                ? doc.category?.parent?.name
+                                : doc.category?.name
                         "
                         type="category"
                     />
                     <CategoryLabel
-                        v-if="doc.category.parent"
-                        :name="doc.category.name"
+                        v-if="doc.category?.parent"
+                        :name="doc.category?.name"
                         type="subcategory"
                     />
                 </template>
@@ -184,15 +184,15 @@ const resultLinkClasses = (doc) => ({
                     <CategoryLabel
                         v-if="!_isEmpty(doc.category)"
                         :name="
-                            doc.category.parent
-                                ? doc.category.parent.name
-                                : doc.category.name
+                            doc.category?.parent
+                                ? doc.category?.parent?.name
+                                : doc.category?.name
                         "
                         type="category"
                     />
                     <CategoryLabel
                         v-if="doc.category?.parent"
-                        :name="doc.category.name"
+                        :name="doc.category?.name"
                         type="subcategory"
                     />
                 </template>

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicyResults.vue
@@ -166,9 +166,18 @@ const resultLinkClasses = (doc) => ({
                 />
                 <template v-if="doc.resource_type === 'internal'">
                     <CategoryLabel
-                        v-if="!_isEmpty(doc.document_type)"
-                        :name="doc.document_type.name"
+                        v-if="!_isEmpty(doc.category)"
+                        :name="
+                            doc.category.parent
+                                ? doc.category.parent.name
+                                : doc.category.name
+                        "
                         type="category"
+                    />
+                    <CategoryLabel
+                        v-if="doc.category.parent"
+                        :name="doc.category.name"
+                        type="subcategory"
                     />
                 </template>
                 <template v-else>

--- a/solution/ui/regulations/test/unit-test/__snapshots__/SupplementalContent.test.js.snap
+++ b/solution/ui/regulations/test/unit-test/__snapshots__/SupplementalContent.test.js.snap
@@ -16,7 +16,6 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
         >
           Subpart A Resources
         </h2>
-        <!---->
         <div
           class="supplemental-content-container"
         >
@@ -5902,7 +5901,6 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
       >
         Subpart A Resources
       </h2>
-      <!---->
       <div
         class="supplemental-content-container"
       >


### PR DESCRIPTION
Resolves [EREGCSC-2461](https://jiraent.cms.gov/browse/EREGCSC-2461)

**Description**

Display new internal document categories and subcategories instead of internal Document Type when displaying internal documents on the Policy Repository.  This will match how public resources are displayed.

**This pull request changes:**

- Updates `PolicyResults.vue` logic to display `category.name` or `category.parent.name` instead of `category.document_type.name`.

**Steps to manually verify this change:**

1. Visit the [Policy Repository on the experimental deployment](https://uihabfjjnl.execute-api.us-east-1.amazonaws.com/dev1161/policy-repository)
2. View internal docs and note the category labels above each internal result item
3. Click through to a related citation and make sure the internal categories listed in the reader view's right sidebar match the category on the item when displayed in the Policy Repository

