### PR TITLE
[Hotfix] Python `version-number` needs to be string in pythonLint workflow .yml

### DIFF
--- a/.github/workflows/pythonLint.yml
+++ b/.github/workflows/pythonLint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Resolves failing `Python-Lint` action

**Description**

Python was just upgraded to version 3.10.  See [PR here](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1209).

Since that upgrade, the Python-Lint action has been failing with the following message:

```
Version 3.1 was not found in the local cache
Error: The version '3.1' with architecture 'x64' was not found for Ubuntu 20.04.
```

In the `pythonLint.yml` workflow config file, the `python-version` property is set as follows:

```
with:
  python-version: 3.10
```

It's likely that this version is being interpreted as a float and the trailing zero is being ignored, which is causing the version number to be interpreted as `3.1` when the Github Action is being set up.

**This pull request changes:**

- Surrounds `3.10` with quotes in `pythonLint` workflow yml file so that the correct version of Python is used when setting up Python-Lint Github action.

**Steps to manually verify this change...**

1. Make sure Python-Lint action succeeds for this PR.

