### PR TITLE
[Tech Debt] Upgrade front end dependency versions to satisfy Dependabot/Snyk

### DIFF
--- a/solution/ui/regulations/eregs-component-lib/package-lock.json
+++ b/solution/ui/regulations/eregs-component-lib/package-lock.json
@@ -14,13 +14,13 @@
         "mitt": "^3.0.1",
         "shelljs": "^0.8.5",
         "vue": "^3.4.21",
-        "vuetify": "^3.5.11"
+        "vuetify": "^3.5.17"
       },
       "devDependencies": {
-        "@vitejs/plugin-vue": "^4.5.0",
+        "@vitejs/plugin-vue": "^4.6.2",
         "eslint-plugin-vuetify": "^2.2.0",
         "fast-glob": "^3.2.12",
-        "vite": "^5.2.9",
+        "vite": "^5.2.10",
         "vite-plugin-vuetify": "^2.0.3"
       },
       "optionalDependencies": {
@@ -2520,9 +2520,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.9.tgz",
-      "integrity": "sha512-uOQWfuZBlc6Y3W/DTuQ1Sr+oIXWvqljLvS881SVmAj00d5RdgShLcuXWxseWPd4HXwiYBFW/vXHfKFeqj9uQnw==",
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.10.tgz",
+      "integrity": "sha512-PAzgUZbP7msvQvqdSD+ErD5qGnSFiGOoWmV5yAKUEI0kdhjbH6nMWVyZQC/hSc4aXwc0oJ9aEdIiF9Oje0JFCw==",
       "devOptional": true,
       "dependencies": {
         "esbuild": "^0.20.1",
@@ -2638,9 +2638,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.14.tgz",
-      "integrity": "sha512-bmfid7K4D+wPi9h7sK4PxjmIB2tBzNuqlW14cs30iQ7GAphEeo/HYwn6aEdNK/Na+imhti8CJDDqdGs6SEfyXQ==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.17.tgz",
+      "integrity": "sha512-/Veklxxyu/l63q7QQOqJZeZukIKI2sBxY7FKMDcNup2KSGMjyjT+oYXy1DOdl7wlU3c3fKGQMFHqVWb0HDsyDw==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },

--- a/solution/ui/regulations/eregs-component-lib/package.json
+++ b/solution/ui/regulations/eregs-component-lib/package.json
@@ -17,13 +17,13 @@
     "mitt": "^3.0.1",
     "shelljs": "^0.8.5",
     "vue": "^3.4.21",
-    "vuetify": "^3.5.11"
+    "vuetify": "^3.5.17"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.5.0",
+    "@vitejs/plugin-vue": "^4.6.2",
     "eslint-plugin-vuetify": "^2.2.0",
     "fast-glob": "^3.2.12",
-    "vite": "^5.2.9",
+    "vite": "^5.2.10",
     "vite-plugin-vuetify": "^2.0.3"
   },
   "optionalDependencies": {

--- a/solution/ui/regulations/eregs-vite/package-lock.json
+++ b/solution/ui/regulations/eregs-vite/package-lock.json
@@ -13,13 +13,13 @@
         "vue": "^3.4.21",
         "vue-router": "^4.3.0",
         "vue-template-compiler": "^2.7.16",
-        "vuetify": "^3.5.11"
+        "vuetify": "^3.5.17"
       },
       "devDependencies": {
-        "@vitejs/plugin-vue": "^4.5.0",
+        "@vitejs/plugin-vue": "^4.6.2",
         "eslint-plugin-vuetify": "^2.2.0",
         "sass": "^1.69.3",
-        "vite": "^5.2.9",
+        "vite": "^5.2.10",
         "vite-plugin-vuetify": "^2.0.3"
       },
       "optionalDependencies": {
@@ -784,9 +784,9 @@
       "peer": true
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.0.tgz",
-      "integrity": "sha512-a2WSpP8X8HTEww/U00bU4mX1QpLINNuz/2KMNpLsdu3BzOpak3AGI1CJYBTXcc4SPhaD0eNRUp7IyQK405L5dQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.6.2.tgz",
+      "integrity": "sha512-kqf7SGFoG+80aZG6Pf+gsZIVvGSCKE98JbiWqcCV9cThtg91Jav0yvYFC9Zb+jKetNGF6ZKeoaxgZfND21fWKw==",
       "dev": true,
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -2465,9 +2465,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.9.tgz",
-      "integrity": "sha512-uOQWfuZBlc6Y3W/DTuQ1Sr+oIXWvqljLvS881SVmAj00d5RdgShLcuXWxseWPd4HXwiYBFW/vXHfKFeqj9uQnw==",
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.10.tgz",
+      "integrity": "sha512-PAzgUZbP7msvQvqdSD+ErD5qGnSFiGOoWmV5yAKUEI0kdhjbH6nMWVyZQC/hSc4aXwc0oJ9aEdIiF9Oje0JFCw==",
       "devOptional": true,
       "dependencies": {
         "esbuild": "^0.20.1",
@@ -2606,9 +2606,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.11.tgz",
-      "integrity": "sha512-us5I0jyFwIQYG4v41PFmVMkoc/oJddVT4C2RFjJTI99ttigbQ92gsTeG5SB8BPfmfnUS4paR5BedZwk6W3KlJw==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.17.tgz",
+      "integrity": "sha512-/Veklxxyu/l63q7QQOqJZeZukIKI2sBxY7FKMDcNup2KSGMjyjT+oYXy1DOdl7wlU3c3fKGQMFHqVWb0HDsyDw==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },
@@ -2618,10 +2618,10 @@
       },
       "peerDependencies": {
         "typescript": ">=4.7",
-        "vite-plugin-vuetify": ">=2.0.3",
+        "vite-plugin-vuetify": ">=1.0.0",
         "vue": "^3.3.0",
         "vue-i18n": "^9.0.0",
-        "webpack-plugin-vuetify": ">=2.0.0-alpha.11"
+        "webpack-plugin-vuetify": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/solution/ui/regulations/eregs-vite/package.json
+++ b/solution/ui/regulations/eregs-vite/package.json
@@ -15,13 +15,13 @@
     "vue": "^3.4.21",
     "vue-router": "^4.3.0",
     "vue-template-compiler": "^2.7.16",
-    "vuetify": "^3.5.11"
+    "vuetify": "^3.5.17"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.5.0",
+    "@vitejs/plugin-vue": "^4.6.2",
     "eslint-plugin-vuetify": "^2.2.0",
     "sass": "^1.69.3",
-    "vite": "^5.2.9",
+    "vite": "^5.2.10",
     "vite-plugin-vuetify": "^2.0.3"
   },
   "optionalDependencies": {

--- a/solution/ui/regulations/package-lock.json
+++ b/solution/ui/regulations/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@cmsgov/design-system": "^2.5.0",
         "@fortawesome/fontawesome-free": "^5.15.4",
-        "@vitejs/plugin-vue": "^4.5.0",
+        "@vitejs/plugin-vue": "^4.6.2",
         "@vue/test-utils": "^2.4.5",
         "flush-promises": "^1.0.2",
         "localforage": "^1.10.0",
@@ -19,7 +19,7 @@
         "sass": "^1.72.0",
         "vue": "^3.4.21",
         "vue-loader": "^16.0.0",
-        "vuetify": "^3.5.11"
+        "vuetify": "^3.5.17"
       },
       "devDependencies": {
         "@babel/core": "^7.13.16",
@@ -48,7 +48,7 @@
         "prettier": "2.2.1",
         "sass-loader": "^13.0.2",
         "storybook-addon-sass-postcss": "^0.1.3",
-        "vite": "^5.2.9",
+        "vite": "^5.2.10",
         "vitest": "^0.31.0",
         "webpack": "^5.76.0",
         "whatwg-fetch": "^3.6.2"
@@ -8778,9 +8778,9 @@
       }
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.5.0.tgz",
-      "integrity": "sha512-a2WSpP8X8HTEww/U00bU4mX1QpLINNuz/2KMNpLsdu3BzOpak3AGI1CJYBTXcc4SPhaD0eNRUp7IyQK405L5dQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.6.2.tgz",
+      "integrity": "sha512-kqf7SGFoG+80aZG6Pf+gsZIVvGSCKE98JbiWqcCV9cThtg91Jav0yvYFC9Zb+jKetNGF6ZKeoaxgZfND21fWKw==",
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
@@ -25645,9 +25645,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.2.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.9.tgz",
-      "integrity": "sha512-uOQWfuZBlc6Y3W/DTuQ1Sr+oIXWvqljLvS881SVmAj00d5RdgShLcuXWxseWPd4HXwiYBFW/vXHfKFeqj9uQnw==",
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.10.tgz",
+      "integrity": "sha512-PAzgUZbP7msvQvqdSD+ErD5qGnSFiGOoWmV5yAKUEI0kdhjbH6nMWVyZQC/hSc4aXwc0oJ9aEdIiF9Oje0JFCw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.20.1",
@@ -27082,9 +27082,9 @@
       "dev": true
     },
     "node_modules/vuetify": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.11.tgz",
-      "integrity": "sha512-us5I0jyFwIQYG4v41PFmVMkoc/oJddVT4C2RFjJTI99ttigbQ92gsTeG5SB8BPfmfnUS4paR5BedZwk6W3KlJw==",
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.17.tgz",
+      "integrity": "sha512-/Veklxxyu/l63q7QQOqJZeZukIKI2sBxY7FKMDcNup2KSGMjyjT+oYXy1DOdl7wlU3c3fKGQMFHqVWb0HDsyDw==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },
@@ -27094,10 +27094,10 @@
       },
       "peerDependencies": {
         "typescript": ">=4.7",
-        "vite-plugin-vuetify": ">=2.0.3",
+        "vite-plugin-vuetify": ">=1.0.0",
         "vue": "^3.3.0",
         "vue-i18n": "^9.0.0",
-        "webpack-plugin-vuetify": ">=2.0.0-alpha.11"
+        "webpack-plugin-vuetify": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/solution/ui/regulations/package.json
+++ b/solution/ui/regulations/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@cmsgov/design-system": "^2.5.0",
     "@fortawesome/fontawesome-free": "^5.15.4",
-    "@vitejs/plugin-vue": "^4.5.0",
+    "@vitejs/plugin-vue": "^4.6.2",
     "@vue/test-utils": "^2.4.5",
     "flush-promises": "^1.0.2",
     "localforage": "^1.10.0",
@@ -29,7 +29,7 @@
     "sass": "^1.72.0",
     "vue": "^3.4.21",
     "vue-loader": "^16.0.0",
-    "vuetify": "^3.5.11"
+    "vuetify": "^3.5.17"
   },
   "devDependencies": {
     "@babel/core": "^7.13.16",
@@ -58,7 +58,7 @@
     "prettier": "2.2.1",
     "sass-loader": "^13.0.2",
     "storybook-addon-sass-postcss": "^0.1.3",
-    "vite": "^5.2.9",
+    "vite": "^5.2.10",
     "vitest": "^0.31.0",
     "webpack": "^5.76.0",
     "whatwg-fetch": "^3.6.2"


### PR DESCRIPTION
Resolves PRs [1270](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1270), [1271](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1271), and [1273](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1273)

**Description**

Bumps versions of Vite, Vue, and Vuetify dependencies

**This pull request changes:**

- Upgrades Vuetify to 3.5.17
- Upgrades Vite to 4.2.10
- Upgrades `vitejs/plugin-vue` to 4.6.2

**Steps to manually verify this change:**

1. Green check marks
2. Experimental deployment looks and acts as expected
