### PR TITLE
EREGCSC-2522-Make-prod-logout-behavior-match-other-env

### DIFF
--- a/solution/backend/cmcs_regulations/settings/euasettings.py
+++ b/solution/backend/cmcs_regulations/settings/euasettings.py
@@ -20,7 +20,7 @@ OIDC_REDIRECT_URL = "/admin/oidc/callback/"
 OIDC_RP_SIGN_ALGO = 'RS256'
 LOGIN_REDIRECT_URL = '/login/'
 
-LOGOUT_REDIRECT_URL = 'http://localhost:8000/login'
+LOGOUT_REDIRECT_URL = '/login'
 EUA_FEATUREFLAG = os.getenv('EUA_FEATUREFLAG', 'False').lower() == 'true'
 OIDC_END_EUA_SESSION = os.environ.get("OIDC_END_EUA_SESSION", None)
 OIDC_OP_LOGOUT_URL_METHOD = 'regulations.logout.eua_logout'

--- a/solution/backend/cmcs_regulations/settings/euasettings.py
+++ b/solution/backend/cmcs_regulations/settings/euasettings.py
@@ -1,5 +1,6 @@
 import os
 import re
+from django.urls import reverse
 
 # EUA settings
 AUTHENTICATION_BACKENDS = (
@@ -16,16 +17,11 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("OIDC_OP_AUTHORIZATION_ENDPOINT"
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("OIDC_OP_TOKEN_ENDPOINT", None)
 OIDC_OP_USER_ENDPOINT = os.environ.get("OIDC_OP_USER_ENDPOINT", None)
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("OIDC_OP_JWKS_ENDPOINT", None)
-OIDC_REDIRECT_URL = "/admin/oidc/callback/"
+OIDC_REDIRECT_URL = '/admin/oidc/callback/'
 OIDC_RP_SIGN_ALGO = 'RS256'
-LOGIN_REDIRECT_URL = '/login/'
-
-LOGOUT_REDIRECT_URL = '/login'
+LOGIN_REDIRECT_URL = 'custom_login'
+LOGOUT_REDIRECT_URL = 'logout'
 EUA_FEATUREFLAG = os.getenv('EUA_FEATUREFLAG', 'False').lower() == 'true'
 OIDC_END_EUA_SESSION = os.environ.get("OIDC_END_EUA_SESSION", None)
 OIDC_OP_LOGOUT_URL_METHOD = 'regulations.logout.eua_logout'
 OIDC_STORE_ID_TOKEN = True
-
-if re.match(r'^dev\d*$', STAGE_ENV) or STAGE_ENV == 'dev' or STAGE_ENV == 'val':
-    LOGIN_REDIRECT_URL = f"/{STAGE_ENV}/login/"
-    LOGOUT_REDIRECT_URL = f"/{STAGE_ENV}/login/"

--- a/solution/backend/cmcs_regulations/settings/euasettings.py
+++ b/solution/backend/cmcs_regulations/settings/euasettings.py
@@ -1,6 +1,4 @@
 import os
-import re
-from django.urls import reverse
 
 # EUA settings
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
Resolves #EREGCSC-2522

**Description-**
cleaned up eau_settings.yml it had localhost:8000 as default which is a bug.
**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. Make sure tests passing.
2. Visit [this site](https://5trxu4mf3i.execute-api.us-east-1.amazonaws.com/dev1141)
3. Sign in and then sign out, make sure you are logged out correctly and redirected to the right page. 

