### PR TITLE
[Hotfix] In test, add user search query that is guaranteed to succeed

### DIFF
--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -514,18 +514,18 @@ describe("Find by Subjects", () => {
     });
 
     it("should display and fetch the correct search query on load if it is included in URL", () => {
-        cy.intercept("**/v3/content-search/?q=test**").as("qFiles");
+        cy.intercept("**/v3/content-search/?q=streamlined%20modular%20certification**").as("qFiles");
         cy.viewport("macbook-15");
         cy.eregsLogin({
             username,
             password,
             landingPage: "/subjects/",
         });
-        cy.visit("/subjects/?q=test");
+        cy.visit("/subjects/?q=streamlined%20modular%20certification");
         cy.wait("@qFiles").then((interception) => {
             expect(interception.response.statusCode).to.eq(200);
         });
-        cy.get("input#main-content").should("have.value", "test");
+        cy.get("input#main-content").should("have.value", "streamlined modular certification");
         cy.get(".subject__heading").should("not.exist");
     });
 


### PR DESCRIPTION
Resolves failing test on `dev` environment due to data being synced with `prod`

**Description**

We're syncing up database data for `dev`, `val`, and `prod` environments.  So far, we've taken a dump of `prod` data and used it to populated `dev`.  Now, `dev` behaves like `prod` -- which, in our case, means that certain search queries will now fail.

This is causing a test to fail on `dev`, which is blocking deployment to `prod`.

For future discussion: this failing test is one of the few tests that does not intercept a request and use fixtures for the results. Instead, it waits for the actual response from the server.

**This pull request changes:**

- Replaces the search query `test`, which fails, which search query `streamlined modular certification`, which passes.

**Steps to manually verify this change:**

1. This PR can be successfully deployed to `prod`.

