### PR TITLE
EREGCSC-2563 -- Omit admins from analytics

### DIFF
--- a/solution/backend/cmcs_regulations/context_processors.py
+++ b/solution/backend/cmcs_regulations/context_processors.py
@@ -8,6 +8,12 @@ def google_analytics(request):
     }
 
 
+def is_admin_user(request):
+    return {
+        "IS_ADMIN_USER": request.user.groups.filter(name='EREGS_ADMIN').exists()
+    }
+
+
 def custom_url(request):
     custom_url = settings.CUSTOM_URL
     host = request.get_host()

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -146,6 +146,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "django.template.context_processors.request",
                 "cmcs_regulations.context_processors.google_analytics",
+                "cmcs_regulations.context_processors.is_admin_user",
                 "cmcs_regulations.context_processors.custom_url",
                 "cmcs_regulations.context_processors.survey_url",
                 "cmcs_regulations.context_processors.signup_url",

--- a/solution/backend/regulations/templates/regulations/base.html
+++ b/solution/backend/regulations/templates/regulations/base.html
@@ -8,6 +8,7 @@ CSS/Javascript etc., should inherit from this template.
 <!DOCTYPE html>
 <html class="no-js" lang="en">
     <head>
+    {% if not IS_ADMIN_USER %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script nonce="{{ request.csp_nonce }}" async src="https://www.googletagmanager.com/gtag/js?id={{ GA_ID }}"></script>
     <script nonce="{{ request.csp_nonce }}">
@@ -16,6 +17,7 @@ CSS/Javascript etc., should inherit from this template.
         function gtag(){dataLayer.push(arguments);}
         gtag("js", new Date());
         gtag("config", "{{ GA_ID }}");
+    {% endif %}
     </script>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=11; IE=EDGE">

--- a/solution/ui/e2e/cypress/e2e/analytics.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/analytics.spec.cy.js
@@ -1,0 +1,30 @@
+const username = Cypress.env("TEST_USERNAME");
+const password = Cypress.env("TEST_PASSWORD");
+const readerUsername = Cypress.env("READER_USERNAME");
+const readerPassword = Cypress.env("READER_PASSWORD");
+
+describe("Analytics", () => {
+    beforeEach(() => {
+        cy.intercept("/**", (req) => {
+            req.headers["x-automated-test"] =
+                Cypress.env("DEPLOYING");
+        }).as("headers");
+    });
+
+    it("does not render Google Analytics script tag if logged in as an admin", () => {
+        cy.viewport("macbook-15");
+
+        cy.visit("/");
+        cy.get('head script[src*="googletagmanager"]').should("exist");
+
+        cy.eregsLogin({ username: readerUsername, password: readerPassword, landingPage: "/" });
+        cy.get('head script[src*="googletagmanager"]').should("exist");
+
+        cy.get("#logout").click();
+
+        cy.eregsLogin({ username, password, landingPage: "/" });
+        cy.visit("/");
+        cy.get('head script[src*="googletagmanager"]').should("not.exist");
+    });
+
+});


### PR DESCRIPTION
Resolves [EREGCSC-2563](https://jiraent.cms.gov/browse/EREGCSC-2563)

**Description**

In order to create meaningful reports about user behavior, we don't want to count logged-in people with admin roles (job codes) as part of our Google Analytics.

**This pull request changes:**

- Creates `IS_ADMIN_USER` variable that can be used in all templates
- Adds logic to base template that will only render Google Tag Manager/Analytics `script` tags in the page `head` if `IS_ADMIN_USER` is `False`

**Steps to manually verify this change:**

1. Visit [experimental deployment](https://sascih35oc.execute-api.us-east-1.amazonaws.com/dev1210)
2. Ensure you are NOT logged in
3. Open DevTools and inspect the `head` element of any page.  
   - You should see the following comment: `<!-- Global site tag (gtag.js) - Google Analytics -->`
   - Underneath the comment, you should see two `script` tags.  One with a `src` that includes `googletagmanager.com`, and a second that contains some `gtag` logic
4.  Log in with an account that is not an admin
5. You should still see the two script tags described above
6. Log out and log in with an account that IS an admin
7. You should not see the GTag comment or the script tags in `head`


