### PR TITLE
EREGCSC-2561 Update Python to unblock Django upgrade

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: success() && steps.findPr.outputs.number
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: success() && steps.findPr.outputs.number
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       # Configure AWS credentials for GitHub Actions
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2
@@ -199,7 +199,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -237,7 +237,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: success() && steps.findPr.outputs.number
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: 18.14
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -64,7 +64,7 @@ jobs:
           popd
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/pythonLint.yml
+++ b/.github/workflows/pythonLint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -32,7 +32,7 @@ jobs:
       # Setup Python
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       # Configure AWS credentials for GitHub Actions
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 18.14
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/solution/Dockerfile.template
+++ b/solution/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine
+FROM python:3.10-alpine
 
 COPY ["static-assets/requirements.txt", "/app/src/"]
 WORKDIR /app/src/

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -3,7 +3,7 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
-  runtime: python3.9
+  runtime: python3.10
   region: us-east-1
   iam:
     role: LambdaFunctionRole

--- a/solution/backend/serverless-redirect.yml
+++ b/solution/backend/serverless-redirect.yml
@@ -2,7 +2,7 @@ service: redirect-api
 
 provider:
   name: aws
-  runtime: python3.9
+  runtime: python3.10
   region: us-east-1
   iam:
     role: LambdaFunctionRole

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -3,7 +3,7 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
-  runtime: python3.9
+  runtime: python3.10
   region: us-east-1
   iam:
     role: LambdaFunctionRole

--- a/solution/serverless-test-files/serverless-backend.yml
+++ b/solution/serverless-test-files/serverless-backend.yml
@@ -4,7 +4,7 @@ variablesResolutionMode: 20210326
 #change the db password and teh username/name to whatever you would like.  You can change other fields if you would like as well but be wary it might not work with your changes.
 provider:
   name: aws
-  runtime: python3.9
+  runtime: python3.10
   region: us-east-1
   iam:
     role: LambdaFunctionRole

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -2,7 +2,7 @@ service: cmcs-eregs-static-assets
 
 provider:
   name: aws
-  runtime: python3.9
+  runtime: python3.10
   region: us-east-1
   deploymentBucket:
     blockPublicAccess: true
@@ -18,7 +18,7 @@ custom:
       name: python-django
       description: "Layer which contains django requirements"
       compatibleRuntimes:
-        - python3.9
+        - python3.10
 
 package:
   #patterns:


### PR DESCRIPTION
Resolves #2561

**Description-**

We are currently on Django 3.2 which supports up to Python 3.10. In order to unblock migrating to the latest versions of Django we can upgrade to Python 3.10 which unblocks up to Django 5.0.

Once we have upgraded Django, we can revisit upgrading again to an even newer version of Python.

**This pull request changes...**

- Update Python to 3.10 locally and on deployment.
- In one case, downgrade from 3.11 to 3.10 for consistency.

**Steps to manually verify this change...**

1. Green check marks on this deployment (unit tests good, no cypress errors, no seed data errors, no migration errors, etc.)
2. Visit the experimental deploy and click around to make sure the site is working as expected.
3. Create a new instance locally (rebuild, either with `docker system prune` or use `docker compose up -d --build regulations`).
4. Make sure the build completes successfully, and visit the site to make sure it's working as expected locally.
5. Run unit tests (`make test.pytest`).

