### PR TITLE
hotfix - change the handler path

### DIFF
--- a/solution/backend/serverless-redirect.yml
+++ b/solution/backend/serverless-redirect.yml
@@ -23,8 +23,8 @@ functions:
     handler: redirect_lambda.handler
     timeout: 30
     events:
-      - http: ANY /redirect
-      - http: ANY /redirect/{proxy+}
+      - http: ANY /
+      - http: ANY /{proxy+}
 resources:
   Resources:
     LambdaFunctionRole:


### PR DESCRIPTION
Resolves #

**Description-**
On production the api-gateway for the redirect function has the path /redirect. To make it similar to our api gateway that hosts our django website, I am change it to use / and /proxy
**This pull request changes...**

- expected change 1
serverless.yml file updated
**Steps to manually verify this change...**
You can see it in the serverless.yml file but wont see the changes till its merged to dev. 


