### PR TITLE
[Hotfix] Provide `apiUrl` to PolicyResults component in the combined search page

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -219,6 +219,7 @@ export default {
 
     provide() {
         return {
+            apiUrl: this.apiUrl,
             base: this.homeUrl,
         };
     },


### PR DESCRIPTION
**Description**

We recently retired Search.gov search on the Combined Search page and replaced it with the `content-search` endpoint used on the Subjects page.

A defect was introduced: the `apiUrl` was no longer being properly passed to the internal results, and these links became broken.

**This pull request changes:**

- Provides `apiUrl` to `PolicyResults` component so that internal documents can be successfully downloaded

**Steps to manually verify this change:**

1. Visit [experimental deployment](https://03u4vhsho0.execute-api.us-east-1.amazonaws.com/dev1197) and log in
2. Try downloading internal documents on both the Combined Search page and the Subjects page
3. Internal document downloads should work on both pages
