### PR TITLE
EREGCSC-25595-auto-remove-s3-log-buckets

### DIFF
--- a/solution/backend/empty_bucket.py
+++ b/solution/backend/empty_bucket.py
@@ -2,9 +2,17 @@ import os
 
 import boto3
 
-
-def handler(event, context):
-    bucket_name = os.environ.get("AWS_STORAGE_BUCKET_NAME", None)
+def empty_bucket(bucket_name):
     s3 = boto3.resource('s3')
     bucket = s3.Bucket(bucket_name)
     bucket.objects.all().delete()
+
+
+def handler(event, context):
+    stage = os.environ.get("STAGE_ENV")
+
+    # empty storage bucket
+    empty_bucket(os.environ.get("AWS_STORAGE_BUCKET_NAME", None))
+
+    # empty the cloudfront logs bucket.
+    empty_bucket(f"eregs-{stage}-cloudfront-logs")

--- a/solution/backend/empty_bucket.py
+++ b/solution/backend/empty_bucket.py
@@ -11,9 +11,11 @@ def empty_bucket(bucket_name):
 
 def handler(event, context):
     stage = os.environ.get("STAGE_ENV")
+    storage_bucket_name = os.environ.get("AWS_STORAGE_BUCKET_NAME")
+    cloudfront_logs_bucket_name = f"eregs-{stage}-cloudfront-logs"
 
     # empty storage bucket
-    empty_bucket(os.environ.get("AWS_STORAGE_BUCKET_NAME", None))
+    empty_bucket(storage_bucket_name)
 
     # empty the cloudfront logs bucket.
-    empty_bucket(f"eregs-{stage}-cloudfront-logs")
+    empty_bucket(cloudfront_logs_bucket_name)

--- a/solution/backend/empty_bucket.py
+++ b/solution/backend/empty_bucket.py
@@ -2,6 +2,7 @@ import os
 
 import boto3
 
+
 def empty_bucket(bucket_name):
     s3 = boto3.resource('s3')
     bucket = s3.Bucket(bucket_name)

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -202,7 +202,17 @@ resources:
                    Resource:
                      - "${ssm:/eregulations/textextractor-arn}"
                      - "${self:custom.settings.text_extractor_arn}" # Extractor created by the environment
-
+                - Effect: Allow
+                  Action:
+                    - "s3:ListBucket"
+                    - "s3:ListBucketVersions"
+                    - "s3:ListObjectVersions"
+                    - "s3:GetBucketVersioning"
+                    - "s3:DeleteObject"
+                    - "s3:DeleteObjectVersion"
+                  Resource:
+                    - "arn:aws:s3:::eregs-${self:custom.stage}-cloudfront-logs"
+                    - "arn:aws:s3:::eregs-${self:custom.stage}-cloudfront-logs/*"
 
 plugins:
   - serverless-wsgi

--- a/solution/backend/serverless-experimental.yml
+++ b/solution/backend/serverless-experimental.yml
@@ -207,6 +207,7 @@ resources:
                     - "s3:ListBucket"
                     - "s3:ListBucketVersions"
                     - "s3:ListObjectVersions"
+                    - "s3:ListObjects"
                     - "s3:GetBucketVersioning"
                     - "s3:DeleteObject"
                     - "s3:DeleteObjectVersion"

--- a/solution/static-assets/serverless.yml
+++ b/solution/static-assets/serverless.yml
@@ -68,8 +68,6 @@ resources:
         OwnershipControls:
           Rules:
             - ObjectOwnership: BucketOwnerPreferred
-        VersioningConfiguration:
-          Status: Enabled
         AccessControl: LogDeliveryWrite
     CloudFrontLogsBucketPolicy:
       Type: "AWS::S3::BucketPolicy"


### PR DESCRIPTION
Resolves # EREGCSC-2595

Description-
This pull request updates the empty_buckets.py to delete the cloudfront logs bucket. The cloudfront logs bucket also has versioning switched on which was not necessary and causing issues deleting the bucket.

After the bucket is emptied, github actions will run serverless remove the bucket. Which will in turn delete the bucket.

This pull request changes...
solution/backend/empty_bucket.py
The script is modified to not only empty the file storage bucket but also to empty cloudfront logs bucket. 

solution/static-assets/serverless-experimental.yml
update permissions for emptying the logs bucket that it did not have permissions to. 

Steps to manually verify this change...

Go to aws s3 buckets and take note of [eregs-dev1248-cloudfront-logs](https://us-east-1.console.aws.amazon.com/s3/buckets/eregs-dev1248-cloudfront-logs?region=us-east-1)
close this PR
Visit aws s3 buckets and notice that eregs-dev1248-cloudfront-logs has been deleted.