### PR TITLE
EREGCSC-2313 -- Update `<title>` tags

### DIFF
--- a/solution/backend/regulations/templates/500.html
+++ b/solution/backend/regulations/templates/500.html
@@ -1,6 +1,6 @@
 {% extends "error_base.html" %}
 
-{% block title %}Error 500 | Medicaid & CHIP eRegulations{% endblock %}
+{% block subtitle %}Error 500 | {% endblock %}
 
 {% block error_code %}
     500

--- a/solution/backend/regulations/templates/500.html
+++ b/solution/backend/regulations/templates/500.html
@@ -1,6 +1,6 @@
 {% extends "error_base.html" %}
 
-{% block subtitle %}Error 500 | {% endblock %}
+{% block title_prefix %}Error 500 | {% endblock %}
 
 {% block error_code %}
     500

--- a/solution/backend/regulations/templates/500.html
+++ b/solution/backend/regulations/templates/500.html
@@ -1,5 +1,7 @@
 {% extends "error_base.html" %}
 
+{% block title %}Error 500 | Medicaid & CHIP eRegulations{% endblock %}
+
 {% block error_code %}
     500
 {% endblock %}

--- a/solution/backend/regulations/templates/error_base.html
+++ b/solution/backend/regulations/templates/error_base.html
@@ -1,7 +1,10 @@
 {% extends "regulations/base.html" %}
 {% load static %}
 
-{% block title %}Page Not Found | Medicaid & CHIP eRegulations{% endblock %}
+{% block title %}
+    {% block subtitle %}Page Not Found | {% endblock %}
+    Medicaid &amp; CHIP eRegulations
+{% endblock %}
 
 {% block header %}
     {% include "regulations/partials/header.html" %}

--- a/solution/backend/regulations/templates/error_base.html
+++ b/solution/backend/regulations/templates/error_base.html
@@ -1,10 +1,7 @@
 {% extends "regulations/base.html" %}
 {% load static %}
 
-{% block title %}
-    {% block subtitle %}Page Not Found | {% endblock %}
-    Medicaid &amp; CHIP eRegulations
-{% endblock %}
+{% block title_prefix %}Page Not Found | {% endblock %}
 
 {% block header %}
     {% include "regulations/partials/header.html" %}

--- a/solution/backend/regulations/templates/error_base.html
+++ b/solution/backend/regulations/templates/error_base.html
@@ -1,7 +1,7 @@
 {% extends "regulations/base.html" %}
 {% load static %}
 
-{% block title %}Page Not Found | Medicaid & CHIP eRegulations {% endblock %}
+{% block title %}Page Not Found | Medicaid & CHIP eRegulations{% endblock %}
 
 {% block header %}
     {% include "regulations/partials/header.html" %}

--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -1,7 +1,7 @@
 {% extends "regulations/base.html" %}
 {% load static %}
 
-{% block subtitle %}About This Tool | {% endblock %}
+{% block title_prefix %}About This Tool | {% endblock %}
 
 {% block header %}
     {% include "regulations/partials/header.html" %}

--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -1,7 +1,7 @@
 {% extends "regulations/base.html" %}
 {% load static %}
 
-{% block title %}About This Tool | Medicaid & CHIP eRegulations{% endblock %}
+{% block subtitle %}About This Tool | {% endblock %}
 
 {% block header %}
     {% include "regulations/partials/header.html" %}

--- a/solution/backend/regulations/templates/regulations/base.html
+++ b/solution/backend/regulations/templates/regulations/base.html
@@ -26,7 +26,7 @@ CSS/Javascript etc., should inherit from this template.
         {% if not allow_indexing %}<meta name="robots" content="noindex" />{% endif %}
         <title>
             {% block title %}
-                {% block subtitle %}{{title}} CFR {{reg_part}} {% if subpart %} Subpart {{subpart}} {% endif %} | {% endblock %}
+                {% block title_prefix %}{{title}} CFR {{reg_part}} {% if subpart %} Subpart {{subpart}} {% endif %} | {% endblock %}
                 Medicaid &amp; CHIP eRegulations
             {% endblock %}
         </title>

--- a/solution/backend/regulations/templates/regulations/base.html
+++ b/solution/backend/regulations/templates/regulations/base.html
@@ -26,7 +26,8 @@ CSS/Javascript etc., should inherit from this template.
         {% if not allow_indexing %}<meta name="robots" content="noindex" />{% endif %}
         <title>
             {% block title %}
-                {{title}} CFR {{reg_part}} {% if subpart %} Subpart {{subpart}} {% endif %} | Medicaid &amp; CHIP eRegulations
+                {% block subtitle %}{{title}} CFR {{reg_part}} {% if subpart %} Subpart {{subpart}} {% endif %} | {% endblock %}
+                Medicaid &amp; CHIP eRegulations
             {% endblock %}
         </title>
         {% include "regulations/partials/favicon.html" %}

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load render_nested %}
 
-{% block subtitle %}{% endblock %}
+{% block title_prefix %}{% endblock %}
 
 {% block spa_styles %}
 <link

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -2,9 +2,7 @@
 {% load static %}
 {% load render_nested %}
 
-{% block title %}
-Medicaid &amp; CHIP eRegulations
-{% endblock %}
+{% block subtitle %}{% endblock %}
 
 {% block spa_styles %}
 <link

--- a/solution/backend/regulations/templates/regulations/homepage.html
+++ b/solution/backend/regulations/templates/regulations/homepage.html
@@ -3,7 +3,7 @@
 {% load render_nested %}
 
 {% block title %}
-Medicaid &amp; CHIP eRegulations - A CMCS Pilot Project
+Medicaid &amp; CHIP eRegulations
 {% endblock %}
 
 {% block spa_styles %}

--- a/solution/backend/regulations/templates/regulations/login.html
+++ b/solution/backend/regulations/templates/regulations/login.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="{% static '/vite/index.css' %}" />
 {% endblock %}
 
-{% block title %}Single sign-on to CMCS | Medicaid & CHIP eRegulations{% endblock %}
+{% block subtitle %}Single sign-on to CMCS | {% endblock %}
 
 {% block header %}
     {% include "regulations/partials/header.html" %}

--- a/solution/backend/regulations/templates/regulations/login.html
+++ b/solution/backend/regulations/templates/regulations/login.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="{% static '/vite/index.css' %}" />
 {% endblock %}
 
-{% block subtitle %}Single sign-on to CMCS | {% endblock %}
+{% block title_prefix %}Single sign-on to CMCS | {% endblock %}
 
 {% block header %}
     {% include "regulations/partials/header.html" %}

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load string_formatters %}
 
-{% block title %}Search {% if q %}for {{ q }} {% endif %}| Medicaid & CHIP eRegulations{% endblock %}
+{% block subtitle %}Search {% if q %}for {{ q }} {% endif %}| {% endblock %}
 
 {% block spa_styles %}
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load string_formatters %}
 
-{% block subtitle %}Search {% if q %}for {{ q }} {% endif %}| {% endblock %}
+{% block title_prefix %}Search {% if q %}for {{ q }} {% endif %}| {% endblock %}
 
 {% block spa_styles %}
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load string_formatters %}
 
-{% block title %}Statute Reference | Medicaid &amp; CHIP eRegulations{% endblock %}
+{% block subtitle %}Statute Reference | {% endblock %}
 
 {% block spa_styles %}
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load string_formatters %}
 
-{% block subtitle %}Statute Reference | {% endblock %}
+{% block title_prefix %}Statute Reference | {% endblock %}
 
 {% block spa_styles %}
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load string_formatters %}
 
-{% block title %}Statute Reference{% endblock %}
+{% block title %}Statute Reference | Medicaid &amp; CHIP eRegulations{% endblock %}
 
 {% block spa_styles %}
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">

--- a/solution/backend/regulations/templates/regulations/subjects.html
+++ b/solution/backend/regulations/templates/regulations/subjects.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load string_formatters %}
 
-{% block title %}Find by Subject{% endblock %}
+{% block title %}Find by Subject | Medicaid &amp; CHIP eRegulations{% endblock %}
 
 {% block spa_styles %}
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">

--- a/solution/backend/regulations/templates/regulations/subjects.html
+++ b/solution/backend/regulations/templates/regulations/subjects.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load string_formatters %}
 
-{% block title %}Find by Subject | Medicaid &amp; CHIP eRegulations{% endblock %}
+{% block title %} {% if subject_name %} {{ subject_name }} | {% endif %}Find by Subject | Medicaid &amp; CHIP eRegulations{% endblock %}
 
 {% block spa_styles %}
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">

--- a/solution/backend/regulations/templates/regulations/subjects.html
+++ b/solution/backend/regulations/templates/regulations/subjects.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load string_formatters %}
 
-{% block title %} {% if subject_name %} {{ subject_name }} | {% endif %}Find by Subject | Medicaid &amp; CHIP eRegulations{% endblock %}
+{% block subtitle %} {% if subject_name %} {{ subject_name }} | {% endif %}Find by Subject | {% endblock %}
 
 {% block spa_styles %}
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">

--- a/solution/backend/regulations/templates/regulations/subjects.html
+++ b/solution/backend/regulations/templates/regulations/subjects.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load string_formatters %}
 
-{% block subtitle %} {% if subject_name %} {{ subject_name }} | {% endif %}Find by Subject | {% endblock %}
+{% block title_prefix %} {% if subject_name %} {{ subject_name }} | {% endif %}Find by Subject | {% endblock %}
 
 {% block spa_styles %}
     <link href="https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css" rel="stylesheet">

--- a/solution/backend/regulations/views/subjects.py
+++ b/solution/backend/regulations/views/subjects.py
@@ -16,7 +16,7 @@ class SubjectsView(TemplateView):
             subject_abbreviation = subject.abbreviation
             subject_fullname = subject.full_name
             subject_name = subject_abbreviation if subject_abbreviation else subject_fullname
-        except Subject.DoesNotExist:
+        except (ValueError, Subject.DoesNotExist):
             subject_name = None
 
         host = self.request.get_host()

--- a/solution/backend/regulations/views/subjects.py
+++ b/solution/backend/regulations/views/subjects.py
@@ -1,5 +1,7 @@
 from django.views.generic.base import TemplateView
 
+from file_manager.models import Subject
+
 
 class SubjectsView(TemplateView):
 
@@ -7,6 +9,16 @@ class SubjectsView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        subject_id = self.request.GET.get('subjects')
+
+        try:
+            subject = Subject.objects.get(id=subject_id)
+            subject_abbreviation = subject.abbreviation
+            subject_fullname = subject.full_name
+            subject_name = subject_abbreviation if subject_abbreviation else subject_fullname
+        except Subject.DoesNotExist:
+            subject_name = None
+
         host = self.request.get_host()
         is_authenticated = self.request.user.is_authenticated
         user_groups = [group.name for group in self.request.user.groups.all()]
@@ -16,6 +28,7 @@ class SubjectsView(TemplateView):
             'host': host,
             'is_authenticated': is_authenticated,
             'has_editable_job_code': has_editable_job_code,
+            'subject_name': subject_name
         }
 
         return {**context, **c}

--- a/solution/ui/e2e/cypress/e2e/title-tags.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/title-tags.spec.cy.js
@@ -4,6 +4,10 @@ describe("Updated HTML Title Tags", { scrollBehavior: "center" }, () => {
         cy.intercept("/**", (req) => {
             req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
         });
+
+        cy.intercept("**/v3/file-manager/subjects", {
+            fixture: "subjects.json",
+        }).as("subjects");
     });
 
     it("Homepage title tags", () => {
@@ -18,6 +22,38 @@ describe("Updated HTML Title Tags", { scrollBehavior: "center" }, () => {
         cy.title().should(
             "eq",
             "Statute Reference | Medicaid & CHIP eRegulations"
+        );
+    });
+
+    it("Subjects page without a selected subject", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/subjects/");
+        cy.title().should(
+            "eq",
+            "Find by Subject | Medicaid & CHIP eRegulations"
+        );
+
+        cy.get(".subj-toc__list li[data-testid=subject-toc-li-63] a")
+            .should("have.text", " Managed Care ")
+            .click({ force: true });
+        cy.title().should(
+            "eq",
+            "Managed Care | Find by Subject | Medicaid & CHIP eRegulations"
+        );
+
+        cy.go("back");
+        cy.title().should(
+            "eq",
+            "Find by Subject | Medicaid & CHIP eRegulations"
+        );
+    });
+
+    it("Subjects page with a selected subject already in URL", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/subjects/");
+        cy.title().should(
+            "eq",
+            "Find by Subject | Medicaid & CHIP eRegulations"
         );
     });
 });

--- a/solution/ui/e2e/cypress/e2e/title-tags.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/title-tags.spec.cy.js
@@ -1,0 +1,23 @@
+describe("Updated HTML Title Tags", { scrollBehavior: "center" }, () => {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.intercept("/**", (req) => {
+            req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
+        });
+    });
+
+    it("Homepage title tags", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/");
+        cy.title().should("eq", "Medicaid & CHIP eRegulations");
+    });
+
+    it("Statutes page title tags", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/statutes/");
+        cy.title().should(
+            "eq",
+            "Statute Reference | Medicaid & CHIP eRegulations"
+        );
+    });
+});

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectChip.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectChip.vue
@@ -41,6 +41,7 @@ defineProps({
                 subjects: [subjectId.toString()],
                 type: ['all'],
             },
+            params: { subjectName },
         }"
     >
         {{ subjectName }}

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
@@ -96,12 +96,17 @@ const subjectClick = (event) => {
 
     if (subjectsArray.includes(subjectToAdd)) return;
 
+    const subject = props.policyDocSubjects.results.find(
+        (s) => s.id === parseInt(subjectToAdd, 10)
+    );
+
     $router.push({
         name: "subjects",
         query: {
             ...$route.query,
             subjects: [subjectToAdd],
         },
+        params: { subjectName: getSubjectName(subject) },
     });
 };
 

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectTOC.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectTOC.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, inject } from "vue";
 
-import { getSubjectNameParts } from "utilities/filters";
+import { getSubjectName, getSubjectNameParts } from "utilities/filters";
 
 const isAuthenticated = inject("isAuthenticated");
 
@@ -35,6 +35,7 @@ const subjectsLength = computed(() => props.policyDocSubjects.results.length);
                         :to="{
                             name: 'subjects',
                             query: { subjects: [subject.id.toString()] },
+                            params: { subjectName: getSubjectName(subject) },
                         }"
                     >
                         <template

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -21,12 +21,23 @@ Vue.directive("clickaway", Clickaway);
 const router = vueRouter({ customUrl, host });
 
 router.beforeEach((to, _from, next) => {
-    if (!isAuthenticated && to.name === "subjects" && to.query?.type) {
-        const { type, ...query } = to.query;
-        next({ ...to, query });
-    } else {
-        next();
+    const pageTitle = "Find by Subject | Medicaid & CHIP eRegulations";
+
+    if (to.name === "subjects") {
+        if (to.params?.subjectName) {
+            // set document title here with available information
+            document.title = `${to.params.subjectName} | ${pageTitle}`;
+        } else {
+            document.title = pageTitle;
+        }
+
+        if (!isAuthenticated && to.query?.type) {
+            const { type, ...query } = to.query;
+            next({ ...to, query });
+        }
     }
+
+    next();
 });
 
 // Silence duplicate navigation errors

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -24,11 +24,13 @@ router.beforeEach((to, _from, next) => {
     const pageTitle = "Find by Subject | Medicaid & CHIP eRegulations";
 
     if (to.name === "subjects") {
-        if (to.params?.subjectName) {
-            // set document title here with available information
-            document.title = `${to.params.subjectName} | ${pageTitle}`;
-        } else {
-            document.title = pageTitle;
+        if (_from.name) {
+            if (to.params?.subjectName) {
+                // set document title here with available information
+                document.title = `${to.params.subjectName} | ${pageTitle}`;
+            } else {
+                document.title = pageTitle;
+            }
         }
 
         if (!isAuthenticated && to.query?.type) {

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -24,7 +24,9 @@ router.beforeEach((to, _from, next) => {
     const pageTitle = "Find by Subject | Medicaid & CHIP eRegulations";
 
     if (to.name === "subjects") {
-        if (_from.name) {
+        if ( window.event?.type === "popstate" ) {
+            document.title = pageTitle;
+        } else if (_from.name) {
             if (to.params?.subjectName) {
                 // set document title here with available information
                 document.title = `${to.params.subjectName} | ${pageTitle}`;

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -20,7 +20,7 @@ Vue.directive("clickaway", Clickaway);
 
 const router = vueRouter({ customUrl, host });
 
-router.beforeEach((to, from, next) => {
+router.beforeEach((to, _from, next) => {
     if (!isAuthenticated && to.name === "subjects" && to.query?.type) {
         const { type, ...query } = to.query;
         next({ ...to, query });

--- a/solution/ui/regulations/eregs-vite/src/router/index.js
+++ b/solution/ui/regulations/eregs-vite/src/router/index.js
@@ -27,6 +27,7 @@ const routes = [
         path: "/subjects",
         name: "subjects",
         component: Subjects,
+        props: true,
     },
 ];
 

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -282,6 +282,21 @@ const setSelectedSubjectParts = () => {
 };
 
 watch(
+    () => selectedSubjectParts.value,
+    async (newSubjectParts) => {
+        if (_isEmpty(newSubjectParts)) {
+            // set standard title
+            document.title =
+                "Find by Subject | Medicaid & CHIP eRegulations";
+        } else {
+            document.title = `${
+                newSubjectParts[0][0] ?? newSubjectParts[1][0]
+            } | Find by Subject | Medicaid & CHIP eRegulations`;
+        }
+    }
+);
+
+watch(
     () => policyDocSubjects.value.loading,
     async (newLoading) => {
         if (!newLoading) {

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -365,9 +365,7 @@ getDocSubjects();
                     <JumpTo :home-url="homeUrl" />
                 </template>
                 <template #links>
-                    <HeaderLinks
-                        :statutes-url="statutesUrl"
-                    />
+                    <HeaderLinks :statutes-url="statutesUrl" />
                 </template>
                 <template #search>
                     <HeaderSearch :search-url="searchUrl" />

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -283,21 +283,6 @@ const setSelectedSubjectParts = () => {
 };
 
 watch(
-    () => selectedSubjectParts.value,
-    async (newSubjectParts) => {
-        if (_isEmpty(newSubjectParts)) {
-            // set standard title
-            document.title =
-                "Find by Subject | Medicaid & CHIP eRegulations";
-        } else {
-            document.title = `${
-                newSubjectParts[0][0] ?? newSubjectParts[1][0]
-            } | Find by Subject | Medicaid & CHIP eRegulations`;
-        }
-    }
-);
-
-watch(
     () => policyDocSubjects.value.loading,
     async (newLoading) => {
         if (!newLoading) {


### PR DESCRIPTION
Resolves [EREGCSC-2313](https://jiraent.cms.gov/browse/EREGCSC-2313)

**Description**

Tidy up page title tags to help make analytics more meaningful.

**This pull request changes:**

- Updates Django templates where appropriate to match expected title text
- Uses template `block`s for title parts to stay DRY
- gets `subject_name` from Django `Subject` model if page is loaded with a subject query parameter and adds it to title
- Updates Subjects page title using a Vue Router navigation guard as the user interacts with the Subjects page single page app
- Adds Cypress test suite to assert various app states display the expected title text

**Steps to manually verify this change...**

1. Visit [experimental deployment](https://e782e3ue2e.execute-api.us-east-1.amazonaws.com/dev1207)
2. See [JIRA story](https://jiraent.cms.gov/browse/EREGCSC-2313) for detailed Acceptance Criteria. Ensure the title text matches what is outlined in the JIRA story on the following pages:
   - [Homepage](https://e782e3ue2e.execute-api.us-east-1.amazonaws.com/dev1207)
   - [Statutes page](https://e782e3ue2e.execute-api.us-east-1.amazonaws.com/dev1207/statutes/)
   - [Subjects page without subject selected](https://e782e3ue2e.execute-api.us-east-1.amazonaws.com/dev1207/subjects/)
   - [Subjects page with subject query param already in URL](https://e782e3ue2e.execute-api.us-east-1.amazonaws.com/dev1207/subjects/?subjects=2)
3. Click around the Subjects page, add and remove subjects several times, and make sure title matches selected subject.  Also make sure it does not have a subject if no subject is selected
4. Click the browser Back and Forward buttons and see if the title stays in sync with what is expected.
   - using the back button to step back through a long list of subjects will likely not show the subject in the title
   - the idea is to make sure the title isn't showing an incorrect subject when using the back and forward buttons
