### PR TITLE
Upgrade Github Action runner images to Ubuntu 22

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -17,7 +17,7 @@ jobs:
     environment:
       name: "dev"
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Checkout the code
       - name: Checkout
@@ -77,7 +77,7 @@ jobs:
   deploy-text-extractor:
     environment:
       name: "dev"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Checkout the code
       - name: Checkout
@@ -114,7 +114,7 @@ jobs:
       name: "dev"
     outputs:
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [deploy-static, deploy-text-extractor]
     steps:
       # Checkout the code
@@ -166,7 +166,7 @@ jobs:
           popd
   test-python:
     needs: [deploy-django]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       STATIC_URL: http://localhost:8888/
       DB_HOST: localhost
@@ -212,7 +212,7 @@ jobs:
   build-and-deploy-vue:
     environment:
       name: "dev"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: deploy-django
     steps:
       # Checkout the code
@@ -276,7 +276,7 @@ jobs:
   deploy-go:
     environment:
       name: "dev"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: deploy-django
     steps:
       # Checkout the code
@@ -326,7 +326,7 @@ jobs:
   notify:
     permissions:
       pull-requests: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [deploy-go, deploy-django]
     steps:
       - name: Find PR number
@@ -350,7 +350,7 @@ jobs:
   test-cypress:
     environment:
       name: "dev"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [deploy-go, deploy-django, build-and-deploy-vue]
     steps:
       # Checkout the code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres

--- a/.github/workflows/git-secrets.yaml
+++ b/.github/workflows/git-secrets.yaml
@@ -2,7 +2,7 @@ name: gitleaks
 on: [pull_request, push, workflow_dispatch]
 jobs:
   gitleaks-scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: Run gitlakes docker	    

--- a/.github/workflows/load-regulations.yml
+++ b/.github/workflows/load-regulations.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
     environment:
       name: ${{ matrix.environment }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/load-supp-content.yml
+++ b/.github/workflows/load-supp-content.yml
@@ -19,7 +19,7 @@ jobs:
   load:
     environment:
       name: ${{ github.event.inputs.env }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -14,7 +14,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   parser-checks:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pythonLint.yml
+++ b/.github/workflows/pythonLint.yml
@@ -13,7 +13,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -14,7 +14,7 @@ jobs:
   remove:
     environment:
       name: "dev"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # gettign PR is trivial here because the only tirgger is closing a PR
       - name: Echo PR#

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   remove:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ruff-action.yml
+++ b/.github/workflows/ruff-action.yml
@@ -2,7 +2,7 @@ name: Ruff
 on: [ push, pull_request, workflow_dispatch ]
 jobs:
   ruff:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: chartboost/ruff-action@v1

--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -15,7 +15,7 @@ jobs:
     environment:
       name: ${{ matrix.environment }}
     name: Run sync
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repo
         uses: actions/checkout@v3

--- a/.github/workflows/snyk-test.yml
+++ b/.github/workflows/snyk-test.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   snyk_run:
     name: Snyk Run (for PR)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'pull_request'
     
     steps:
@@ -29,7 +29,7 @@ jobs:
   
   snyk_nightly_run:  
       name: Snyk Nightly Run (for nightly cron with JIRA)
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       if: github.event_name == 'schedule'
       steps:
         - name: Check out repository


### PR DESCRIPTION
**Description**

In our Github Action config files, we use `jobs.<job_id>.runs-on` to define the type of machine on which to run the job.

More info: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on

We're currently specifying Ubuntu 20, which will be supported through 2025.  However, Ubuntu 22 is the latest LTS and should be supported through 2027.  If we can stay current and upgrade to Ubuntu 22 without any issues, we should.

**This pull request changes:**

- changes `runs-on` image label from `ubuntu-20.04` or `ubuntu-latest` to `ubuntu-22.04` in all `.github/workflows/*.yml` files

**Steps to manually verify this change:**

1. Green check marks

