### PR TITLE
EREGCSC-2542 Don't extract extra large PDFs

### DIFF
--- a/solution/text-extractor/README.md
+++ b/solution/text-extractor/README.md
@@ -164,7 +164,7 @@ from .extractor import Extractor
 class SampleExtractor(Extractor):
     file_types = ("filetype1", "filetype2", ...)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         return ...extract text here...
 ```
 
@@ -180,6 +180,8 @@ from .sample import SampleExtractor as SampleExtractor  # Note the redundant ali
 
 The extractor is now registered and will be automatically instantiated when a file has one of the MIME types listed in `file_types`.
 
+Note the underscore in front of the `_extract()` method definition. Be sure to override this instead of `extract()` because the latter performs pre-extraction checks, then calls `_extract()`.
+
 ## Extracting embedded files
 
 Many types of files contain other files within them. For example, an email has attachments. You can use the `_extract_embedded` method of the `Extractor` class to do so. For example:
@@ -188,7 +190,7 @@ Many types of files contain other files within them. For example, an email has a
 class SampleExtractor(Extractor):
     file_types = ("filetype1", "filetype2", ...)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         text = get_the_text(file)
         attachments = get_the_attachments(file)
         for i in attachments:
@@ -207,7 +209,7 @@ When writing an extractor, it is sometimes necessary to save the file's byte arr
 class SampleExtractor(Extractor):
     file_types = ("filetype1", "filetype2", ...)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         file_path = self._write_file(file)
         return extract_text_by_path(file_path)
 ```
@@ -225,7 +227,7 @@ class SampleExtractor(Extractor):
     file_types = ("filetype1", "filetype2", ...)
     max_size = 5
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         ...
 ```
 
@@ -280,12 +282,12 @@ class TestSampleExtractor(FixtureTestCase):
         self._test_file_type("filetype1", collection="group1")
 
     @patch.object(some_module, "call_api_extractor", mock_external_api_extractor)
-    def test_filetype2(self):
+    def test_filetype2(self, *args):
         # Save your fixture as "extractors/tests/fixtures/group1/sample.filetype2"
         self._test_file_type("filetype2", collection="group1")
 
     @patch.object(some_module, "call_api_extractor", mock_external_api_extractor)
-    def test_filetype3(self):
+    def test_filetype3(self, *args):
         # Save your fixture as "extractors/tests/fixtures/group1/sample.filetype3"
         self._test_file_type("filetype3", collection="group1")
 ```

--- a/solution/text-extractor/README.md
+++ b/solution/text-extractor/README.md
@@ -281,3 +281,23 @@ Also note that this parameter can be used in conjunction with `variation`, and f
 You can also easily use the existing unit test suite to generate new fixture files, instead of doing it manually. Just edit the file `extractors/tests/__init__.py` and uncomment the 2 lines near the bottom of the file, below the comment that says `Uncomment these 2 lines to re-export fixture files the next time tests are run.`.
 
 Be sure to re-comment these 2 lines when you're done, or fixture files will be re-created every time you run unit tests, which may produce undesired behavior.
+
+## Fixing misdetected or unsupported MIME types
+
+The text extractor uses [Google's Magika library](https://github.com/google/magika) for MIME type detection, which uses a machine learning algorithm that promises greater than 99% accuracy when detecting known file types. However, not all file types are supported and their model has to be trained to support them.
+
+You can [open an issue](https://github.com/google/magika/issues) on their repository to report a misdetection or missing file type. To do so, install Magika on your machine so that you can generate a report, like so:
+
+```shell
+$ pip install magika
+$ magika -i unknown_type.xyz
+unknown_type.xyz: application/octet-stream
+$ magika --generate-report unknown_type.xyz
+unknown_type.xyz: Unknown binary data (unknown)
+########################################
+###              REPORT              ###
+########################################
+....... etc .......
+```
+
+Copy the `REPORT` section into the description of your GitHub issue to give the Magika team the information they need to fix the issue.

--- a/solution/text-extractor/README.md
+++ b/solution/text-extractor/README.md
@@ -256,20 +256,20 @@ def mock_external_api_extractor(file):
 
 # For all of these tests, save your expected output as "extractors/tests/fixtures/group1/expected.txt"
 class TestSampleExtractor(FixtureTestCase):
-    def test_filetype1(self):
+    @patch.object(some_module, "call_api_extractor", mock_external_api_extractor)
+    def test_filetype1(self, *args):
         # Save your fixture as "extractors/tests/fixtures/group1/sample.filetype1"
-        with patch("some_module.call_api_extractor", new=mock_external_api_extractor):
-            self._test_file_type("filetype1", collection="group1")
+        self._test_file_type("filetype1", collection="group1")
 
+    @patch.object(some_module, "call_api_extractor", mock_external_api_extractor)
     def test_filetype2(self):
         # Save your fixture as "extractors/tests/fixtures/group1/sample.filetype2"
-        with patch("some_module.call_api_extractor", new=mock_external_api_extractor):
-            self._test_file_type("filetype2", collection="group1")
+        self._test_file_type("filetype2", collection="group1")
 
+    @patch.object(some_module, "call_api_extractor", mock_external_api_extractor)
     def test_filetype3(self):
         # Save your fixture as "extractors/tests/fixtures/group1/sample.filetype3"
-        with patch("some_module.call_api_extractor", new=mock_external_api_extractor):
-            self._test_file_type("filetype3", collection="group1")
+        self._test_file_type("filetype3", collection="group1")
 ```
 
 In this example, the "expected.txt" file should contain the text "Fake data indicating the API call succeeded" based on line 9.

--- a/solution/text-extractor/README.md
+++ b/solution/text-extractor/README.md
@@ -44,12 +44,12 @@ The following data structure is required:
     "token": "xxxxxx",                       // If the return point uses a jwt token for authentication
     "backend": "s3",                         // Optional - defaults to 'web'
     "ignore_max_size": true,                 // Optional - include in request to ignore any size restrictions
-    // Only include if using the S3 backend
+    // Only necessary to include if using the S3 backend
     "aws": {
         "aws_access_key_id": "xxxxxx",       // The access key for the AWS bucket
         "aws_secret_access_key": "xxxxxx",   // The AWS secret key
-        "aws_storage_bucket_name": "xxxxxx",  // The name of the bucket to retrieve the object from
-        "use_lambda": true,                  //  If you are using a local text extractor or a deployed text extractor(pertains to local development)
+        "aws_storage_bucket_name": "xxxxxx", // The name of the bucket to retrieve the object from
+        "use_lambda": true,                  // If you are using a local text extractor or a deployed text extractor (pertains to local development)
         "aws_region": "us-east-1"            // AWS region for Textract
     },
 }

--- a/solution/text-extractor/README.md
+++ b/solution/text-extractor/README.md
@@ -1,3 +1,21 @@
+# Contents
+
+1. [About](#about)
+2. [Supported file types](#supported-file-types)
+3. [Running locally](#running-locally)
+4. [Request structure](#request-structure)
+    1. [Currently supported backends](#currently-supported-backends)
+5. [Response structure](#response-structure)
+6. [Creating a new file backend](#creating-a-new-file-backend)
+7. [Creating a new text extractor](#creating-a-new-text-extractor)
+    1. [Extracting embedded files](#extracting-embedded-files)
+    2. [Writing the file to disk](#writing-the-file-to-disk)
+    3. [Setting a file size limit for file extraction](#setting-a-file-size-limit-for-file-extraction)
+    4. [Unit testing your new extractor](#unit-testing-your-new-extractor)
+    5. [Storing fixture files in a "collection"](#storing-fixture-files-in-a-collection)
+    6. [Generating new fixture files](#generating-new-fixture-files)
+    7. [Fixing misdetected or unsupported MIME types](#fixing-misdetected-or-unsupported-mime-types)
+
 # About
 
 This Lambda function is run to extract text from a variety of file types and POST it to an arbitrary URL. The purpose of this is to support eRegs' full-text search goals as our users begin uploading files to the policy repository.

--- a/solution/text-extractor/extractors/binary.py
+++ b/solution/text-extractor/extractors/binary.py
@@ -8,7 +8,7 @@ from .extractor import Extractor
 class BinaryExtractor(Extractor):
     file_types = ("application/msword",)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         #  Solution taken from here https://stackoverflow.com/questions/64397811/reading-a-doc-file-in-memory.  Doc files
         #  This is used for binary types.  So far just .doc but might include .xls.  We shall see.
         file_path = self._write_file(file)

--- a/solution/text-extractor/extractors/email.py
+++ b/solution/text-extractor/extractors/email.py
@@ -38,7 +38,7 @@ class EmailExtractor(Extractor):
         )
         return f" {file_name} {text}"
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         try:
             msg = email.message_from_bytes(file)
         except Exception as e:

--- a/solution/text-extractor/extractors/excel.py
+++ b/solution/text-extractor/extractors/excel.py
@@ -14,7 +14,7 @@ class ExcelExtractor(Extractor):
 
     _valid_cell_types = ["s", "n", "b", "inlineStr", "str"]
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         file_path = self._write_file(file, extension="xlsx")
         output = ""
 

--- a/solution/text-extractor/extractors/extractor.py
+++ b/solution/text-extractor/extractors/extractor.py
@@ -64,9 +64,9 @@ class Extractor:
         return ""
 
     def extract(self, file: bytes) -> str:
-        file_size = sys.getsizeof(file) / 1024
+        file_size = sys.getsizeof(file) / 1024 / 1024  # Convert file size to megabytes
         if self.max_size >= 0 and file_size > self.max_size and not self.config.get("ignore_max_size", False):
-            raise ExtractorException(f"file size is too large: {file_size} > {self.max_size}. "
+            raise ExtractorException(f"file size is too large: {int(file_size)}MB > {self.max_size}MB. "
                                      "You may override this with 'ignore_max_size = True'.")
         return self._extract(file)
 

--- a/solution/text-extractor/extractors/extractor.py
+++ b/solution/text-extractor/extractors/extractor.py
@@ -67,7 +67,7 @@ class Extractor:
         file_size = sys.getsizeof(file) / 1024
         if self.max_size >= 0 and file_size > self.max_size and not self.config.get("ignore_max_size", False):
             raise ExtractorException(f"file size is too large: {file_size} > {self.max_size}. "
-                                      "You may override this with 'ignore_max_size = True'.")
+                                     "You may override this with 'ignore_max_size = True'.")
         return self._extract(file)
 
     def _extract(self, file: bytes) -> str:

--- a/solution/text-extractor/extractors/image.py
+++ b/solution/text-extractor/extractors/image.py
@@ -25,7 +25,7 @@ class ImageExtractor(Extractor):
         super().__init__(file_type, config)
         self.extractor = Extractor.get_extractor("image/jpeg", config)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         image = Image.open(io.BytesIO(file))
         if not image.mode == "RGB":
             image = image.convert("RGB")

--- a/solution/text-extractor/extractors/markup.py
+++ b/solution/text-extractor/extractors/markup.py
@@ -12,7 +12,7 @@ class MarkupExtractor(Extractor):
         "application/xml",
     )
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)  # Hide unnecessary warning about parsing XML
         extractor = BeautifulSoup(file, "html.parser")  # Use html.parser to avoid lxml dependency (has M1 issues)
         warnings.resetwarnings()

--- a/solution/text-extractor/extractors/old_excel.py
+++ b/solution/text-extractor/extractors/old_excel.py
@@ -6,7 +6,7 @@ from .extractor import Extractor
 class OldExcelExtractor(Extractor):
     file_types = ("application/vnd.ms-excel",)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         file_path = self._write_file(file)
         workbook = xlrd.open_workbook(file_path)
         sheets = workbook.sheet_names()

--- a/solution/text-extractor/extractors/outlook.py
+++ b/solution/text-extractor/extractors/outlook.py
@@ -32,7 +32,7 @@ class OutlookExtractor(Extractor):
                 body += self._handle_message(attachment.data)
         return body
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         try:
             msg = extract_msg.openMsg(file)
         except Exception as e:

--- a/solution/text-extractor/extractors/pdf.py
+++ b/solution/text-extractor/extractors/pdf.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 class PdfExtractor(Extractor):
     file_types = ("application/pdf",)
+    max_size = 20
 
     def __init__(self, file_type: str, config: dict):
         super().__init__(file_type, config)
@@ -25,7 +26,7 @@ class PdfExtractor(Extractor):
             fmt="jpeg",
         )
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         with TemporaryDirectory() as temp_dir:
             try:
                 pages = self._convert_to_images(file, temp_dir)

--- a/solution/text-extractor/extractors/pdf.py
+++ b/solution/text-extractor/extractors/pdf.py
@@ -15,7 +15,7 @@ class PdfExtractor(Extractor):
 
     def __init__(self, file_type: str, config: dict):
         super().__init__(file_type, config)
-        self.extractor = Extractor.get_extractor("jpeg", config)
+        self.extractor = Extractor.get_extractor("image/jpeg", config)
 
     def _convert_to_images(self, file: bytes, temp_dir: str) -> [str]:
         logger.debug("Converting PDF file to images stored in a temporary directory.")

--- a/solution/text-extractor/extractors/powerpoint.py
+++ b/solution/text-extractor/extractors/powerpoint.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 class PowerPointExtractor(Extractor):
     file_types = ("application/vnd.openxmlformats-officedocument.presentationml.presentation",)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         file_path = self._write_file(file)
         presentation = Presentation(file_path)
         text = ""

--- a/solution/text-extractor/extractors/rtf.py
+++ b/solution/text-extractor/extractors/rtf.py
@@ -9,5 +9,5 @@ class RichTextExtractor(Extractor):
         "application/rtf",
     )
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         return rtf_to_text(file.decode(), errors="replace")

--- a/solution/text-extractor/extractors/tests/__init__.py
+++ b/solution/text-extractor/extractors/tests/__init__.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 
 from extractors import Extractor
 
-from magika import Magika
 
 
 logging.disable(logging.CRITICAL)
@@ -29,7 +28,7 @@ class FixtureTestCase(unittest.TestCase):
             expected = f.read().decode()
 
         # Determine the file's MIME type
-        mime_type = Magika().identify_bytes(sample).output.mime_type
+        mime_type = Extractor.get_file_type(sample)
 
         with patch("extractors.Extractor._extract_embedded", new=mock_extract_embedded):
             extractor = Extractor.get_extractor(mime_type, config)

--- a/solution/text-extractor/extractors/tests/test_extractor.py
+++ b/solution/text-extractor/extractors/tests/test_extractor.py
@@ -108,14 +108,14 @@ class ExtractorTest(unittest.TestCase):
         self.assertEqual(output, "")
 
     def test_extract_under_max_size(self):
-        size = 1 * 1024
+        size = 1 * 1024 * 1024
         file = b"0" * size
         extractor = Extractor.get_extractor("type7")
         output = extractor.extract(file)
         self.assertEqual(output, "All good")
 
     def test_extract_over_max_size(self):
-        size = 6 * 1024
+        size = 6 * 1024 * 1024
         file = b"0" * size
         extractor = Extractor.get_extractor("type7")
         with self.assertRaises(ExtractorException):
@@ -125,7 +125,7 @@ class ExtractorTest(unittest.TestCase):
         config = {
             "ignore_max_size": True
         }
-        size = 6 * 1024
+        size = 6 * 1024 * 1024
         file = b"0" * size
         extractor = Extractor.get_extractor("type7", config)
         output = extractor.extract(file)

--- a/solution/text-extractor/extractors/tests/test_extractor.py
+++ b/solution/text-extractor/extractors/tests/test_extractor.py
@@ -15,7 +15,7 @@ class TestExtractor(Extractor):
 class WriteFileExtractor(Extractor):
     file_types = ("type3",)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         file_path = self._write_file(file)
         with open(file_path, "rb") as f:
             data = f.read()
@@ -25,22 +25,30 @@ class WriteFileExtractor(Extractor):
 class EmbeddedFileExtractor(Extractor):
     file_types = ("type4",)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         return file.decode()
 
 
 class EmbeddedFileExtractorExpectedFailure(Extractor):
     file_types = ("type5",)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         raise ExtractorException("Failed to extract")
 
 
 class EmbeddedFileExtractorUnexpectedFailure(Extractor):
     file_types = ("type6",)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         raise TypeError()
+
+
+class MaxSizeExtractor(Extractor):
+    file_types = ("type7",)
+    max_size = 5
+
+    def _extract(self, file: bytes) -> str:
+        return "All good"
 
 
 class ExtractorTest(unittest.TestCase):
@@ -67,7 +75,7 @@ class ExtractorTest(unittest.TestCase):
         text = extractor.extract(file)
         self.assertEqual(text, file.decode())
 
-    @patch.object(Extractor, "_get_mime_type", return_value="type4")
+    @patch.object(Extractor, "get_file_type", return_value="type4")
     def test_extract_embedded_success(self, *args):
         file = b"This is a file"
         file_name = "file.type4"
@@ -75,7 +83,7 @@ class ExtractorTest(unittest.TestCase):
         output = extractor._extract_embedded(file_name, file)
         self.assertEqual(output, file.decode())
 
-    @patch.object(Extractor, "_get_mime_type", return_value="type1000")
+    @patch.object(Extractor, "get_file_type", return_value="type1000")
     def test_extract_embedded_invalid_type(self, *args):
         file = b"This is a file"
         file_name = "file.type1000"
@@ -83,7 +91,7 @@ class ExtractorTest(unittest.TestCase):
         output = extractor._extract_embedded(file_name, file)
         self.assertEqual(output, "")
 
-    @patch.object(Extractor, "_get_mime_type", return_value="type5")
+    @patch.object(Extractor, "get_file_type", return_value="type5")
     def test_extract_embedded_extract_failure(self, *args):
         file = b"This is a file"
         file_name = "file.type5"
@@ -91,10 +99,34 @@ class ExtractorTest(unittest.TestCase):
         output = extractor._extract_embedded(file_name, file)
         self.assertEqual(output, "")
 
-    @patch.object(Extractor, "_get_mime_type", return_value="type6")
+    @patch.object(Extractor, "get_file_type", return_value="type6")
     def test_extract_embedded_unexpected_failure(self, *args):
         file = b"This is a file"
         file_name = "file.type6"
         extractor = Extractor.get_extractor("type1")
         output = extractor._extract_embedded(file_name, file)
         self.assertEqual(output, "")
+
+    def test_extract_under_max_size(self):
+        size = 1 * 1024
+        file = b"0" * size
+        extractor = Extractor.get_extractor("type7")
+        output = extractor.extract(file)
+        self.assertEqual(output, "All good")
+
+    def test_extract_over_max_size(self):
+        size = 6 * 1024
+        file = b"0" * size
+        extractor = Extractor.get_extractor("type7")
+        with self.assertRaises(ExtractorException):
+           extractor.extract(file)
+
+    def test_extract_max_size_override(self):
+        config = {
+            "ignore_max_size": True
+        }
+        size = 6 * 1024
+        file = b"0" * size
+        extractor = Extractor.get_extractor("type7", config)
+        output = extractor.extract(file)
+        self.assertEqual(output, "All good")

--- a/solution/text-extractor/extractors/tests/test_extractor.py
+++ b/solution/text-extractor/extractors/tests/test_extractor.py
@@ -119,7 +119,7 @@ class ExtractorTest(unittest.TestCase):
         file = b"0" * size
         extractor = Extractor.get_extractor("type7")
         with self.assertRaises(ExtractorException):
-           extractor.extract(file)
+            extractor.extract(file)
 
     def test_extract_max_size_override(self):
         config = {

--- a/solution/text-extractor/extractors/tests/test_pdf.py
+++ b/solution/text-extractor/extractors/tests/test_pdf.py
@@ -20,7 +20,7 @@ class MockJpegExtractor:
 
 
 def mock_get_extractor(file_type: str, config: dict = {}) -> Extractor:
-    if file_type == "jpeg":
+    if file_type == "image/jpeg":
         return MockJpegExtractor()
     return orig(file_type, config)
 

--- a/solution/text-extractor/extractors/text.py
+++ b/solution/text-extractor/extractors/text.py
@@ -6,6 +6,6 @@ from .extractor import Extractor
 class TextExtractor(Extractor):
     file_types = ("text/plain",)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         extractor = UnicodeDammit(file)
         return extractor.unicode_markup

--- a/solution/text-extractor/extractors/textract.py
+++ b/solution/text-extractor/extractors/textract.py
@@ -38,7 +38,7 @@ class TextractExtractor(Extractor):
                 "config": boto3.session.Config(signature_version='s3v4',),
             }
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         try:
             logger.debug("Sending image bytes to AWS Textract.")
             response = self.client.detect_document_text(Document={'Bytes': file})

--- a/solution/text-extractor/extractors/word.py
+++ b/solution/text-extractor/extractors/word.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class WordExtractor(Extractor):
     file_types = ("application/vnd.openxmlformats-officedocument.wordprocessingml.document",)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         file_path = self._write_file(file)
         with TemporaryDirectory() as temp_dir:
             logger.debug("Extracting text. Embedded images stored in temporary directory.")

--- a/solution/text-extractor/extractors/zip.py
+++ b/solution/text-extractor/extractors/zip.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 class ZipExtractor(Extractor):
     file_types = ("application/zip",)
 
-    def extract(self, file: bytes) -> str:
+    def _extract(self, file: bytes) -> str:
         file_path = self._write_file(file)
         text = ""
 

--- a/solution/text-extractor/text_extractor.py
+++ b/solution/text-extractor/text_extractor.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 import requests
-from magika import Magika
 
 from .backends import (
     BackendException,
@@ -64,9 +63,9 @@ def handler(event: dict, context: dict) -> dict:
     except Exception as e:
         return lambda_failure(500, f"Backend unexpectedly failed: {str(e)}")
 
-    # Determine the file's MIME type using Google's Magika ML algorithm
+    # Determine the file's MIME type
     try:
-        file_type = Magika().identify_bytes(file).output.mime_type
+        file_type = Extractor.get_file_type(file)
     except Exception as e:
         return lambda_failure(500, f"Failed to determine file type: {str(e)}")
 


### PR DESCRIPTION
Resolves #2542

**Description-**

We want to be able to limit the maximum size that the text extractor will extract, and offer an override functionality.

**This pull request changes...**

- The `Extractor` class now has an attribute, `max_size`, which is disabled (`-1`) by default. If set to a positive integer, the extractor will refuse to extract any file larger than `max_size` in megabytes.
    - This is configurable per-extractor because some extractors are slower than others.
    - Callers of the text extractor lambda may pass in `ignore_max_size: true` in the config dict to override this behavior.
    - Additionally, all extractor's `extract` methods are renamed to `_extract` to support the template method of function overriding. (`extract()` checks the size first, and then calls the child class's `_extract()`.)
- PdfExtractor's `max_size` is set to 20, per this PR's AC.
- Also, moved MIME type detection to the Extractor class as a classmethod to eliminate code duplication.
- Updated the README file.

**Steps to manually verify this change...**

1. Go to the admin panel and visit Uploaded Files.
2. Upload a small PDF (less than 20MB) and verify that the extractor will extract text successfully. (Click "Get content" -> go back -> refresh the page until "Index populated" is populated.)
3. Upload a large PDF (greater than 20MB) and verify that the extractor will NOT extract text anymore. (Same process as before, but this time, wait a long time to make sure "Index populated" is never populated.)

