### PR TITLE
EREGCSC-2581 Upgrade Python to 3.12

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: success() && steps.findPr.outputs.number
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: success() && steps.findPr.outputs.number
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       # Configure AWS credentials for GitHub Actions
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2
@@ -199,7 +199,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -237,7 +237,7 @@ jobs:
       - uses: actions/setup-python@v4
         if: success() && steps.findPr.outputs.number
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: 18.14
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -64,7 +64,7 @@ jobs:
           popd
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/pythonLint.yml
+++ b/.github/workflows/pythonLint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -32,7 +32,7 @@ jobs:
       # Setup Python
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       # Configure AWS credentials for GitHub Actions
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 18.14
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Configure AWS credentials for GitHub Actions
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/solution/Dockerfile.template
+++ b/solution/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.12-alpine
 
 COPY ["static-assets/requirements.txt", "/app/src/"]
 WORKDIR /app/src/

--- a/solution/backend/pyproject.toml
+++ b/solution/backend/pyproject.toml
@@ -58,5 +58,5 @@ line-length = 130
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.10.
-target-version = "py310"
+# Assume Python 3.12.
+target-version = "py312"

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -4,7 +4,7 @@ variablesResolutionMode: 20210326
 provider:
   name: aws
   memorySize: 4096
-  runtime: python3.10
+  runtime: python3.12
   region: us-east-1
   iam:
     role: LambdaFunctionRole

--- a/solution/backend/serverless-redirect.yml
+++ b/solution/backend/serverless-redirect.yml
@@ -2,7 +2,7 @@ service: redirect-api
 
 provider:
   name: aws
-  runtime: python3.10
+  runtime: python3.12
   region: us-east-1
   iam:
     role: LambdaFunctionRole

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -4,7 +4,7 @@ variablesResolutionMode: 20210326
 provider:
   name: aws
   memorySize: 4096
-  runtime: python3.10
+  runtime: python3.12
   region: us-east-1
   iam:
     role: LambdaFunctionRole

--- a/solution/lambda-proxy/pyproject.toml
+++ b/solution/lambda-proxy/pyproject.toml
@@ -46,5 +46,5 @@ line-length = 130
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.10.
-target-version = "py310"
+# Assume Python 3.12.
+target-version = "py312"

--- a/solution/serverless-test-files/serverless-backend.yml
+++ b/solution/serverless-test-files/serverless-backend.yml
@@ -4,7 +4,7 @@ variablesResolutionMode: 20210326
 #change the db password and teh username/name to whatever you would like.  You can change other fields if you would like as well but be wary it might not work with your changes.
 provider:
   name: aws
-  runtime: python3.10
+  runtime: python3.12
   region: us-east-1
   iam:
     role: LambdaFunctionRole

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -2,7 +2,7 @@ service: cmcs-eregs-static-assets
 
 provider:
   name: aws
-  runtime: python3.10
+  runtime: python3.12
   region: us-east-1
   deploymentBucket:
     blockPublicAccess: true
@@ -18,7 +18,7 @@ custom:
       name: python-django
       description: "Layer which contains django requirements"
       compatibleRuntimes:
-        - python3.10
+        - python3.12
 
 package:
   #patterns:

--- a/solution/text-extractor/pyproject.toml
+++ b/solution/text-extractor/pyproject.toml
@@ -48,5 +48,5 @@ exclude = [
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.10.
-target-version = "py310"
+# Assume Python 3.12.
+target-version = "py312"


### PR DESCRIPTION
Resolves #2581

**Description-**

To increase future maintainability and support newer Python features/enhancements, we want eRegs to be running on the latest stable version of Python, which as of now is 3.12.

**This pull request changes...**

- Update Python to 3.12.
- Thoroughly tested the site, ran unit tests, checked Cypress, etc to ensure nothing has broken.
- Checked for deprecations using `python -wa`.

**Steps to manually verify this change...**

1. Green check marks for this experimental deployment.
2. Rebuild your regulations container locally and verify it builds and runs successfully using Python 3.12 (verify it's running 3.12 with `docker compose exec regulations python --version`.)
3. Run unit tests locally (`make test.pytest`).

