### PR TITLE
[HOTFIX] Ensure login link on Subjects page includes `next` path for redirect after login

### DIFF
--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -68,7 +68,9 @@ describe("Find by Subjects", () => {
 
         cy.get(".div__login-sidebar a")
             .click();
-        cy.url().should("include", "/?next=/subjects/");
+        cy.url().should("include", "/?next=")
+            .and("include", "subjects/")
+            .and("not.include", "q=");
     });
 
     it("should show only public items when logged out", () => {

--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -49,7 +49,8 @@ describe("Find by Subjects", () => {
         cy.url().should("include", "/subjects/?subjects=2&q=test");
         cy.get(".div__login-sidebar a")
             .should("have.attr", "href")
-            .and("include", "/?next=/subjects/?subjects=2&q=test");
+            .and("include", "next")
+            .and("include", "subjects/?q=test&subjects=2");
     });
 
     it("shows the custom eua login screen when you visit /subjects/ and click 'sign in'", () => {
@@ -57,7 +58,10 @@ describe("Find by Subjects", () => {
         cy.visit("/subjects/");
         cy.get(".div__login-sidebar a")
             .should("have.attr", "href")
-            .and("include", "/?next=/subjects/");
+            .and("include", "next")
+            .and("include", "subjects/")
+            .and("not.include", "q=");
+
         cy.get(".div__login-sidebar a")
             .click();
         cy.url().should("include", "/?next=/subjects/");

--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -50,7 +50,7 @@ describe("Find by Subjects", () => {
         cy.get(".div__login-sidebar a")
             .should("have.attr", "href")
             .and("include", "next")
-            .and("include", "subjects/?q=test&subjects=2");
+            .and("include", "subjects/?subjects=2&q=test");
     });
 
     it("shows the custom eua login screen when you visit /subjects/ and click 'sign in'", () => {

--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -46,14 +46,21 @@ describe("Find by Subjects", () => {
         cy.viewport("macbook-15");
         cy.visit("/policy-repository?subjects=2&q=test");
         cy.url().should("not.include", "/policy-repository");
-        cy.url().should("include", "/subjects/?q=test&subjects=2");
+        cy.url().should("include", "/subjects/?subjects=2&q=test");
+        cy.get(".div__login-sidebar a")
+            .should("have.attr", "href")
+            .and("include", "/?next=/subjects/?subjects=2&q=test");
     });
 
     it("shows the custom eua login screen when you visit /subjects/ and click 'sign in'", () => {
         cy.viewport("macbook-15");
         cy.visit("/subjects/");
-        cy.get(".div__login-sidebar a").click();
-        cy.url().should("include", "/login");
+        cy.get(".div__login-sidebar a")
+            .should("have.attr", "href")
+            .and("include", "/?next=/subjects/");
+        cy.get(".div__login-sidebar a")
+            .click();
+        cy.url().should("include", "/?next=/subjects/");
     });
 
     it("should show only public items when logged out", () => {
@@ -95,13 +102,13 @@ describe("Find by Subjects", () => {
             .should("exist")
             .and("have.text", "Managed Care");
         cy.url().should("include", "/subjects?subjects=63");
-    })
+    });
 
     it("should strip document-type query parameter from URL when not logged in", () => {
         cy.viewport("macbook-15");
         cy.visit("/subjects/?type=internal");
         cy.url().should("not.include", "type");
-    })
+    });
 
     it("should show public and internal items when logged in", () => {
         cy.viewport("macbook-15");
@@ -361,10 +368,7 @@ describe("Find by Subjects", () => {
         cy.get(`button[data-testid=add-subject-3]`).click({
             force: true,
         });
-        cy.url().should(
-            "include",
-            "/subjects?type=internal&subjects=3"
-        );
+        cy.url().should("include", "/subjects?type=internal&subjects=3");
         cy.get("input#main-content")
             .should("be.visible")
             .type("test search", { force: true });

--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -46,11 +46,15 @@ describe("Find by Subjects", () => {
         cy.viewport("macbook-15");
         cy.visit("/policy-repository?subjects=2&q=test");
         cy.url().should("not.include", "/policy-repository");
-        cy.url().should("include", "/subjects/?subjects=2&q=test");
+        cy.url().should("include", "/subjects/")
+            .and("include", "subjects=2")
+            .and("include", "q=test");
         cy.get(".div__login-sidebar a")
             .should("have.attr", "href")
             .and("include", "next")
-            .and("include", "subjects/?subjects=2&q=test");
+            .and("include", "subjects/")
+            .and("include", "q=test")
+            .and("include", "subjects=2");
     });
 
     it("shows the custom eua login screen when you visit /subjects/ and click 'sign in'", () => {

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicySidebar.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicySidebar.vue
@@ -11,19 +11,21 @@ const $route = useRoute();
 const loginUrl = ref(customLoginUrl);
 
 const setLoginUrl = () => {
+    const redirectUrl = `${customLoginUrl}?next=${homeUrl}subjects/`;
+
     if (!$route.fullPath.includes("?")) {
-        loginUrl.value = customLoginUrl;
+        loginUrl.value = redirectUrl;
         return;
     }
 
     const pathQuery = $route.fullPath.split("?")[1];
 
     if (pathQuery.length == 0) {
-        loginUrl.value = customLoginUrl;
+        loginUrl.value = redirectUrl;
         return;
     }
 
-    loginUrl.value = `${customLoginUrl}?next=${homeUrl}subjects/?${pathQuery}`;
+    loginUrl.value = `${redirectUrl}?${pathQuery}`;
 };
 
 watch(


### PR DESCRIPTION
Resolves issue on `prod`

**Description**

If the user is at the Subjects page and has not yet logged in, the Sign In link does not contain the proper `next` parameter unless a subject is selected and/or a text query has been entered.  This `next` parameter ensures a redirect back to the Subjects page after a successful login

**This pull request changes:**

- Updates logic to ensure the `next` parameter is included in the Sign In URL at all times and contains query parameters if they exist

**Steps to manually verify this change:**

1. Visit [Subjects page on the experimental deployment](https://tflob23l1j.execute-api.us-east-1.amazonaws.com/dev1171/subjects/)
2. Click "sign in" without selecting a subject or performing a text query
3. Ensure that the URL of the Custom login page contains a `next` parameter that includes `/subjects/`
4. Sign out and visit the Subjects page again
5. Select a subject and enter a text query
6. Click "sign in"
7. Ensure that the URL of the Custom login page contains a `next` parameter that includes `/subjects/` as well as `q=` and `subjects=` query params

