### PR TITLE
EREGCSC02310*enable-htt-strict-transport-security

### DIFF
--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -72,6 +72,7 @@ MIDDLEWARE = [
     'csp.middleware.CSPMiddleware',
     'regulations.middleware.JsonErrors',
     'regulations.middleware.NoIndex',
+    'regulations.middleware.ProcessResponse',
     'regcore.middleware.HtmlApi',
 ]
 

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -71,7 +71,6 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'csp.middleware.CSPMiddleware',
     'regulations.middleware.JsonErrors',
-    'regulations.middleware.NoIndex',
     'regulations.middleware.ProcessResponse',
     'regcore.middleware.HtmlApi',
 ]

--- a/solution/backend/regulations/middleware.py
+++ b/solution/backend/regulations/middleware.py
@@ -25,18 +25,6 @@ class ProcessResponse:
         return response
 
 
-class NoIndex:
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        config = SiteConfiguration.objects.first()
-        response = self.get_response(request)
-        if not config.allow_indexing:
-            response["X-Robots-Tag"] = "noindex"
-        return response
-
-
 class JsonErrors:
     def __init__(self, get_response):
         self.get_response = get_response

--- a/solution/backend/regulations/middleware.py
+++ b/solution/backend/regulations/middleware.py
@@ -6,6 +6,25 @@ from django.http.response import HttpResponse
 from regulations.models import SiteConfiguration
 
 
+class ProcessResponse:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        config = SiteConfiguration.objects.first()
+        response = self.get_response(request)
+
+        # Add Strict-Transport-Security header if HTTPS
+        if request.is_secure() and not response.get("Strict-Transport-Security"):
+            response["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains; preload"
+
+        # Add X-Robots-Tag header based on configuration
+        if not config.allow_indexing:
+            response["X-Robots-Tag"] = "noindex"
+
+        return response
+
+
 class NoIndex:
     def __init__(self, get_response):
         self.get_response = get_response


### PR DESCRIPTION
Resolves #EREGCSC-02310

**Description-**
HTTP Strict Transport Security (HSTS)            

**This pull request changes...**

- expected change 1
Update the middleware to include ProcessResponse method. 
Update settings file to add it as a middleware

**Steps to manually verify this change...**

1. from your local terminal call this command
`curl -I https://7s1cyobtej.execute-api.us-east-1.amazonaws.com/dev1165`
2. look for this in the output "strict-transport-security: max-age=63072000; includeSubDomains; preload"


![Screen Shot 2024-02-07 at 11 11 26 AM](https://github.com/Enterprise-CMCS/cmcs-eregulations/assets/7727136/20731ac4-8e48-4b9e-bf22-a40b0f5e21ed)

