### PR TITLE
EREGCSC-2534-fix-ruff

### DIFF
--- a/.github/workflows/ruff-action.yml
+++ b/.github/workflows/ruff-action.yml
@@ -6,19 +6,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: chartboost/ruff-action@v1
         with:
-          python-version: 3.9
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff  
-
-      - name: Run Ruff
-        run: |
-          ruff check --preview  
+          src: "./solution"
+          args: --preview

--- a/.github/workflows/ruff-action.yml
+++ b/.github/workflows/ruff-action.yml
@@ -1,10 +1,24 @@
 name: Ruff
 on: [ push, pull_request, workflow_dispatch ]
+
 jobs:
   ruff:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: chartboost/ruff-action@v1
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
         with:
-          src: "./solution"
+          python-version: 3.9
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff  
+
+      - name: Run Ruff
+        run: |
+          ruff check --preview  

--- a/.github/workflows/ruff-action.yml
+++ b/.github/workflows/ruff-action.yml
@@ -1,10 +1,8 @@
 name: Ruff
 on: [ push, pull_request, workflow_dispatch ]
-
 jobs:
   ruff:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - uses: chartboost/ruff-action@v1

--- a/solution/Makefile
+++ b/solution/Makefile
@@ -83,11 +83,11 @@ storybook: ui/regulations/.storybook
 lint:
 	flake8;
 ruff:
-	docker-compose exec regulations ruff check .
-	docker-compose exec text-extractor ruff check .
+	docker-compose exec regulations ruff check --preview .
+	docker-compose exec text-extractor ruff check --preview .
 ruff-fix:
-	docker-compose exec regulations ruff --fix .
-	docker-compose exec text-extractor ruff --fix .
+	docker-compose exec regulations ruff --preview --fix .
+	docker-compose exec text-extractor ruff --preview --fix .
 local: ## Start a local environment with parts 400 and 433 loaded.
 local: regulations local.docker data.local
 	@echo Local environment started. Visit http://localhost:8000

--- a/solution/backend/createsu.py
+++ b/solution/backend/createsu.py
@@ -11,8 +11,9 @@ def handler(self, *args, **options):
 
     e_regs_admin_group, _ = Group.objects.get_or_create(name='EREGS_ADMIN')
     e_regs_reader_group, _ = Group.objects.get_or_create(name='EREGS_READER')
-    e_regs_editor_group, _ = Group.objects.get_or_create(name='EREGS_EDITOR')
-    e_regs_manager_group, _ = Group.objects.get_or_create(name='EREGS_MANAGER')
+    # TBD - will be used in the future
+    # e_regs_editor_group, _ = Group.objects.get_or_create(name='EREGS_EDITOR')
+    # e_regs_manager_group, _ = Group.objects.get_or_create(name='EREGS_MANAGER')
 
     if not User.objects.filter(username=os.environ.get('DJANGO_ADMIN_USERNAME')).exists():
         admin_user = User.objects.create_superuser(os.environ.get('DJANGO_ADMIN_USERNAME'),

--- a/solution/backend/file_manager/models.py
+++ b/solution/backend/file_manager/models.py
@@ -81,7 +81,7 @@ class UploadedFile(models.Model):
          editable=False)
 
     def extension(self):
-        name, extension = os.path.splitext(self.file_name)
+        _, extension = os.path.splitext(self.file_name)
         return extension
 
     def get_key(self):

--- a/solution/backend/pyproject.toml
+++ b/solution/backend/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.pytest.ini_options]
+
 DJANGO_SETTINGS_MODULE = "cmcs_regulations.settings.test_settings"
 
 [tool.coverage.run]
@@ -9,20 +10,6 @@ omit = [
 
 
 [tool.ruff]
-# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F", "G", "I", "S", "W", "ASYNC",
-          "E111", "E112", "E113", "E114", "E115", "E116", "E117", "E201", "E202", "E203", "E211", "E222", "E222", "E223",
-          "E224", "E225", "E226", "E227", "E228", "E231", "E241", "E242", "E251", "E252", "E261", "E262", "E265", "E266",
-          "E271", "E272", "E273", "E274", "E275",
-        ]
-ignore = ['S101']
-
-# Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["E", "F", "I", "W",
-           "E201", "E202", "E203", "E211", "E231",
-          ]
-unfixable = []
-
 # Exclude a variety of commonly ignored directories.
 exclude = [
     ".bzr",
@@ -48,6 +35,22 @@ exclude = [
     "venv",
     "migrations",
 ]
+line-length = 130
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F", "G", "I", "S", "W", "ASYNC",
+          "E111", "E112", "E113", "E114", "E115", "E116", "E117", "E201", "E202", "E203", "E211", "E222", "E222", "E223",
+          "E224", "E225", "E226", "E227", "E228", "E231", "E241", "E242", "E251", "E252", "E261", "E262", "E265", "E266",
+          "E271", "E272", "E273", "E274", "E275",
+        ]
+ignore = ['S101']
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+[lint]
+fixable = ["E", "F", "I", "W",
+           "E201", "E202", "E203", "E211", "E231",
+          ]
+unfixable = []
+
 
 # Same as Black.
 line-length = 130

--- a/solution/backend/regcore/serializers/parser.py
+++ b/solution/backend/regcore/serializers/parser.py
@@ -79,21 +79,21 @@ class PartUploadSerializer(serializers.Serializer):
             from resources.models import Section, Subpart  # can throw ImportError, this is fine
 
             for section in validated_data.get("sections", []):
-                new_orphan_section, created = Section.objects.get_or_create(
+                Section.objects.get_or_create(
                     title=section["title"],
                     part=section["part"],
                     section_id=section["section"],
                 )
 
             for subpart in validated_data.get("subparts", []):
-                new_subpart, created = Subpart.objects.get_or_create(
+                new_subpart, _ = Subpart.objects.get_or_create(
                     title=subpart["title"],
                     part=subpart["part"],
                     subpart_id=subpart["subpart"],
                 )
 
                 for section in subpart["sections"]:
-                    new_section, created = Section.objects.update_or_create(
+                    Section.objects.update_or_create(
                         title=section["title"],
                         part=section["part"],
                         section_id=section["section"],

--- a/solution/backend/regcore/views/parser.py
+++ b/solution/backend/regcore/views/parser.py
@@ -66,7 +66,7 @@ class PartUploadViewSet(viewsets.ModelViewSet):
             "depth_stack": [],
             "depth": -1,
         }
-        part, created = Part.objects.get_or_create(title=data["title"], name=data["name"], date=data["date"], defaults=defaults)
+        part, _ = Part.objects.get_or_create(title=data["title"], name=data["name"], date=data["date"], defaults=defaults)
         data["id"] = part.pk
         sc = self.get_serializer(part, data=data)
         if sc.is_valid(raise_exception=True):

--- a/solution/lambda-proxy/pyproject.toml
+++ b/solution/lambda-proxy/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.ruff]
+[lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 select = ["E", "F", "G", "I", "S", "W", "ASYNC",
           "E111", "E112", "E113", "E114", "E115", "E116", "E117", "E201", "E202", "E203", "E211", "E222", "E222", "E223",

--- a/solution/text-extractor/pyproject.toml
+++ b/solution/text-extractor/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.ruff]
+[lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
 select = ["E", "F", "G", "I", "S", "W", "ASYNC",
           "E111", "E112", "E113", "E114", "E115", "E116", "E117", "E201", "E202", "E203", "E211", "E222", "E222", "E223",


### PR DESCRIPTION
Resolves #EREGCSC-2534-fix-ruff 

**Description-**
Ruff depregated running the rules with out the --preview. Also it is now required to have [lint] infront of certain rules. 

**This pull request changes...**
Updated makefile and github actions to run ruff check with --preview. 
Updated the configuratiaons to use lint as it had asked.
Updated the pre-existing violations with a #no qa  but moving forward these have to be fixed.

- expected change 9 files.
some ruff violations fixed in this pull request as well as updating the ruff configurations. 
**Steps to manually verify this change...**

1. check that ruff ran ok. 
2. download branch and run `make ruff` and `make ruff-fix` make sure these are running correctly. 

