### PR TITLE
EREGCSC-2571-s3-bucket-ssl

### DIFF
--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -71,6 +71,7 @@ resources:
         VersioningConfiguration:
           Status: Enabled
         AccessControl: LogDeliveryWrite
+      DeletionPolicy: Delete
     CloudFrontLogsBucketPolicy:
       Type: "AWS::S3::BucketPolicy"
       Properties:

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -81,37 +81,17 @@ resources:
               Condition:
                 Bool:
                   aws:SecureTransport: false
+            - Effect: Allow
+              Principal:
+                Service: "delivery.logs.amazonaws.com"
+              Action: "s3:PutObject"
+              Resource: !Sub "arn:aws:s3:::${CloudFrontLogsBucket}/*"
         OwnershipControls:
           Rules:
             - ObjectOwnership: BucketOwnerPreferred
         VersioningConfiguration:
           Status: Enabled
         AccessControl: LogDeliveryWrite
-    CloudFrontLogsBucketPolicy:
-      Type: "AWS::S3::BucketPolicy"
-      Properties:
-        Bucket: !Ref CloudFrontLogsBucket
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Deny
-              Action: 's3:*'
-              Resource:
-                - !Join
-                  - ''
-                  - - 'arn:aws:s3:::'
-                    - !Ref CloudFrontLogsBucket
-                    - '/*'
-              Principal: '*'
-              Condition:
-                Bool:
-                  aws:SecureTransport: false
-            - Effect: Allow
-              Principal:
-                Service: "delivery.logs.amazonaws.com"
-              Action: "s3:PutObject"
-              Resource: !Sub "arn:aws:s3:::${CloudFrontLogsBucket}/*"
-
     CloudFrontOriginAccessIdentity:
       Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
       Properties:

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -71,7 +71,6 @@ resources:
         VersioningConfiguration:
           Status: Enabled
         AccessControl: LogDeliveryWrite
-      DeletionPolicy: Delete
     CloudFrontLogsBucketPolicy:
       Type: "AWS::S3::BucketPolicy"
       Properties:

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -65,33 +65,25 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: eregs-${self:custom.stage}-cloudfront-logs
-        DeletionPolicy: Retain
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Deny
-              Action: 's3:*'
-              Resource:
-                - !Join
-                  - ''
-                  - - 'arn:aws:s3:::'
-                    - !Ref CloudFrontLogsBucket
-                    - '/*'
-              Principal: '*'
-              Condition:
-                Bool:
-                  aws:SecureTransport: false
-            - Effect: Allow
-              Principal:
-                Service: "delivery.logs.amazonaws.com"
-              Action: "s3:PutObject"
-              Resource: !Sub "arn:aws:s3:::${CloudFrontLogsBucket}/*"
         OwnershipControls:
           Rules:
             - ObjectOwnership: BucketOwnerPreferred
         VersioningConfiguration:
           Status: Enabled
         AccessControl: LogDeliveryWrite
+    CloudFrontLogsBucketPolicy:
+      Type: "AWS::S3::BucketPolicy"
+      Properties:
+        Bucket: !Ref CloudFrontLogsBucket
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service: "delivery.logs.amazonaws.com"
+              Action: "s3:PutObject"
+              Resource: !Sub "arn:aws:s3:::${CloudFrontLogsBucket}/*"
+
     CloudFrontOriginAccessIdentity:
       Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
       Properties:
@@ -124,6 +116,10 @@ resources:
                   - - 'arn:aws:s3:::'
                     - !Ref AssetsBucket
                     - /*
+                - !Join
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - !Ref AssetsBucket
               Principal: '*'
               Condition:
                 Bool:
@@ -133,7 +129,7 @@ resources:
       Type: AWS::WAFv2::WebACL
       Properties:
         Name: eregs-${self:custom.stage}-cloudfront-ACL
-        DefaultAction: 
+        DefaultAction:
           Allow: {}
         Scope: CLOUDFRONT
         VisibilityConfig:

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -65,6 +65,21 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: eregs-${self:custom.stage}-cloudfront-logs
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Deny
+              Action: 's3:*'
+              Resource:
+                - !Join
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - !Ref CloudFrontLogsBucket
+                    - '/*'
+              Principal: '*'
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
         OwnershipControls:
           Rules:
             - ObjectOwnership: BucketOwnerPreferred
@@ -78,6 +93,18 @@ resources:
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
+            - Effect: Deny
+              Action: 's3:*'
+              Resource:
+                - !Join
+                  - ''
+                  - - 'arn:aws:s3:::'
+                    - !Ref CloudFrontLogsBucket
+                    - '/*'
+              Principal: '*'
+              Condition:
+                Bool:
+                  aws:SecureTransport: false
             - Effect: Allow
               Principal:
                 Service: "delivery.logs.amazonaws.com"
@@ -116,10 +143,6 @@ resources:
                   - - 'arn:aws:s3:::'
                     - !Ref AssetsBucket
                     - /*
-                - !Join
-                  - ''
-                  - - 'arn:aws:s3:::'
-                    - !Ref AssetsBucket
               Principal: '*'
               Condition:
                 Bool:

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -79,16 +79,16 @@ resources:
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
-            - Sid: "EnforceSSLOnly"
-              Effect: "Deny"
-              Principal: "*"
+            - Sid: "AllowSSLRequestsOnly"
               Action: "s3:*"
+              Effect: "Deny"
               Resource:
                 - !Sub "arn:aws:s3:::${CloudFrontLogsBucket}/*"
                 - !Sub "arn:aws:s3:::${CloudFrontLogsBucket}"
               Condition:
                 Bool:
                   "aws:SecureTransport": "false"
+              Principal: "*"
             - Sid: "AllowCloudFrontLogsDelivery"
               Effect: "Allow"
               Principal:

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -78,11 +78,25 @@ resources:
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
-            - Effect: Allow
+            - Sid: "EnforceSSLOnly"
+              Effect: "Deny"
+              Principal: "*"
+              Action: "s3:*"
+              Resource:
+                - !Sub "arn:aws:s3:::${CloudFrontLogsBucket}/*"
+                - !Sub "arn:aws:s3:::${CloudFrontLogsBucket}"
+              Condition:
+                Bool:
+                  "aws:SecureTransport": "false"
+            - Sid: "AllowCloudFrontLogsDelivery"
+              Effect: "Allow"
               Principal:
                 Service: "delivery.logs.amazonaws.com"
               Action: "s3:PutObject"
               Resource: !Sub "arn:aws:s3:::${CloudFrontLogsBucket}/*"
+              Condition:
+                StringEquals:
+                  "s3:x-amz-acl": "bucket-owner-full-control"
 
     CloudFrontOriginAccessIdentity:
       Type: AWS::CloudFront::CloudFrontOriginAccessIdentity

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -65,6 +65,7 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: eregs-${self:custom.stage}-cloudfront-logs
+        DeletionPolicy: Retain
         PolicyDocument:
           Version: '2012-10-17'
           Statement:


### PR DESCRIPTION
Resolves #CMCS eRegulations[EREGCSC-2571](https://jiraent.cms.gov/browse/EREGCSC-2571)

**Description-**
Security Hub control checks whether an Amazon S3 general purpose bucket has a policy that requires requests to use SSL. The control fails if the bucket policy doesn't require requests to use SSL.
**This pull request changes...**

- Update serverless.yml file to change the s3 bucket for cloudfront logs policy to require SSL 

**Steps to manually verify this change...**

1. steps to view and verify change
Visit AWS S3 buckets. 
Look at [eregs-dev1235-cloudfront-logs](https://us-east-1.console.aws.amazon.com/s3/buckets/eregs-dev1235-cloudfront-logs?region=us-east-1&bucketType=general)
Click on Permissions tab
Look at the [cloudfront bucket policy](https://us-east-1.console.aws.amazon.com/s3/buckets/eregs-dev1235-cloudfront-logs?region=us-east-1&bucketType=general&tab=permissions)
Ensure SSL is being enforced by checking the policy and see if it matches this document:
https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-5
![Screen Shot 2024-04-05 at 2 58 09 PM](https://github.com/Enterprise-CMCS/cmcs-eregulations/assets/7727136/bb91913b-0cf5-4d54-b687-d2cade700f00)
