### PR TITLE
[Hotfix] Re-enable client side caching for `getCombinedContent` where used

### DIFF
--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -7,6 +7,7 @@ const readerUsername = Cypress.env("READER_USERNAME");
 const readerPassword = Cypress.env("READER_PASSWORD");
 
 const _beforeEach = () => {
+    cy.clearIndexedDB();
     cy.intercept("/**", (req) => {
         req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
     });

--- a/solution/ui/regulations/eregs-component-lib/src/components/reader-sidebar/InternalDocsContainer.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/reader-sidebar/InternalDocsContainer.vue
@@ -81,7 +81,6 @@ const getDocuments = async ({ section }) => {
             getCategories(),
             getCombinedContent({
                 apiUrl: props.apiUrl,
-                cacheResponse: false,
                 requestParams: `resource-type=internal&${locationString}`,
             }),
         ]);

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -350,7 +350,6 @@ export default {
             try {
                 response = await getCombinedContent({
                     apiUrl: this.apiUrl,
-                    cacheResponse: false,
                     requestParams,
                 });
 

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -163,7 +163,6 @@ const getDocList = async (requestParams = "") => {
     try {
         const contentList = await getCombinedContent({
             apiUrl: props.apiUrl,
-            cacheResponse: false,
             requestParams,
         });
         policyDocList.value.results = contentList.results;


### PR DESCRIPTION
**Description**

`content-search` endpoint is consistently failing due to a timeout. This will re-enable client side caching for this endpoint wherever it is used.

The first request will still take ~10 seconds to recieve a response, but all subsequence requests for that endpoint with the same query parameters will be retrieved from the browser cache immediately with no waiting.

**This pull request changes...**

- Removes `cacheResponse: false` prop when calling `getCombinedContent`
   - the default parameter sets `cacheResponse` to `true`

**Steps to manually verify this change:**

1. Visit Subjects page or Search page on the [experimental deployment](https://6dsqjcks44.execute-api.us-east-1.amazonaws.com/dev1196).
2. Search for `test`
3. Measure the response time for the first request using the Network tab in DevTools
4. Reload the page and note that `content-search` no longer appears in the Network Tab's list of requests. 
5. This is because it has been served from the browser cache and should load immediately.
