### PR TITLE
[Hotfix] show Expand Your Search box on single column failure

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -6,6 +6,7 @@
 
 .error-msg__container {
     font-size: $font-size-lg;
+    margin-bottom: 1em;
 }
 
 .search-page {

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -42,8 +42,10 @@
                     <div class="search-results-count">
                         <h2>Regulations</h2>
                         <span v-if="regsLoading">Loading...</span>
-                        <span v-else-if="regsError"
-                            >We’re unable to display results for this query
+                        <span
+                            v-else-if="regsError"
+                            class="regs-count__span--error"
+                            >We're unable to display results for this query
                             right now</span
                         >
                         <span v-else>
@@ -95,8 +97,10 @@
                     <div class="search-results-count">
                         <h2>Resources</h2>
                         <span v-if="resourcesLoading">Loading...</span>
-                        <span v-else-if="resourcesError"
-                            >We’re unable to display results for this query
+                        <span
+                            v-else-if="resourcesError"
+                            class="resources-count__span--error"
+                            >We're unable to display results for this query
                             right now</span
                         >
                         <span v-else>

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -58,10 +58,17 @@
                         </span>
                     </div>
                     <template v-if="!regsLoading">
-                        <SearchErrorMsg
-                            v-if="regsError"
-                            :survey-url="surveyUrl"
-                        />
+                        <template v-if="regsError">
+                            <SearchErrorMsg :survey-url="surveyUrl" />
+                            <template
+                                v-if="!isLoading && resourcesResults.length > 0"
+                            >
+                                <SearchEmptyState
+                                    :query="searchQuery"
+                                    :show-internal-link="false"
+                                />
+                            </template>
+                        </template>
                         <RegResults
                             v-else
                             :results="regResults"
@@ -104,10 +111,17 @@
                         </span>
                     </div>
                     <template v-if="!resourcesLoading">
-                        <SearchErrorMsg
-                            v-if="resourcesError"
-                            :survey-url="surveyUrl"
-                        />
+                        <template v-if="resourcesError">
+                            <SearchErrorMsg :survey-url="surveyUrl" />
+                            <template
+                                v-if="!isLoading && regResults.length > 0"
+                            >
+                                <SearchEmptyState
+                                    :query="searchQuery"
+                                    :show-internal-link="false"
+                                />
+                            </template>
+                        </template>
                         <PolicyResults
                             v-else
                             :base="homeUrl"
@@ -357,7 +371,7 @@ export default {
         async retrieveRegResults({ query, page, pageSize }) {
             this.regsError = false;
             try {
-                 const response = await getRegSearchResults({
+                const response = await getRegSearchResults({
                     q: query,
                     page,
                     page_size: pageSize,
@@ -381,7 +395,7 @@ export default {
             }&page_size=${pageSize}&paginate=true`;
             let response = "";
             try {
-                 response = await getCombinedContent({
+                response = await getCombinedContent({
                     apiUrl: this.apiUrl,
                     cacheResponse: false,
                     requestParams,


### PR DESCRIPTION
**Description**

On the Combined Search page, a single column failure (e.g. Reg Results are returned successfully but Resources fail), the "Expand Your Search" box is not shown.

**This pull request changes:**

- Adds logic to show "Expand Your Search" box in each column is that column, and only that column, returns an error
- Adds Cypress tests to validate error states

**Steps to manually verify this change:**

1. Green check marks
3. Normal searches work as expected (with results, with zero results, etc)
