### PR TITLE
EREGCSC-2603 Improve efficiency of subjects endpoint

### DIFF
--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -60,7 +60,7 @@ class SubjectViewset(viewsets.ReadOnlyModelViewSet):
     def list(self, request):
         search_query = self.request.GET.get("q")
         query = self.model.objects.all()
-        index_prefetch = ContentIndex.objects.all()
+        index_prefetch = ContentIndex.objects.all().only("resource_type", "id")
         if search_query:
             index_prefetch = index_prefetch.search(search_query)
         index_prefetch_internal = index_prefetch.filter(resource_type='internal').values_list('id', flat=True)


### PR DESCRIPTION
Resolves #2603

**Description-**

The subjects endpoint was taking a long time and using significant memory because of the `ContentIndex.objects.all()` call. This was loading all of the fields into memory (including the very large `content` field).

**This pull request changes...**

- Change `ContentIndex.objects.all()` to `ContentIndex.objects.all().only("resource_type", "id")`, which are the 2 fields being used for the endpoint.

**Steps to manually verify this change...**

1. Check the `/v3/file-manager/subjects` endpoint and see that it loads almost instantly now.
2. Check the CloudWatch logs for the lambda after accessing the endpoint and see memory usage is approximately 150mb or less.

