### PR TITLE
update code to redirect dynamically

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -156,6 +156,7 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
+          serverless deploy --config ./serverless-redirect.yml --stage dev${PR} | tee output.log
           serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -156,7 +156,6 @@ jobs:
           pushd solution/backend
           npm install serverless -g
           npm install
-          serverless deploy --config ./serverless-redirect.yml --stage dev${PR} | tee output.log
           serverless deploy --config ./serverless-experimental.yml --stage dev${PR} | tee output.log
           serverless invoke --config ./serverless-experimental.yml --function create_database --stage dev${PR}
           serverless invoke --config ./serverless-experimental.yml --function reg_core_migrate --stage dev${PR}

--- a/solution/backend/redirect_lambda.py
+++ b/solution/backend/redirect_lambda.py
@@ -1,4 +1,4 @@
-def lambda_handler(event, context):
+def handler(event, context):
     original_path = event['path']
     new_domain = 'https://eregulations.cms.gov'
     new_url = f'{new_domain}{original_path}'

--- a/solution/backend/redirect_lambda.py
+++ b/solution/backend/redirect_lambda.py
@@ -1,9 +1,16 @@
-def handler(event, context):
-    redirect_url = "https://eregulations.cms.gov"
+import json
+
+def lambda_handler(event, context):
+    original_path = event['path']
+    new_domain = 'https://eregulations.cms.gov'
+    new_url = f'{new_domain}{original_path}'
+
     response = {
-        "statusCode": 302,
-        "headers": {
-            "Location": redirect_url,
+        'statusCode': 302,  # HTTP status code for redirection
+        'headers': {
+            'Location': new_url,  # Set the new URL in the Location header
         },
+        'body': '',  # Empty body for a redirect response
     }
+
     return response

--- a/solution/backend/redirect_lambda.py
+++ b/solution/backend/redirect_lambda.py
@@ -1,15 +1,16 @@
+from urllib.parse import urljoin
+
+
 def handler(event, context):
     original_path = event['path']
     new_domain = 'https://eregulations.cms.gov'
-    new_url = f'{new_domain}{original_path}'
+    new_url = urljoin(new_domain, original_path)
 
     response = {
         'statusCode': 302,
         'headers': {
             'Location': new_url,
         },
-        'body': f'Redirecting to: {new_url}',
-
     }
 
     return response

--- a/solution/backend/redirect_lambda.py
+++ b/solution/backend/redirect_lambda.py
@@ -1,16 +1,15 @@
-import json
-
 def lambda_handler(event, context):
     original_path = event['path']
     new_domain = 'https://eregulations.cms.gov'
     new_url = f'{new_domain}{original_path}'
 
     response = {
-        'statusCode': 302,  # HTTP status code for redirection
+        'statusCode': 302,
         'headers': {
-            'Location': new_url,  # Set the new URL in the Location header
+            'Location': new_url,
         },
-        'body': '',  # Empty body for a redirect response
+        'body': f'Redirecting to: {new_url}',
+
     }
 
     return response


### PR DESCRIPTION
Resolves # 

**Description-**

We want to redirect to eregulations but also the redirection should include the path. 
for example if we visit 
regulations-pilot.cms.gov/43/430 it should redirect to eregulations.cms.gov/42/430 not eregulations.cms.gov

expected change 1
- Update the lambda function to retain the path. 

**Steps to manually verify this change...**
1. Visit https://8t3teirzae.execute-api.us-east-1.amazonaws.com/dev1206/42/430
2. Notice it redirects to http://eregulations.cms.gov/dev1206/42/430
3. This does not impact our api gateway django code as it has its own api. So if you visit 
https://y0hrkjjdek.execute-api.us-east-1.amazonaws.com/dev1206/42/430/
it stays the same. 

