### PR TITLE
[Hotfix] Increase prod lambda timeout to 20 seconds

### DIFF
--- a/solution/backend/serverless_functions/prod_functions.yml
+++ b/solution/backend/serverless_functions/prod_functions.yml
@@ -8,7 +8,7 @@ reg_site:
   events:
     - http: ANY /
     - http: ANY {proxy+}
-  timeout: 10
+  timeout: 20
 reg_core_migrate:
   handler: migrate.handler
   layers:


### PR DESCRIPTION
Resolves #n/a

**Description-**

Content search is failing due to a timeout. This is a bandaid fix to hopefully avoid that.

**This pull request changes...**

- Prod's lambda timeout is increased to 20 seconds.

**Steps to manually verify this change...**

1. Verify that `/v3/content-search?q=test` no longer times out. You should refresh it several times to make sure.

