### PR TITLE
EREGCSC-2499 -- Enable subject lookup for non-logged in users

### DIFF
--- a/solution/backend/content_search/tests/test_search.py
+++ b/solution/backend/content_search/tests/test_search.py
@@ -70,14 +70,16 @@ class SearchTest(TestCase):
         index_group(UploadedFile.objects.all())
 
     def test_no_query_not_logged_in(self):
+        response = self.client.get("/v3/content-search/?resource-type=internal")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         response = self.client.get("/v3/content-search/?resource-type=external")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = get_paginated_data(response)
         self.assertEqual(data['count'], 6)
-        response = self.client.get("/v3/content-search/?resource-type=internal")
+        response = self.client.get("/v3/content-search/?resource-type=all")
         data = get_paginated_data(response)
         self.assertEqual(data['count'], 6)
-        response = self.client.get("/v3/content-search/?resource-type=all")
+        response = self.client.get("/v3/content-search/")
         data = get_paginated_data(response)
         self.assertEqual(data['count'], 6)
 

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -84,11 +84,14 @@ class ContentSearchViewset(LocationFiltererMixin, OptionalPaginationMixin, views
                                                      .select_related("repositorysubcategory__parent")
 
         # If they are not authenticated and the resource type is internal, raise an error
-        if not request.user.is_authenticated and resource_type == 'internal':
-            raise NotAuthenticated()
+        if not request.user.is_authenticated:
+            if resource_type == 'internal':
+                raise NotAuthenticated()
+            else:
+                query = query.filter(resource_type='external')
         elif resource_type == 'internal':
             query = query.filter(resource_type='internal')
-        else:
+        elif resource_type == 'external':
             query = query.filter(resource_type='external')
 
         context = self.get_serializer_context()

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
+from rest_framework.exceptions import NotAuthenticated
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -82,11 +83,13 @@ class ContentSearchViewset(LocationFiltererMixin, OptionalPaginationMixin, views
         repo_category_prefetch = AbstractRepoCategory.objects.all().select_subclasses()\
                                                      .select_related("repositorysubcategory__parent")
 
-        # If they are not authenticated they csan only get 'external' documents
-        if not request.user.is_authenticated or resource_type == 'external':
-            query = query.filter(resource_type='external')
+        # If they are not authenticated and the resource type is internal, raise an error
+        if not request.user.is_authenticated and resource_type == 'internal':
+            raise NotAuthenticated()
         elif resource_type == 'internal':
             query = query.filter(resource_type='internal')
+        else:
+            query = query.filter(resource_type='external')
 
         context = self.get_serializer_context()
         context['content_id'] = True

--- a/solution/backend/regulations/templates/regulations/policy_repository.html
+++ b/solution/backend/regulations/templates/regulations/policy_repository.html
@@ -18,11 +18,11 @@
 {% endblock %}
 
 {% block body %}
-
 <div
     id="vite-app"
     data-api-url="{{ API_BASE }}"
     data-about-url="{% url 'about' %}"
+    data-custom-login-url="{% url 'custom_login' %}"
     data-custom-url="{{ CUSTOM_URL }}"
     data-home-url="{% url 'homepage' %}"
     data-resources-url="{% url 'resources' %}"

--- a/solution/backend/regulations/views/policy_repository.py
+++ b/solution/backend/regulations/views/policy_repository.py
@@ -1,7 +1,5 @@
 from django.views.generic.base import TemplateView
 
-from regulations.views.mixins import IsAuthenticatedMixin
-
 
 class PolicyRepositoryView(TemplateView):
 

--- a/solution/backend/regulations/views/policy_repository.py
+++ b/solution/backend/regulations/views/policy_repository.py
@@ -3,7 +3,7 @@ from django.views.generic.base import TemplateView
 from regulations.views.mixins import IsAuthenticatedMixin
 
 
-class PolicyRepositoryView(IsAuthenticatedMixin, TemplateView):
+class PolicyRepositoryView(TemplateView):
 
     template_name = 'regulations/policy_repository.html'
 

--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -581,7 +581,7 @@ describe("Policy Repository", () => {
         cy.url().should("include", "/resources");
     });
 
-    it("returns you to the custom eua login page when you log out", () => {
+    it("returns you to the policy repo logged out view when you log out", () => {
         cy.viewport("macbook-15");
         cy.eregsLogin({
             username,
@@ -590,7 +590,18 @@ describe("Policy Repository", () => {
         });
         cy.visit("/policy-repository");
         cy.get("#logout").click();
-        cy.url().should("include", "/login");
+        cy.url().should("include", "/policy-repository");
+        cy.get("#loginIndicator").should("not.be.visible");
+        cy.get(".doc-type__toggle fieldset > div")
+            .eq(0)
+            .find("input")
+            .should("be.checked")
+            .and("be.disabled");
+        cy.get(".doc-type__toggle fieldset > div")
+            .eq(1)
+            .find("input")
+            .should("not.be.checked")
+            .and("be.disabled");
     });
 });
 

--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -52,6 +52,9 @@ describe("Policy Repository", () => {
     it("should show only public items when logged out", () => {
         cy.viewport("macbook-15");
         cy.visit("/policy-repository/");
+
+        cy.injectAxe();
+
         cy.get("#loginIndicator").should("not.be.visible");
         cy.get(".doc-type__toggle fieldset > div")
             .eq(0)
@@ -63,6 +66,9 @@ describe("Policy Repository", () => {
             .find("input")
             .should("not.be.checked")
             .and("be.disabled");
+
+        cy.checkAccessibility();
+
         cy.get(
             ".subj-toc__list li[data-testid=subject-toc-li-3] a"
         ).scrollIntoView();

--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -62,7 +62,7 @@ describe("Policy Repository", () => {
             ".subj-toc__list li[data-testid=subject-toc-li-3] div.subj-toc-li__count"
         )
             .should("be.visible")
-            .and("have.text", "0 public and 1 internal resources ");
+            .and("have.text", "0 public and 1 internal resources");
         cy.get(
             ".subj-toc__list li[data-testid=subject-toc-li-63] a"
         ).scrollIntoView();

--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -31,7 +31,7 @@ Cypress.Commands.add("getPolicyDocs", ({ username, password }) => {
         fixture: "policy-docs.json",
     }).as("subjectFiles");
     cy.viewport("macbook-15");
-    cy.eregsLogin({ username, password, landingPage: "/policy-repository/"});
+    cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
     cy.visit("/policy-repository/?q=mock");
     cy.injectAxe();
     cy.wait("@subjectFiles").then((interception) => {
@@ -42,15 +42,56 @@ Cypress.Commands.add("getPolicyDocs", ({ username, password }) => {
 describe("Policy Repository", () => {
     beforeEach(_beforeEach);
 
-    it("shows the custom eua login screen when you visit /policy-repository/ without logging in", () => {
+    it("shows the custom eua login screen when you visit /policy-repository/ and click 'sign in'", () => {
         cy.viewport("macbook-15");
         cy.visit("/policy-repository/");
+        cy.get(".div__login-sidebar a").click();
         cy.url().should("include", "/login");
     });
 
-    it("should show the policy repository page when logged in", () => {
+    it("should show only public items when logged out", () => {
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.visit("/policy-repository/");
+        cy.get("#loginIndicator").should("not.be.visible");
+        cy.get(".doc-type__toggle fieldset > div")
+            .eq(0)
+            .find("input")
+            .should("be.checked")
+            .and("be.disabled");
+        cy.get(".doc-type__toggle fieldset > div")
+            .eq(1)
+            .find("input")
+            .should("not.be.checked")
+            .and("be.disabled");
+        cy.get(
+            ".subj-toc__list li[data-testid=subject-toc-li-3] a"
+        ).scrollIntoView();
+        cy.get(
+            ".subj-toc__list li[data-testid=subject-toc-li-3] div.subj-toc-li__count"
+        )
+            .should("be.visible")
+            .and("have.text", "0 public resources");
+        cy.get(
+            ".subj-toc__list li[data-testid=subject-toc-li-63] a"
+        ).scrollIntoView();
+        cy.get(".subj-toc__list li[data-testid=subject-toc-li-63] a")
+            .should("have.text", " Managed Care ")
+            .click({ force: true });
+        cy.url().should("include", "/policy-repository?subjects=63");
+        cy.get(".subject__heading")
+            .should("exist")
+            .and("have.text", "Managed Care");
+        cy.url().should("include", "/policy-repository?subjects=63");
+
+    })
+
+    it("should show public and internal items when logged in", () => {
+        cy.viewport("macbook-15");
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
         cy.visit("/policy-repository");
         cy.url().should("include", "/policy-repository/");
         cy.get("#loginIndicator").should("be.visible");
@@ -139,7 +180,11 @@ describe("Policy Repository", () => {
     it("should make a successful request to the content-search endpoint", () => {
         cy.intercept("**/v3/content-search/?**").as("files");
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
         cy.visit("/policy-repository");
         cy.url().should("include", "/policy-repository/");
         cy.get(".subj-toc__list li:nth-child(1) a").click({ force: true });
@@ -150,7 +195,11 @@ describe("Policy Repository", () => {
 
     it("loads the correct subject and search query when the URL is changed", () => {
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
 
         cy.visit("/policy-repository");
         cy.url().should("include", "/policy-repository/");
@@ -271,7 +320,11 @@ describe("Policy Repository", () => {
             fixture: "policy-docs.json",
         }).as("subjectFiles");
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
 
         cy.visit("/policy-repository/");
         cy.get(".doc-type__toggle fieldset > div")
@@ -304,7 +357,9 @@ describe("Policy Repository", () => {
             "include",
             "/policy-repository?type=internal&subjects=3&q=test%20search"
         );
-        cy.get(".search-form .form-helper-text .search-suggestion").should("not.exist");
+        cy.get(".search-form .form-helper-text .search-suggestion").should(
+            "not.exist"
+        );
         cy.get(".document__subjects a")
             .eq(0)
             .should("have.text", " Access to Services ");
@@ -334,7 +389,11 @@ describe("Policy Repository", () => {
 
     it("should display correct subject ID number in the URL if one is included in the URL on load and different one is selected via the Subject Selector", () => {
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
         cy.visit("/policy-repository/?subjects=77");
         cy.url().should("include", "/policy-repository/?subjects=77");
         cy.get(`button[data-testid=remove-subject-77]`).should("exist");
@@ -356,7 +415,11 @@ describe("Policy Repository", () => {
 
     it("should filter the subject list when a search term is entered into the subject filter", () => {
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
         cy.visit("/policy-repository/");
 
         cy.injectAxe();
@@ -407,7 +470,11 @@ describe("Policy Repository", () => {
     it("should display and fetch the correct search query on load if it is included in URL", () => {
         cy.intercept("**/v3/content-search/?q=test**").as("qFiles");
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
         cy.visit("/policy-repository/?q=test");
         cy.wait("@qFiles").then((interception) => {
             expect(interception.response.statusCode).to.eq(200);
@@ -418,7 +485,11 @@ describe("Policy Repository", () => {
 
     it("should have a Documents to Show checkbox list", () => {
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
         cy.visit("/policy-repository");
         cy.get(".doc-type__toggle-container h3").should(
             "have.text",
@@ -448,7 +519,11 @@ describe("Policy Repository", () => {
 
     it("should show only the Table of Contents if both or neither checkboxes are checked", () => {
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
         cy.visit("/policy-repository");
         cy.get(".subj-toc__container").should("exist");
         cy.get(".doc-type__toggle fieldset > div")
@@ -476,7 +551,11 @@ describe("Policy Repository", () => {
     it("should not make a request to the content-search endpoint if both checkboxes are checked on load", () => {
         cy.intercept("**/v3/content-search/**").as("contentSearch");
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
         cy.visit("/policy-repository");
         cy.wait(2000);
         cy.get("@contentSearch.all").then((interception) => {
@@ -486,7 +565,11 @@ describe("Policy Repository", () => {
 
     it("goes to another SPA page from the policy repository page", () => {
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
         cy.visit("/policy-repository");
         cy.clickHeaderLink({ page: "Resources", screen: "wide" });
         cy.url().should("include", "/resources");
@@ -494,7 +577,11 @@ describe("Policy Repository", () => {
 
     it("returns you to the custom eua login page when you log out", () => {
         cy.viewport("macbook-15");
-        cy.eregsLogin({ username, password, landingPage: "/policy-repository/" });
+        cy.eregsLogin({
+            username,
+            password,
+            landingPage: "/policy-repository/",
+        });
         cy.visit("/policy-repository");
         cy.get("#logout").click();
         cy.url().should("include", "/login");
@@ -539,7 +626,9 @@ describe("Policy Repository Search", () => {
             force: true,
         });
         cy.url().should("include", "/policy-repository/search?q=test%20search");
-        cy.get(".search-form .form-helper-text .search-suggestion").should("not.exist");
+        cy.get(".search-form .form-helper-text .search-suggestion").should(
+            "not.exist"
+        );
         cy.wait("@queriedFiles").then((interception) => {
             expect(interception.response.statusCode).to.eq(200);
         });

--- a/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/policy-repository.spec.cy.js
@@ -88,7 +88,12 @@ describe("Policy Repository", () => {
             .should("exist")
             .and("have.text", "Managed Care");
         cy.url().should("include", "/policy-repository?subjects=63");
+    })
 
+    it("should strip document-type query parameter from URL when not logged in", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/policy-repository/?type=internal");
+        cy.url().should("not.include", "type");
     })
 
     it("should show public and internal items when logged in", () => {

--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -575,3 +575,11 @@ select {
     height: 32px;
     padding: 0 12px;
 }
+
+.div__login-sidebar {
+    background-color: $secondary_background_color;
+    border: 1px solid $border_color;
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+    margin: 1rem 0;
+}

--- a/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
+++ b/solution/ui/regulations/css/scss/partials/_sidebar_right.scss
@@ -35,14 +35,6 @@ aside.right-sidebar {
         margin-bottom: 0px !important;
     }
 
-    .div__login-sidebar {
-        background-color: $secondary_background_color;
-        border: 1px solid $border_color;
-        border-radius: 0.25rem;
-        padding: 0.5rem;
-        margin: 1rem 0;
-    }
-
     .label__container {
         display: flex;
         margin-top: 1rem;

--- a/solution/ui/regulations/eregs-vite/src/App.vue
+++ b/solution/ui/regulations/eregs-vite/src/App.vue
@@ -13,6 +13,10 @@ export default {
             type: String,
             default: "/about/",
         },
+        customLoginUrl: {
+            type: String,
+            default: "",
+        },
         customUrl: {
             type: String,
             default: "",
@@ -54,6 +58,7 @@ export default {
         <router-view
             :api-url="apiUrl"
             :about-url="aboutUrl"
+            :custom-login-url="customLoginUrl"
             :custom-url="customUrl"
             :home-url="homeUrl"
             :resources-url="resourcesUrl"

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/DocumentTypeSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/DocumentTypeSelector.vue
@@ -16,16 +16,21 @@ const { type: typeParams } = $route.query;
 const isAuthenticated = inject("isAuthenticated");
 
 // v-model with a ref to control if the checkbox displays as checked or not
-// refactor this ugly monster into let boxesArr and if/else blocks
-const boxesArr = !isAuthenticated
-    ? ["external"]
-    : _isUndefined(typeParams) ||
-      typeParams === "all" ||
-      typeParams.includes("all")
-    ? [...DOCUMENT_TYPES]
-    : _isArray(typeParams)
-    ? typeParams
-    : [typeParams];
+let boxesArr;
+
+if (!isAuthenticated) {
+    boxesArr = ["external"];
+} else if (
+    _isUndefined(typeParams) ||
+    typeParams === "all" ||
+    typeParams.includes("all")
+) {
+    boxesArr = [...DOCUMENT_TYPES];
+} else if (_isArray(typeParams)) {
+    boxesArr = typeParams;
+} else {
+    boxesArr = [typeParams];
+}
 
 const checkedBoxes = ref(boxesArr);
 

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/DocumentTypeSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/DocumentTypeSelector.vue
@@ -16,6 +16,7 @@ const { type: typeParams } = $route.query;
 const isAuthenticated = inject("isAuthenticated");
 
 // v-model with a ref to control if the checkbox displays as checked or not
+// refactor this ugly monster into let boxesArr and if/else blocks
 const boxesArr = !isAuthenticated
     ? ["external"]
     : _isUndefined(typeParams) ||

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/DocumentTypeSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/DocumentTypeSelector.vue
@@ -15,7 +15,7 @@ const { type: typeParams } = $route.query;
 
 const isAuthenticated = inject("isAuthenticated");
 
-// v-model with a ref to control if the checkbox displays as checked or not
+// v-model with a ref to control if the checkbox is displayed as checked or not
 let boxesArr;
 
 if (!isAuthenticated) {

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicySidebar.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/PolicySidebar.vue
@@ -1,3 +1,41 @@
+<script setup>
+import { inject, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router/composables";
+
+const customLoginUrl = inject("customLoginUrl");
+const homeUrl = inject("homeUrl");
+const isAuthenticated = inject("isAuthenticated");
+
+const $route = useRoute();
+
+const loginUrl = ref(customLoginUrl);
+
+const setLoginUrl = () => {
+    if (!$route.fullPath.includes("?")) {
+        loginUrl.value = customLoginUrl;
+        return;
+    }
+
+    const pathQuery = $route.fullPath.split("?")[1];
+
+    if (pathQuery.length == 0) {
+        loginUrl.value = customLoginUrl;
+        return;
+    }
+
+    loginUrl.value = `${customLoginUrl}?next=${homeUrl}policy-repository/?${pathQuery}`;
+};
+
+watch(
+    () => $route.query,
+    async (newQueryParams) => {
+        setLoginUrl();
+    }
+);
+
+setLoginUrl();
+</script>
+
 <template>
     <div class="sidebar__filters">
         <slot name="title">
@@ -6,6 +44,13 @@
         <div class="sidebar-filters__container">
             <slot name="selections"> </slot>
             <slot name="search"> </slot>
+            <template v-if="!isAuthenticated">
+                <div class="div__login-sidebar">
+                    CMCS staff participating in the Policy Repository pilot can
+                    <a :href="loginUrl" rel="noopener noreferrer">sign in</a>
+                    to see internal resources.
+                </div>
+            </template>
             <slot name="filters"></slot>
         </div>
     </div>

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectTOC.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectTOC.vue
@@ -68,7 +68,12 @@ const subjectsLength = computed(() => props.policyDocSubjects.results.length);
                                 >{{ subject.internal_content ?? 0 }}</span
                             >
                             internal </span
-                        >resources
+                        >resource<span
+                            v-if="
+                                isAuthenticated || subject.external_content != 1
+                            "
+                            >s</span
+                        >
                     </div>
                 </li>
             </ul>

--- a/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectTOC.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/policy-repository/SubjectTOC.vue
@@ -1,7 +1,9 @@
 <script setup>
-import { computed, ref } from "vue";
+import { computed, inject } from "vue";
 
 import { getSubjectNameParts } from "utilities/filters";
+
+const isAuthenticated = inject("isAuthenticated");
 
 const props = defineProps({
     policyDocSubjects: {
@@ -58,12 +60,15 @@ const subjectsLength = computed(() => props.policyDocSubjects.results.length);
                         <span class="subj-doc__count subj-doc__count--public">{{
                             subject.external_content ?? 0
                         }}</span>
-                        public and
-                        <span
-                            class="subj-doc__count subj-doc__count--internal"
-                            >{{ subject.internal_content ?? 0 }}</span
-                        >
-                        internal resources
+                        public
+                        <span v-if="isAuthenticated"
+                            >and
+                            <span
+                                class="subj-doc__count subj-doc__count--internal"
+                                >{{ subject.internal_content ?? 0 }}</span
+                            >
+                            internal </span
+                        >resources
                     </div>
                 </li>
             </ul>

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -21,7 +21,7 @@ Vue.directive("clickaway", Clickaway);
 const router = vueRouter({ customUrl, host });
 
 router.beforeEach((to, from, next) => {
-    if (!isAuthenticated && to.query?.type) {
+    if (!isAuthenticated && to.name === "policy-repository" && to.query?.type) {
         const { type, ...query } = to.query;
         next({ ...to, query });
     } else {

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -13,9 +13,21 @@ const mountEl = document.querySelector("#vite-app");
 Vue.config.devtools = true;
 const { customUrl, host } = mountEl.dataset;
 
+let { isAuthenticated } = mountEl.dataset;
+isAuthenticated = isAuthenticated === "True";
+
 Vue.directive("clickaway", Clickaway);
 
 const router = vueRouter({ customUrl, host });
+
+router.beforeEach((to, from, next) => {
+    if (!isAuthenticated && to.query?.type) {
+        const { type, ...query } = to.query;
+        next({ ...to, query });
+    } else {
+        next();
+    }
+});
 
 // Silence duplicate navigation errors
 // see:

--- a/solution/ui/regulations/eregs-vite/src/views/PolicyRepository.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/PolicyRepository.vue
@@ -81,6 +81,8 @@ const FilterTypesDict = {
 provide("apiUrl", props.apiUrl);
 provide("base", props.homeUrl);
 provide("FilterTypesDict", FilterTypesDict);
+provide("isAuthenticated", props.isAuthenticated);
+
 
 /**
  * @param {Object} queryParams - $route.query

--- a/solution/ui/regulations/eregs-vite/src/views/PolicyRepository.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/PolicyRepository.vue
@@ -41,9 +41,21 @@ const props = defineProps({
         type: String,
         default: "/v3/",
     },
+    customLoginUrl: {
+        type: String,
+        default: "/login",
+    },
+    hasEditableJobCode: {
+        type: Boolean,
+        default: false,
+    },
     homeUrl: {
         type: String,
         default: "/",
+    },
+    isAuthenticated: {
+        type: Boolean,
+        default: false,
     },
     resourcesUrl: {
         type: String,
@@ -56,14 +68,6 @@ const props = defineProps({
     statutesUrl: {
         type: String,
         default: "/statutes/",
-    },
-    isAuthenticated: {
-        type: Boolean,
-        default: false,
-    },
-    hasEditableJobCode: {
-        type: Boolean,
-        default: false,
     },
 });
 
@@ -80,9 +84,10 @@ const FilterTypesDict = {
 // provide Django template variables
 provide("apiUrl", props.apiUrl);
 provide("base", props.homeUrl);
+provide("customLoginUrl", props.customLoginUrl);
 provide("FilterTypesDict", FilterTypesDict);
+provide("homeUrl", props.homeUrl);
 provide("isAuthenticated", props.isAuthenticated);
-
 
 /**
  * @param {Object} queryParams - $route.query

--- a/solution/ui/regulations/eregs-vite/src/views/PolicyRepository.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/PolicyRepository.vue
@@ -158,7 +158,7 @@ const getDocList = async (requestParams = "") => {
     try {
         const contentList = await getCombinedContent({
             apiUrl: props.apiUrl,
-            cacheResponse: !props.isAuthenticated,
+            cacheResponse: false,
             requestParams,
         });
         policyDocList.value.results = contentList.results;


### PR DESCRIPTION
Resolves [EREGCSC-2499](https://jiraent.cms.gov/browse/EREGCSC-2499)

**Description**

Allow unauthenticated users visit the Policy Repository and view Public documents.

See [Figma comp](https://www.figma.com/file/RonM8dMInKz3ZliDACzr96/Logged-Out?type=design&node-id=1-55&mode=design&t=Wu320m7eM1GZhNrJ-0) for design.

**This pull request changes:**

- Disables Public/Internal document checkboxes and makes "Public" the only checked box.
- Adds login Call to Action in the left sidebar with a log in link if user is not logged in.
- Only public item counts are shown in the Subject Table of Contents.
- Internal items are not returned or displayed from the API until user logs in.

**Steps to manually verify this change:**

1. Visit [experimental deployment](https://b9w7peaq33.execute-api.us-east-1.amazonaws.com/dev1167) and make sure you are NOT logged in.
2. Navigate to the [Policy Repository page](https://b9w7peaq33.execute-api.us-east-1.amazonaws.com/dev1167/policy-repository/)
1. Make sure the "Documents to Show" checkboxes in the left sidebar are disabled and cannot be toggled via cursor or keyboard navigation.
   - Only "Public" should be checked
1. Under each subject in the Subject Table of Contents, you should only see a count for "public resources"
1. Filtering by subject and search by test string should work as expected but should only display public items.
3. View the [API endpoint ](https://b9w7peaq33.execute-api.us-east-1.amazonaws.com/dev1167/v3/content-search/?subjects=2)in your browser and ensure that no internal documents are being returned
4. View the [API endpoint with internal documents as the document-type](https://b9w7peaq33.execute-api.us-east-1.amazonaws.com/dev1167/v3/content-search/?resource-type=internal&subjects=2) in your browser.  You should receive a `403 Forbidden` error.
5. Click the "sign in" link on the left side of the page and make sure it takes you to the new custom login screen
   - if you have selected a subject and/or entered a search query, you should see them reflected in the `next` query param at the new custom login screen
1. Log in using `admin` (since EUA doesn't work on all experimental deployments)
6. Make sure "Documents to Show" checkboxes are active and can be toggled.  Make sure site works as expected.
3. View the [API endpoint](https://b9w7peaq33.execute-api.us-east-1.amazonaws.com/dev1167/v3/content-search/?subjects=2) in your browser and notice that both internal and external documents are now being returned.
4. View the [API endpoint with internal documents as the document-type](https://b9w7peaq33.execute-api.us-east-1.amazonaws.com/dev1167/v3/content-search/?resource-type=internal&subjects=2) in your browser.  You should not receive an error and internal documents should now be returned.

