### PR TITLE
EREGCSC-2549 Enable populated filter on admin panel

### DIFF
--- a/solution/backend/common/filters.py
+++ b/solution/backend/common/filters.py
@@ -28,21 +28,19 @@ class ParameterFilter(InputFilter):
             return queryset.filter(**filter).distinct()
 
 
-class TitleFilter(ParameterFilter):
-    parameter_name = "locations__title"
-    title = "Title"
+class IndexPopulatedFilter(SimpleListFilter):
+    title = "index populated"
+    parameter_name = "populated"
 
+    def lookups(self, request, model_admin):
+        return [
+            ("yes", "Yes"),
+            ("no", "No"),
+        ]
 
-class PartFilter(ParameterFilter):
-    parameter_name = "locations__part"
-    title = "Part"
-
-
-class SectionFilter(ParameterFilter):
-    parameter_name = "locations__section__section_id"
-    title = "Section"
-
-
-class SubpartFilter(ParameterFilter):
-    parameter_name = "locations__subpart__subpart_id"
-    title = "Subpart"
+    def queryset(self, request, queryset):
+        if self.value() == "yes":
+            return queryset.filter(contentindex__content__isnull=False)
+        if self.value() == "no":
+            return queryset.filter(contentindex__content__isnull=True)
+        return queryset

--- a/solution/backend/common/tests/test_filters.py
+++ b/solution/backend/common/tests/test_filters.py
@@ -1,0 +1,28 @@
+import pytest
+
+from common.filters import IndexPopulatedFilter
+from content_search.models import ContentIndex
+from file_manager.models import UploadedFile
+
+
+@pytest.mark.django_db
+def test_index_populated_filter():
+    a = UploadedFile.objects.create(document_name="a")
+    b = UploadedFile.objects.create(document_name="b")
+    ContentIndex.objects.create(file=a, content="Hello world")
+    ContentIndex.objects.create(file=b)
+
+    # Test when populated filter is not set
+    results = IndexPopulatedFilter(None, {}, None, None).queryset(None, UploadedFile.objects.all())
+    assert a in results
+    assert b in results
+
+    # Test when populated filter is set to "yes"
+    results = IndexPopulatedFilter(None, {"populated": "yes"}, None, None).queryset(None, UploadedFile.objects.all())
+    assert a in results
+    assert b not in results
+
+    # Test when populated filter is set to "no"
+    results = IndexPopulatedFilter(None, {"populated": "no"}, None, None).queryset(None, UploadedFile.objects.all())
+    assert a not in results
+    assert b in results

--- a/solution/backend/file_manager/admin.py
+++ b/solution/backend/file_manager/admin.py
@@ -9,6 +9,7 @@ from django.db.models import (
 from django.urls import reverse
 from django.utils.html import format_html
 
+from common.filters import IndexPopulatedFilter
 from common.functions import establish_client
 from content_search.functions import add_to_index
 from content_search.models import ContentIndex
@@ -69,6 +70,7 @@ class UploadedFileAdmin(BaseAdmin):
     fields = ("file_name", "file_path", "document_name", "date", "summary",
               "updated_at", "document_type", "subjects", "locations", "internal_notes",
               "index_populated", "get_content", "download_file", "category",)
+    list_filter = [IndexPopulatedFilter]
 
     manytomany_lookups = {
         "locations": lambda: AbstractLocation.objects.all().select_subclasses(),

--- a/solution/backend/resources/admin.py
+++ b/solution/backend/resources/admin.py
@@ -25,16 +25,11 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from solo.admin import SingletonModelAdmin
 
+from common.filters import IndexPopulatedFilter
 from content_search.functions import add_to_index
 from content_search.models import ContentIndex
 
 from . import actions
-from .filters import (
-    PartFilter,
-    SectionFilter,
-    SubpartFilter,
-    TitleFilter,
-)
 from .models import (
     AbstractCategory,
     AbstractLocation,
@@ -147,10 +142,7 @@ class AbstractResourceAdmin(BaseAdmin):
 
     list_filter = [
         "approved",
-        TitleFilter,
-        PartFilter,
-        SectionFilter,
-        SubpartFilter,
+        IndexPopulatedFilter,
     ]
 
     foreignkey_lookups = {


### PR DESCRIPTION
Resolves #2549

**Description-**

This PR allows for filtering on the admin panel by whether the content index has content for a particular item.

**This pull request changes...**

- Removed filter by title, part, subpart, etc. on supplemental content and FR docs.
- Added filter by "Index Populated" to files and resource models.
- Moved filters to `common/filters.py`.

**Steps to manually verify this change...**

1. Go to the admin panel.
2. Upload 2 new files under "Uploaded Files".
3. Click "Get content" on ONLY ONE of the files, click back, and refresh until the "Index Populated" field is populated. Note: if it never populates, try a different file.
4. Go back to the change list (click on "Uploaded Files").
5. Observe the new filter on the right sidebar: "By index populated".
6. Click "Yes" and observe that your file with the populated index shows up, and the other one does not.
7. Click "No" and observe the exact opposite.

