### PR TITLE
HOTFIX - remove vpc

### DIFF
--- a/solution/backend/serverless-redirect.yml
+++ b/solution/backend/serverless-redirect.yml
@@ -15,12 +15,6 @@ provider:
       level: INFO
       roleManagedExternally: true
   lambdaHashingVersion: '20201221'
-  vpc:
-    securityGroupIds:
-      - ${ssm:/eregulations/aws/securitygroupid}
-    subnetIds:
-      - ${ssm:/account_vars/vpc/subnets/private/a/id}
-      - ${ssm:/account_vars/vpc/subnets/private/b/id}
   tracing:
     apiGateway: true
 


### PR DESCRIPTION
Resolves # serverless not creating redirect api

**Description-**
This is to fix the issue of serverless not creating the redirect api on val, prod. Because it's referencing a vpc that is not there on val and prod. 
Due to this being a simple lambda function that is just redirecting a url, we do not need vpc. So I removed it and hopefully it will still build the api. 
**This pull request changes...**

- expected change 1
Update the redirect-serverless.yml file.
**Steps to manually verify this change...**

1. steps to view and verify change
Make sure api is created with the lambda function
