### PR TITLE
[Hotfix] Add user agent for the text extractor

### DIFF
--- a/solution/text-extractor/backends/web.py
+++ b/solution/text-extractor/backends/web.py
@@ -13,13 +13,15 @@ logger = logging.getLogger(__name__)
 
 class WebBackend(FileBackend):
     backend = "web"
-    retry_timeout = 30
 
+    _retry_timeout = 30
     _ignore_robots = False
+    _user_agent = "CMSeRegsTextExtractorBot/1.0"
 
     def __init__(self, config: dict):
-        self._user_agent = requests.utils.default_headers()["User-Agent"]
         self._parser = robotparser.RobotFileParser()
+        self._headers = requests.utils.default_headers()
+        self._headers["User-Agent"] = self._user_agent
 
     def _get_robots_txt(self, url: str):
         logger.debug("Fetching robots.txt from \"%s\".", url)
@@ -56,7 +58,7 @@ class WebBackend(FileBackend):
 
         while True:  # Loop until the lambda times out, max of 15 mins
             try:
-                resp = requests.get(uri, timeout=60)
+                resp = requests.get(uri, timeout=60, headers=self._headers)
             except requests.exceptions.Timeout:
                 logger.warning("GET request timed out. Retrying in %i seconds.", self.retry_timeout)
                 time.sleep(self.retry_timeout)

--- a/solution/text-extractor/backends/web.py
+++ b/solution/text-extractor/backends/web.py
@@ -16,7 +16,7 @@ class WebBackend(FileBackend):
 
     _retry_timeout = 30
     _ignore_robots = False
-    _user_agent = "CMSeRegsTextExtractorBot/1.0"
+    _user_agent = "CMCSeRegsTextExtractorBot/1.0"
 
     def __init__(self, config: dict):
         self._parser = robotparser.RobotFileParser()

--- a/solution/text-extractor/backends/web.py
+++ b/solution/text-extractor/backends/web.py
@@ -58,6 +58,7 @@ class WebBackend(FileBackend):
 
         while True:  # Loop until the lambda times out, max of 15 mins
             try:
+                logger.debug("Sending GET request to %s with headers: %s", uri, str(self._headers))
                 resp = requests.get(uri, timeout=60, headers=self._headers)
             except requests.exceptions.Timeout:
                 logger.warning("GET request timed out. Retrying in %i seconds.", self.retry_timeout)


### PR DESCRIPTION
Resolves #n/a

**Description-**

Adds a user agent for the text extractor: `CMCSeRegsTextExtractorBot/1.0`.

**This pull request changes...**

- Adds a user agent for the text extractor: `CMCSeRegsTextExtractorBot/1.0`.

**Steps to manually verify this change...**

1. Go to the admin panel of the experimental deploy.
2. Go to a supplemental content item with a scrapable URL and click "Get content".
3. Click back and refresh the page until "Index populated" is populated.
4. Go to CloudWatch and view the log group for the text extractor associated with this PR (1187).
5. Go to the most recent log stream and search for "Sending GET request to..." and validate the header contains the "User-Agent" string "CMCSeRegsTextExtractorBot/1.0".

