### PR TITLE
EREGCSC-2592 -- Return a better error message when search times out

### DIFF
--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -28,5 +28,6 @@
     data-host="{{ host }}"
     data-statutes-url="{% url 'statutes' %}"
     data-subjects-url="{% url 'subjects' %}"
+    data-survey-url="{{ SURVEY_URL }}"
 ></div>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/subjects.html
+++ b/solution/backend/regulations/templates/regulations/subjects.html
@@ -28,6 +28,7 @@
     data-search-url="{% url 'search' %}"
     data-statutes-url="{% url 'statutes' %}"
     data-subjects-url="{% url 'subjects' %}"
+    data-survey-url="{{ SURVEY_URL }}"
     data-host="{{ host }}"
     data-is-authenticated="{{ is_authenticated }}"
     data-has-editable-job-code="{{ has_editable_job_code }}"

--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -4,6 +4,16 @@
 
 @import "../application_settings";
 
+.error-msg__container {
+    .error__msg {
+        .error-msg__common {
+            &--first-letter {
+                text-transform: uppercase;
+            }
+        }
+    }
+}
+
 .search-page {
     #searchApp.search-view {
         display: flex;

--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -6,14 +6,6 @@
 
 .error-msg__container {
     font-size: $font-size-lg;
-
-    .error__msg {
-        .error-msg__common {
-            &--first-letter {
-                text-transform: uppercase;
-            }
-        }
-    }
 }
 
 .search-page {

--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -5,6 +5,8 @@
 @import "../application_settings";
 
 .error-msg__container {
+    font-size: $font-size-lg;
+
     .error__msg {
         .error-msg__common {
             &--first-letter {

--- a/solution/ui/regulations/css/scss/partials/_subjects.scss
+++ b/solution/ui/regulations/css/scss/partials/_subjects.scss
@@ -386,6 +386,10 @@
 }
 
 .doc__list {
+    .error-msg__container {
+        padding: 0 1rem;
+    }
+
     .doc-list__document {
         .document__subjects {
             margin-top: 0.75rem;

--- a/solution/ui/regulations/eregs-component-lib/package-lock.json
+++ b/solution/ui/regulations/eregs-component-lib/package-lock.json
@@ -1368,7 +1368,6 @@
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
       "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
-      "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
         "postcss": "^8.4.32",

--- a/solution/ui/regulations/eregs-vite/src/App.vue
+++ b/solution/ui/regulations/eregs-vite/src/App.vue
@@ -37,6 +37,10 @@ export default {
             type: String,
             default: "",
         },
+        surveyUrl: {
+            type: String,
+            default: "",
+        },
         host: {
             type: String,
             default: "",
@@ -64,6 +68,7 @@ export default {
             :search-url="searchUrl"
             :statutes-url="statutesUrl"
             :subjects-url="subjectsUrl"
+            :survey-url="surveyUrl"
             :host="host"
             :is-authenticated="isAuthenticated === 'True'"
             :has-editable-job-code="hasEditableJobCode === 'True'"

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.test.js
@@ -20,7 +20,7 @@ describe("Search Error Message", () => {
         );
 
         expect(errorTextEl.textContent).toBe(
-            "Sorry, we’re unable to display results for Search Query right now. the server is taking too long to respond. Please try a different query, try again later, or let us know."
+            "Sorry, we’re unable to display results for Search Query right now. please try a different query, try again later, or let us know."
         );
 
         const letterToCapitalize = screen.getByTestId(
@@ -51,7 +51,7 @@ describe("Search Error Message", () => {
         );
 
         expect(errorTextEl.textContent).toBe(
-            "Sorry, the server is taking too long to respond. Please try a different query, try again later, or let us know."
+            "Sorry, please try a different query, try again later, or let us know."
         );
 
         const letterToCapitalize = screen.getByTestId(

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.test.js
@@ -9,34 +9,47 @@ describe("Search Error Message", () => {
         const wrapper = render(SearchErrorMsg, {
             props: {
                 searchQuery: "Search Query",
+                showApology: true,
                 surveyUrl: "Survey URL",
             },
         });
 
         await flushPromises();
 
-        const errorTextEl = screen.getByText((content, element) =>
-            content.startsWith("Sorry")
+        const errorTextEl = screen.getByTestId(
+            "error__msg"
         );
 
         expect(errorTextEl.textContent).toBe(
-            "Sorry, we’re unable to display results for Search Query right now. please try a different query, try again later, or let us know."
+            "Sorry, we’re unable to display results for Search Query right now. Please try a different query, try again later, or let us know."
         );
-
-        const letterToCapitalize = screen.getByTestId(
-            "error-msg__common--first-letter"
-        );
-
-        expect(
-            letterToCapitalize.classList.contains(
-                "error-msg__common--first-letter"
-            )
-        ).toBe(true);
 
         expect(wrapper).toMatchSnapshot();
     });
 
     it("Renders a message without a search query", async () => {
+        const wrapper = render(SearchErrorMsg, {
+            props: {
+                searchQuery: "",
+                showApology: true,
+                surveyUrl: "Survey URL",
+            },
+        });
+
+        await flushPromises();
+
+        const errorTextEl = screen.getByTestId(
+            "error__msg"
+        );
+
+        expect(errorTextEl.textContent).toBe(
+            "Sorry, we’re unable to display results right now. Please try a different query, try again later, or let us know."
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it("Renders a message without an apology", async () => {
         const wrapper = render(SearchErrorMsg, {
             props: {
                 searchQuery: "",
@@ -46,24 +59,13 @@ describe("Search Error Message", () => {
 
         await flushPromises();
 
-        const errorTextEl = screen.getByText((content, element) =>
-            content.startsWith("Sorry")
+        const errorTextEl = screen.getByTestId(
+            "error__msg"
         );
 
         expect(errorTextEl.textContent).toBe(
-            "Sorry, please try a different query, try again later, or let us know."
+            "Please try a different query, try again later, or let us know."
         );
-
-        const letterToCapitalize = screen.getByTestId(
-            "error-msg__common--first-letter"
-        );
-
-        expect(
-            letterToCapitalize.classList.contains(
-                "error-msg__common--first-letter"
-            )
-        ).toBe(false);
-
 
         expect(wrapper).toMatchSnapshot();
     });

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.test.js
@@ -1,0 +1,70 @@
+import flushPromises from "flush-promises";
+import { render, screen } from "@testing-library/vue";
+import { describe, it, expect } from "vitest";
+
+import SearchErrorMsg from "./SearchErrorMsg.vue";
+
+describe("Search Error Message", () => {
+    it("Renders a message with a search query", async () => {
+        const wrapper = render(SearchErrorMsg, {
+            props: {
+                searchQuery: "Search Query",
+                surveyUrl: "Survey URL",
+            },
+        });
+
+        await flushPromises();
+
+        const errorTextEl = screen.getByText((content, element) =>
+            content.startsWith("Sorry")
+        );
+
+        expect(errorTextEl.textContent).toBe(
+            "Sorry, we’re unable to display results for Search Query right now. the server is taking too long to respond. Please try a different query, try again later, or let us know."
+        );
+
+        const letterToCapitalize = screen.getByTestId(
+            "error-msg__common--first-letter"
+        );
+
+        expect(
+            letterToCapitalize.classList.contains(
+                "error-msg__common--first-letter"
+            )
+        ).toBe(true);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it("Renders a message without a search query", async () => {
+        const wrapper = render(SearchErrorMsg, {
+            props: {
+                searchQuery: "",
+                surveyUrl: "Survey URL",
+            },
+        });
+
+        await flushPromises();
+
+        const errorTextEl = screen.getByText((content, element) =>
+            content.startsWith("Sorry")
+        );
+
+        expect(errorTextEl.textContent).toBe(
+            "Sorry, the server is taking too long to respond. Please try a different query, try again later, or let us know."
+        );
+
+        const letterToCapitalize = screen.getByTestId(
+            "error-msg__common--first-letter"
+        );
+
+        expect(
+            letterToCapitalize.classList.contains(
+                "error-msg__common--first-letter"
+            )
+        ).toBe(false);
+
+
+        expect(wrapper).toMatchSnapshot();
+    });
+});

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
@@ -4,6 +4,10 @@ const props = defineProps({
         type: String,
         default: "",
     },
+    showApology: {
+        type: Boolean,
+        default: false,
+    },
     surveyUrl: {
         type: String,
         default: "",
@@ -13,19 +17,18 @@ const props = defineProps({
 
 <template>
     <div class="error-msg__container">
-        <span class="error__msg"
-            >Sorry,
-            <span class="error__msg--query" v-if="searchQuery"
-                >we’re unable to display results for
-                <strong>{{ searchQuery }}</strong> right now.
+        <span class="error__msg" data-testid="error__msg">
+            <span class="error__msg--apology" v-if="showApology"
+                >Sorry, we’re unable to display results<span
+                    class="error__msg--query"
+                    v-if="searchQuery"
+                >
+                    for <strong>{{ searchQuery }}</strong></span
+                >
+                right now.
             </span>
             <span class="error-msg__common"
-                ><span
-                    data-testid="error-msg__common--first-letter"
-                    :class="{ 'error-msg__common--first-letter': searchQuery }"
-                    >p</span
-                >lease try a different
-                query, try again later, or
+                >Please try a different query, try again later, or
                 <a :href="surveyUrl" target="_blank" rel="noopener noreferrer"
                     >let us know</a
                 >.</span

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
@@ -18,8 +18,8 @@ const props = defineProps({
         <span class="error__msg"
             >Sorry,
             <span class="error__msg--query" v-if="searchQuery"
-                >we’re unable to display results for {{ searchQuery }} right
-                now.
+                >we’re unable to display results for
+                <strong>{{ searchQuery }}</strong> right now.
             </span>
             <span class="error-msg__common"
                 ><span

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
@@ -1,0 +1,31 @@
+<script setup>
+import { computed, ref } from "vue";
+
+const props = defineProps({
+    searchQuery: {
+        type: String,
+        default: "",
+    },
+});
+</script>
+
+<template>
+    <div class="error-msg__container">
+        <span class="error__msg"
+            >Sorry,
+            <span class="error__msg--query" v-if="searchQuery"
+                >we’re unable to display results for {{ searchQuery }} right
+                now.
+            </span>
+            <span class="error-msg__common"
+                ><span
+                    :class="{ 'error-msg__common--first-letter': searchQuery }"
+                    >t</span
+                >he server is taking too long to respond. Please try a different
+                query, try again later, or let us know.</span
+            ></span
+        >
+    </div>
+</template>
+
+<style></style>

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
@@ -6,6 +6,10 @@ const props = defineProps({
         type: String,
         default: "",
     },
+    surveyUrl: {
+        type: String,
+        default: "",
+    },
 });
 </script>
 
@@ -22,7 +26,10 @@ const props = defineProps({
                     :class="{ 'error-msg__common--first-letter': searchQuery }"
                     >t</span
                 >he server is taking too long to respond. Please try a different
-                query, try again later, or let us know.</span
+                query, try again later, or
+                <a :href="surveyUrl" target="_blank" rel="noopener noreferrer"
+                    >let us know</a
+                >.</span
             ></span
         >
     </div>

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
@@ -23,8 +23,8 @@ const props = defineProps({
                 ><span
                     data-testid="error-msg__common--first-letter"
                     :class="{ 'error-msg__common--first-letter': searchQuery }"
-                    >t</span
-                >he server is taking too long to respond. Please try a different
+                    >p</span
+                >lease try a different
                 query, try again later, or
                 <a :href="surveyUrl" target="_blank" rel="noopener noreferrer"
                     >let us know</a

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
@@ -1,6 +1,4 @@
 <script setup>
-import { computed, ref } from "vue";
-
 const props = defineProps({
     searchQuery: {
         type: String,
@@ -35,5 +33,3 @@ const props = defineProps({
         >
     </div>
 </template>
-
-<style></style>

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
@@ -23,6 +23,7 @@ const props = defineProps({
             </span>
             <span class="error-msg__common"
                 ><span
+                    data-testid="error-msg__common--first-letter"
                     :class="{ 'error-msg__common--first-letter': searchQuery }"
                     >t</span
                 >he server is taking too long to respond. Please try a different

--- a/solution/ui/regulations/eregs-vite/src/components/__snapshots__/SearchErrorMsg.test.js.snap
+++ b/solution/ui/regulations/eregs-vite/src/components/__snapshots__/SearchErrorMsg.test.js.snap
@@ -27,9 +27,9 @@ exports[`Search Error Message > Renders a message with a search query 1`] = `
               class="error-msg__common--first-letter"
               data-testid="error-msg__common--first-letter"
             >
-              t
+              p
             </span>
-            he server is taking too long to respond. Please try a different query, try again later, or 
+            lease try a different query, try again later, or 
             <a
               href="Survey URL"
               rel="noopener noreferrer"
@@ -67,9 +67,9 @@ exports[`Search Error Message > Renders a message with a search query 1`] = `
             class="error-msg__common--first-letter"
             data-testid="error-msg__common--first-letter"
           >
-            t
+            p
           </span>
-          he server is taking too long to respond. Please try a different query, try again later, or 
+          lease try a different query, try again later, or 
           <a
             href="Survey URL"
             rel="noopener noreferrer"
@@ -158,9 +158,9 @@ exports[`Search Error Message > Renders a message without a search query 1`] = `
               class=""
               data-testid="error-msg__common--first-letter"
             >
-              t
+              p
             </span>
-            he server is taking too long to respond. Please try a different query, try again later, or 
+            lease try a different query, try again later, or 
             <a
               href="Survey URL"
               rel="noopener noreferrer"
@@ -190,9 +190,9 @@ exports[`Search Error Message > Renders a message without a search query 1`] = `
             class=""
             data-testid="error-msg__common--first-letter"
           >
-            t
+            p
           </span>
-          he server is taking too long to respond. Please try a different query, try again later, or 
+          lease try a different query, try again later, or 
           <a
             href="Survey URL"
             rel="noopener noreferrer"

--- a/solution/ui/regulations/eregs-vite/src/components/__snapshots__/SearchErrorMsg.test.js.snap
+++ b/solution/ui/regulations/eregs-vite/src/components/__snapshots__/SearchErrorMsg.test.js.snap
@@ -14,7 +14,11 @@ exports[`Search Error Message > Renders a message with a search query 1`] = `
           <span
             class="error__msg--query"
           >
-            we’re unable to display results for Search Query right now. 
+            we’re unable to display results for 
+            <strong>
+              Search Query
+            </strong>
+             right now. 
           </span>
           <span
             class="error-msg__common"
@@ -50,7 +54,11 @@ exports[`Search Error Message > Renders a message with a search query 1`] = `
         <span
           class="error__msg--query"
         >
-          we’re unable to display results for Search Query right now. 
+          we’re unable to display results for 
+          <strong>
+            Search Query
+          </strong>
+           right now. 
         </span>
         <span
           class="error-msg__common"

--- a/solution/ui/regulations/eregs-vite/src/components/__snapshots__/SearchErrorMsg.test.js.snap
+++ b/solution/ui/regulations/eregs-vite/src/components/__snapshots__/SearchErrorMsg.test.js.snap
@@ -9,27 +9,26 @@ exports[`Search Error Message > Renders a message with a search query 1`] = `
       >
         <span
           class="error__msg"
+          data-testid="error__msg"
         >
-          Sorry, 
           <span
-            class="error__msg--query"
+            class="error__msg--apology"
           >
-            we’re unable to display results for 
-            <strong>
-              Search Query
-            </strong>
+            Sorry, we’re unable to display results
+            <span
+              class="error__msg--query"
+            >
+               for 
+              <strong>
+                Search Query
+              </strong>
+            </span>
              right now. 
           </span>
           <span
             class="error-msg__common"
           >
-            <span
-              class="error-msg__common--first-letter"
-              data-testid="error-msg__common--first-letter"
-            >
-              p
-            </span>
-            lease try a different query, try again later, or 
+            Please try a different query, try again later, or 
             <a
               href="Survey URL"
               rel="noopener noreferrer"
@@ -49,27 +48,26 @@ exports[`Search Error Message > Renders a message with a search query 1`] = `
     >
       <span
         class="error__msg"
+        data-testid="error__msg"
       >
-        Sorry, 
         <span
-          class="error__msg--query"
+          class="error__msg--apology"
         >
-          we’re unable to display results for 
-          <strong>
-            Search Query
-          </strong>
+          Sorry, we’re unable to display results
+          <span
+            class="error__msg--query"
+          >
+             for 
+            <strong>
+              Search Query
+            </strong>
+          </span>
            right now. 
         </span>
         <span
           class="error-msg__common"
         >
-          <span
-            class="error-msg__common--first-letter"
-            data-testid="error-msg__common--first-letter"
-          >
-            p
-          </span>
-          lease try a different query, try again later, or 
+          Please try a different query, try again later, or 
           <a
             href="Survey URL"
             rel="noopener noreferrer"
@@ -148,19 +146,19 @@ exports[`Search Error Message > Renders a message without a search query 1`] = `
       >
         <span
           class="error__msg"
+          data-testid="error__msg"
         >
-          Sorry, 
-          <!---->
+          <span
+            class="error__msg--apology"
+          >
+            Sorry, we’re unable to display results
+            <!---->
+             right now. 
+          </span>
           <span
             class="error-msg__common"
           >
-            <span
-              class=""
-              data-testid="error-msg__common--first-letter"
-            >
-              p
-            </span>
-            lease try a different query, try again later, or 
+            Please try a different query, try again later, or 
             <a
               href="Survey URL"
               rel="noopener noreferrer"
@@ -180,19 +178,130 @@ exports[`Search Error Message > Renders a message without a search query 1`] = `
     >
       <span
         class="error__msg"
+        data-testid="error__msg"
       >
-        Sorry, 
+        <span
+          class="error__msg--apology"
+        >
+          Sorry, we’re unable to display results
+          <!---->
+           right now. 
+        </span>
+        <span
+          class="error-msg__common"
+        >
+          Please try a different query, try again later, or 
+          <a
+            href="Survey URL"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            let us know
+          </a>
+          .
+        </span>
+      </span>
+    </div>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Search Error Message > Renders a message without an apology 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <div
+        class="error-msg__container"
+      >
+        <span
+          class="error__msg"
+          data-testid="error__msg"
+        >
+          <!---->
+          <span
+            class="error-msg__common"
+          >
+            Please try a different query, try again later, or 
+            <a
+              href="Survey URL"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              let us know
+            </a>
+            .
+          </span>
+        </span>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="error-msg__container"
+    >
+      <span
+        class="error__msg"
+        data-testid="error__msg"
+      >
         <!---->
         <span
           class="error-msg__common"
         >
-          <span
-            class=""
-            data-testid="error-msg__common--first-letter"
-          >
-            p
-          </span>
-          lease try a different query, try again later, or 
+          Please try a different query, try again later, or 
           <a
             href="Survey URL"
             rel="noopener noreferrer"

--- a/solution/ui/regulations/eregs-vite/src/components/__snapshots__/SearchErrorMsg.test.js.snap
+++ b/solution/ui/regulations/eregs-vite/src/components/__snapshots__/SearchErrorMsg.test.js.snap
@@ -1,0 +1,255 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Search Error Message > Renders a message with a search query 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <div
+        class="error-msg__container"
+      >
+        <span
+          class="error__msg"
+        >
+          Sorry, 
+          <span
+            class="error__msg--query"
+          >
+            we’re unable to display results for Search Query right now. 
+          </span>
+          <span
+            class="error-msg__common"
+          >
+            <span
+              class="error-msg__common--first-letter"
+              data-testid="error-msg__common--first-letter"
+            >
+              t
+            </span>
+            he server is taking too long to respond. Please try a different query, try again later, or 
+            <a
+              href="Survey URL"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              let us know
+            </a>
+            .
+          </span>
+        </span>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="error-msg__container"
+    >
+      <span
+        class="error__msg"
+      >
+        Sorry, 
+        <span
+          class="error__msg--query"
+        >
+          we’re unable to display results for Search Query right now. 
+        </span>
+        <span
+          class="error-msg__common"
+        >
+          <span
+            class="error-msg__common--first-letter"
+            data-testid="error-msg__common--first-letter"
+          >
+            t
+          </span>
+          he server is taking too long to respond. Please try a different query, try again later, or 
+          <a
+            href="Survey URL"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            let us know
+          </a>
+          .
+        </span>
+      </span>
+    </div>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;
+
+exports[`Search Error Message > Renders a message without a search query 1`] = `
+{
+  "baseElement": <body>
+    <div>
+      <div
+        class="error-msg__container"
+      >
+        <span
+          class="error__msg"
+        >
+          Sorry, 
+          <!---->
+          <span
+            class="error-msg__common"
+          >
+            <span
+              class=""
+              data-testid="error-msg__common--first-letter"
+            >
+              t
+            </span>
+            he server is taking too long to respond. Please try a different query, try again later, or 
+            <a
+              href="Survey URL"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              let us know
+            </a>
+            .
+          </span>
+        </span>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="error-msg__container"
+    >
+      <span
+        class="error__msg"
+      >
+        Sorry, 
+        <!---->
+        <span
+          class="error-msg__common"
+        >
+          <span
+            class=""
+            data-testid="error-msg__common--first-letter"
+          >
+            t
+          </span>
+          he server is taking too long to respond. Please try a different query, try again later, or 
+          <a
+            href="Survey URL"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            let us know
+          </a>
+          .
+        </span>
+      </span>
+    </div>
+  </div>,
+  "debug": [Function],
+  "emitted": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "html": [Function],
+  "isUnmounted": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "unmount": [Function],
+  "updateProps": [Function],
+}
+`;

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -172,7 +172,6 @@ import {
     getRegSearchResults,
     getSynonyms,
     getTitles,
-    throwGenericError,
 } from "utilities/api";
 
 import BlockingModal from "eregsComponentLib/src/components/BlockingModal.vue";
@@ -358,8 +357,7 @@ export default {
         async retrieveRegResults({ query, page, pageSize }) {
             this.regsError = false;
             try {
-                /* const response = await getRegSearchResults({ */
-                const response = await throwGenericError({
+                 const response = await getRegSearchResults({
                     q: query,
                     page,
                     page_size: pageSize,
@@ -383,8 +381,7 @@ export default {
             }&page_size=${pageSize}&paginate=true`;
             let response = "";
             try {
-                /* response = await getCombinedContent({ */
-                response = await throwGenericError({
+                 response = await getCombinedContent({
                     apiUrl: this.apiUrl,
                     cacheResponse: false,
                     requestParams,

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -358,7 +358,8 @@ export default {
         async retrieveRegResults({ query, page, pageSize }) {
             this.regsError = false;
             try {
-                const response = await getRegSearchResults({
+                /* const response = await getRegSearchResults({ */
+                const response = await throwGenericError({
                     q: query,
                     page,
                     page_size: pageSize,

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -428,7 +428,7 @@ getDocSubjects();
                         <template v-else-if="policyDocList.error">
                             <div class="doc__list">
                                 <h2
-                                    v-if="searchQuery"
+                                    v-if="!selectedSubjectParts.length || searchQuery"
                                     class="search-results__heading"
                                 >
                                     Search Results

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -71,6 +71,10 @@ const props = defineProps({
         type: String,
         default: "/subjects/",
     },
+    surveyUrl: {
+        type: String,
+        default: "",
+    },
 });
 
 // Router and Route
@@ -86,11 +90,11 @@ const FilterTypesDict = {
 // provide Django template variables
 provide("apiUrl", props.apiUrl);
 provide("base", props.homeUrl);
+provide("currentRouteName", $route.name);
 provide("customLoginUrl", props.customLoginUrl);
 provide("FilterTypesDict", FilterTypesDict);
 provide("homeUrl", props.homeUrl);
 provide("isAuthenticated", props.isAuthenticated);
-provide("currentRouteName", $route.name);
 
 /**
  * @param {Object} queryParams - $route.query
@@ -166,6 +170,7 @@ const getDocList = async (requestParams = "") => {
     policyDocList.value.error = false;
 
     try {
+        /* const contentList = await getCombinedContent({ */
         const contentList = await throwGenericError({
             apiUrl: props.apiUrl,
             cacheResponse: false,
@@ -425,7 +430,10 @@ getDocSubjects();
                                 <h2 class="search-results__heading">
                                     Search Results
                                 </h2>
-                                <SearchErrorMsg :search-query="searchQuery"/>
+                                <SearchErrorMsg
+                                    :search-query="searchQuery"
+                                    :survey-url="surveyUrl"
+                                />
                             </div>
                         </template>
                         <template v-else>

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -7,10 +7,10 @@ import _isEmpty from "lodash/isEmpty";
 
 import {
     getCombinedContent,
-    getCombinedContentError,
     getLastUpdatedDates,
     getPolicyDocSubjects,
     getTitles,
+    throwGenericError,
 } from "utilities/api";
 
 import { getSubjectName, getSubjectNameParts } from "utilities/filters";
@@ -28,6 +28,7 @@ import HeaderSearch from "@/components/header/HeaderSearch.vue";
 import PolicyResults from "@/components/subjects/PolicyResults.vue";
 import PolicySelections from "@/components/subjects/PolicySelections.vue";
 import PolicySidebar from "@/components/subjects/PolicySidebar.vue";
+import SearchErrorMsg from "@/components/SearchErrorMsg.vue";
 import SearchInput from "@/components/SearchInput.vue";
 import SelectedSubjectHeading from "@/components/subjects/SelectedSubjectHeading.vue";
 import SubjectSelector from "@/components/subjects/SubjectSelector.vue";
@@ -165,7 +166,7 @@ const getDocList = async (requestParams = "") => {
     policyDocList.value.error = false;
 
     try {
-        const contentList = await getCombinedContentError({
+        const contentList = await throwGenericError({
             apiUrl: props.apiUrl,
             cacheResponse: false,
             requestParams,
@@ -420,7 +421,12 @@ getDocSubjects();
                             <span class="loading__span">Loading...</span>
                         </template>
                         <template v-else-if="policyDocList.error">
-                            Error message here
+                            <div class="doc__list">
+                                <h2 class="search-results__heading">
+                                    Search Results
+                                </h2>
+                                <SearchErrorMsg :search-query="searchQuery"/>
+                            </div>
                         </template>
                         <template v-else>
                             <PolicyResults

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -10,7 +10,6 @@ import {
     getLastUpdatedDates,
     getPolicyDocSubjects,
     getTitles,
-    throwGenericError,
 } from "utilities/api";
 
 import { getSubjectName, getSubjectNameParts } from "utilities/filters";
@@ -170,8 +169,7 @@ const getDocList = async (requestParams = "") => {
     policyDocList.value.error = false;
 
     try {
-        /* const contentList = await getCombinedContent({ */
-        const contentList = await throwGenericError({
+         const contentList = await getCombinedContent({
             apiUrl: props.apiUrl,
             cacheResponse: false,
             requestParams,

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -427,7 +427,10 @@ getDocSubjects();
                         </template>
                         <template v-else-if="policyDocList.error">
                             <div class="doc__list">
-                                <h2 class="search-results__heading">
+                                <h2
+                                    v-if="searchQuery"
+                                    class="search-results__heading"
+                                >
                                     Search Results
                                 </h2>
                                 <SearchErrorMsg

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -435,6 +435,7 @@ getDocSubjects();
                                 </h2>
                                 <SearchErrorMsg
                                     :search-query="searchQuery"
+                                    show-apology
                                     :survey-url="surveyUrl"
                                 />
                             </div>

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -7,6 +7,7 @@ import _isEmpty from "lodash/isEmpty";
 
 import {
     getCombinedContent,
+    getCombinedContentError,
     getLastUpdatedDates,
     getPolicyDocSubjects,
     getTitles,
@@ -156,13 +157,15 @@ const getPartsLastUpdated = async () => {
 const policyDocList = ref({
     results: [],
     loading: true,
+    error: false,
 });
 
 const getDocList = async (requestParams = "") => {
     policyDocList.value.loading = true;
+    policyDocList.value.error = false;
 
     try {
-        const contentList = await getCombinedContent({
+        const contentList = await getCombinedContentError({
             apiUrl: props.apiUrl,
             cacheResponse: false,
             requestParams,
@@ -170,6 +173,8 @@ const getDocList = async (requestParams = "") => {
         policyDocList.value.results = contentList.results;
     } catch (error) {
         console.error(error);
+        policyDocList.value.results = [];
+        policyDocList.value.error = true;
     } finally {
         policyDocList.value.loading = false;
     }
@@ -413,6 +418,9 @@ getDocSubjects();
                             "
                         >
                             <span class="loading__span">Loading...</span>
+                        </template>
+                        <template v-else-if="policyDocList.error">
+                            Error message here
                         </template>
                         <template v-else>
                             <PolicyResults

--- a/solution/ui/regulations/utilities/api.js
+++ b/solution/ui/regulations/utilities/api.js
@@ -349,7 +349,6 @@ const getRecentResources = async (
     );
 };
 
-
 /**
  *
  */
@@ -580,6 +579,11 @@ const getCombinedContent = async ({
         cacheResponse
     );
 
+const getCombinedContentError = async () =>
+    new Promise((resolve, reject) => {
+        setTimeout(() => reject(new Error("fail")), 2000);
+    });
+
 export {
     config,
     configure,
@@ -588,6 +592,7 @@ export {
     getCacheKeys,
     getCategories,
     getCombinedContent,
+    getCombinedContentError,
     getDecodedIdToken,
     getGovInfoLinks,
     getLastParserSuccessDate,

--- a/solution/ui/regulations/utilities/api.js
+++ b/solution/ui/regulations/utilities/api.js
@@ -579,9 +579,9 @@ const getCombinedContent = async ({
         cacheResponse
     );
 
-const getCombinedContentError = async () =>
-    new Promise((resolve, reject) => {
-        setTimeout(() => reject(new Error("fail")), 2000);
+const throwGenericError = async () =>
+    new Promise((_resolve, reject) => {
+        setTimeout(() => reject(new Error("Contrived error")), 2000);
     });
 
 export {
@@ -592,7 +592,6 @@ export {
     getCacheKeys,
     getCategories,
     getCombinedContent,
-    getCombinedContentError,
     getDecodedIdToken,
     getGovInfoLinks,
     getLastParserSuccessDate,
@@ -612,4 +611,5 @@ export {
     removeCacheItem,
     setCacheItem,
     setIdToken,
+    throwGenericError,
 };


### PR DESCRIPTION
Resolves [EREGCSC-2592](https://jiraent.cms.gov/browse/EREGCSC-2592)

**Description**

It's confusing if the search times out and gives 0 results. Let's tell the reader what's actually happening, so that they know to look elsewhere for the information they need.

See Figma comps here:

[Search Page](https://www.figma.com/file/iZFh6UhvGVEHw1D4IAt3Bw/eRegs-Combined-Search?node-id=4652%3A7064&mode=dev)

[Subjects Page](https://www.figma.com/file/KiWw729Nct6tY9gzmvEkVO/Browse-by-Subject?node-id=818%3A16156&mode=dev)

**This pull request changes:**

- Adds new `throwGenericError` method that returns an error after two seconds
   - This method is being used for validation purposes -- initially, all Search and Subjects page requests will fail on purpose to validate the different error message states
- Creates `SearchErrorMsg` Vue component to be used in Search and Subjects page
   - Built to handle states that include a `searchQuery` and states that don't
- Passes `SURVEY_URL` from Django template into Subjects and Search Single Page Apps to be used with error message  feedback link
- Styles message per Figma comps (see above)
- Adds Vitest tests

**Steps to manually verify this change:**

1. First, visit [experimental deployment](https://zvd7igguq5.execute-api.us-east-1.amazonaws.com/dev1224) with `throwGenericError` enabled for all Search and Subjects page searches.  Compare error message to states shown in Figma comps
2. Once `throwGenericError` is disabled, browse around experimental deployment and make sure things behave as expected

