### PR TITLE
EREGCSC-2484 - Weak Ciphers Enabled

### DIFF
--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -165,7 +165,7 @@ resources:
             TargetOriginId: S3Origin
             ViewerProtocolPolicy: redirect-to-https
           ViewerCertificate:
-            AcmCertificateArn: ${ssm:/eregulations/acm-cert-arn}
+            AcmCertificateArn: arn:aws:acm:us-east-1:910670052382:certificate/b7045ab5-2598-4a59-be48-bad4c925162b
             SslSupportMethod: sni-only
             MinimumProtocolVersion: TLSv1.2
             CloudFrontDefaultCertificate: true

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -165,7 +165,7 @@ resources:
             TargetOriginId: S3Origin
             ViewerProtocolPolicy: redirect-to-https
           ViewerCertificate:
-            AcmCertificateArn: 'arn:aws:acm:us-east-1:910670052382:certificate/b7045ab5-2598-4a59-be48-bad4c925162b'
+            AcmCertificateArn: ${ssm:/eregulations/acm-cert-arn}
             SslSupportMethod: sni-only
             MinimumProtocolVersion: TLSv1.2_2021
           DefaultRootObject: index.html

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -165,6 +165,9 @@ resources:
             TargetOriginId: S3Origin
             ViewerProtocolPolicy: redirect-to-https
           ViewerCertificate:
+            AcmCertificateArn: ${ssm:/eregulations/acm-cert-arn}
+            SslSupportMethod: sni-only
+            MinimumProtocolVersion: TLSv1.2
             CloudFrontDefaultCertificate: true
           DefaultRootObject: index.html
 

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -165,7 +165,7 @@ resources:
             TargetOriginId: S3Origin
             ViewerProtocolPolicy: redirect-to-https
           ViewerCertificate:
-            AcmCertificateArn: arn:aws:acm:us-east-1:910670052382:certificate/b7045ab5-2598-4a59-be48-bad4c925162b
+            AcmCertificateArn: 'arn:aws:acm:us-east-1:910670052382:certificate/b7045ab5-2598-4a59-be48-bad4c925162b'
             SslSupportMethod: sni-only
             MinimumProtocolVersion: TLSv1.2
             CloudFrontDefaultCertificate: true

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -168,7 +168,6 @@ resources:
             AcmCertificateArn: 'arn:aws:acm:us-east-1:910670052382:certificate/b7045ab5-2598-4a59-be48-bad4c925162b'
             SslSupportMethod: sni-only
             MinimumProtocolVersion: TLSv1.2
-            CloudFrontDefaultCertificate: true
           DefaultRootObject: index.html
 
   Outputs:

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -167,7 +167,7 @@ resources:
           ViewerCertificate:
             AcmCertificateArn: 'arn:aws:acm:us-east-1:910670052382:certificate/b7045ab5-2598-4a59-be48-bad4c925162b'
             SslSupportMethod: sni-only
-            MinimumProtocolVersion: TLSv1.2
+            MinimumProtocolVersion: TLSv1.2_2021
           DefaultRootObject: index.html
 
   Outputs:


### PR DESCRIPTION


Resolves #[EREGCSC-2484](https://jiraent.cms.gov/browse/EREGCSC-2484)

**Description-**
Netsparker security scan reported the following:
Invicti Enterprise detected that weak ciphers are enabled during secure communication (SSL).You should allow only strong ciphers on your web server to protect secure communication with your visitors.

Remedy:
Configure your web server to disallow using weak ciphers.
**This pull request changes...**
Updates the serverless for static-assets so that when it creates the cloudfront distribution it also assignes the correct ssl cert. The SSL Cert ARN Value is stored in parameter store. 
- expected change 1

**Steps to manually verify this change...**

1. Sign into cloud tamer. 
2. Go to cloudfront for this pull request. https://us-east-1.console.aws.amazon.com/cloudfront/v4/home?region=us-east-1#/distributions/E1WJ19888GQSV7
3. In settings click Edit
4. Check that the cert is there and its using TLSv1.2_2021 .

