### PR TITLE
EREGCSC-1765-A -- Tweaks and fixes based on prod validation

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_site_homepage.scss
+++ b/solution/ui/regulations/css/scss/partials/_site_homepage.scss
@@ -146,6 +146,8 @@
 
                 @media (max-width: $eds-xs-max) {
                     position: absolute;
+                    height: unset;
+                    width: unset;
                     top: unset;
                     right: unset;
                     left: 0;

--- a/solution/ui/regulations/package.json
+++ b/solution/ui/regulations/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@cmsgov/design-system": "^2.5.0",
-    "@fortawesome/fontawesome-free": "^5.15.3",
+    "@fortawesome/fontawesome-free": "^5.15.4",
     "@vitejs/plugin-vue": "^4.5.0",
     "@vue/test-utils": "^2.4.5",
     "flush-promises": "^1.0.2",


### PR DESCRIPTION
Resolves [EREGCSC-1765](https://jiraent.cms.gov/browse/EREGCSC-1765)

**Description**

A pull request to fix any issues found after Vue 3 upgrade has been merged into `main`.

**This pull request changes:**

- Adjusts position of homepage Menu button in mobile view (i.e. narrow widths) when ToC is closed

**Steps to manually verify this change...**

1. Green check marks
2. Manual validation/comparison of [experimental deployment](https://coimg2r73m.execute-api.us-east-1.amazonaws.com/dev1263) to `prod`

