### PR TITLE
EREGCSC-2349 - remove redirect serverless from experimental, update t…

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -156,7 +156,6 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-redirect.yml --stage redirect${PR} | tee output.log
           serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-redirect.yml --stage redirect | tee output.log
+          serverless deploy --config ./serverless-redirect.yml --stage ${{ matrix.environment }} | tee output.log
           serverless deploy --stage ${{ matrix.environment }} | tee output.log
           serverless invoke --function reg_core_migrate --stage ${{ matrix.environment }}
           serverless invoke --function create_su --stage ${{ matrix.environment }}


### PR DESCRIPTION
…o the stage to be dev/val/prod

Resolves: Remove of deployment of redirect api/lambda function on experimental. 

**Description-**
redirect api is not needed on experimental. As this is to solve the problem on production so that when users sign in to regulations-pilot.cms.gov to be redirected to eregulations.cms.gov. It was added to experimental just so we can test the concept out. Now that its been approved and deployed, removing it. 
Also updated the api-gateway name to make it less redundent. 
**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change
Visit https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/runs/8191295614/job/22400196867?pr=1201 
Notice experimental did not deploy the redirect api.
