### PR TITLE
[Hotfix] Increase memory allotment for lambda functions

### DIFF
--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -3,6 +3,7 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
+  memorySize: 4096
   runtime: python3.10
   region: us-east-1
   iam:

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -3,6 +3,7 @@ variablesResolutionMode: 20210326
 
 provider:
   name: aws
+  memorySize: 4096
   runtime: python3.10
   region: us-east-1
   iam:


### PR DESCRIPTION
**Description**

The `subjects` endpoint is consistently failing every few tries.  The logs indicate that it is running out of memory, which is currently set to the default allotment of 1024MB (1GB).

As more memory is allotted for each lambda, they are also given increased CPU power at roughly one vCPU per GB of memory:

https://aws.amazon.com/blogs/aws/new-for-aws-lambda-functions-with-up-to-10-gb-of-memory-and-6-vcpus/
https://stackoverflow.com/questions/68852520/increasing-the-memory-of-a-lambda-function

This will increase the cost, but the requests will also likely be faster, so the consensus in the discussions above is that the total cost per million invocations would be roughly the same so long as we don't allot more than 4GB of RAM.

**This pull request changes:**

- adds `memorySize` property to serverless.yml files with a value of `4096`

**Steps to manually verify this change:**

1. Make sure it deploys properly

