### PR TITLE
EREGCSC-2636 -- Remove "Uploaded By" label on Uploaded Documents

### DIFF
--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentObject.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentObject.vue
@@ -10,14 +10,14 @@
                 v-if="date"
                 class="supplemental-content-date"
                 :class="{
-                    'supplemental-content-mid-bar': !isBlank(name) || division,
+                    'supplemental-content-mid-bar': !isBlank(name),
                 }"
                 >{{ formatDate(date) }}</span
             >
-            <DivisionLabel
+            <!-- DivisionLabel
                 v-if="docType === 'internal' && division"
                 :division="division"
-            />
+            /-->
             <span
                 v-if="!isBlank(name)"
                 class="supplemental-content-title"

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -216,10 +216,10 @@ const resultLinkClasses = (doc) => ({
                     :class="needsBar(doc) && 'result__context--date--bar'"
                     >{{ formatDate(doc.date_string) }}</span
                 >
-                <DivisionLabel
+                <!-- DivisionLabel
                     v-if="doc.resource_type === 'internal' && doc.division"
                     :division="doc.division"
-                />
+                /-->
                 <span
                     v-if="
                         doc.resource_type === 'external' && doc.doc_name_string

--- a/solution/ui/regulations/test/unit-test/__snapshots__/SupplementalContent.test.js.snap
+++ b/solution/ui/regulations/test/unit-test/__snapshots__/SupplementalContent.test.js.snap
@@ -72,7 +72,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                       target="_blank"
                     >
                       <!--v-if-->
-                      <!--v-if-->
+                      <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                       <span
                         class="supplemental-content-title"
                       >
@@ -97,7 +100,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                       target="_blank"
                     >
                       <!--v-if-->
-                      <!--v-if-->
+                      <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                       <span
                         class="supplemental-content-title"
                       >
@@ -122,7 +128,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                       target="_blank"
                     >
                       <!--v-if-->
-                      <!--v-if-->
+                      <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                       <span
                         class="supplemental-content-title"
                       >
@@ -147,7 +156,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                       target="_blank"
                     >
                       <!--v-if-->
-                      <!--v-if-->
+                      <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                       <span
                         class="supplemental-content-title"
                       >
@@ -2807,7 +2819,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               December 27, 2022
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -2836,7 +2851,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               August 1, 2022
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -2865,7 +2883,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               December 30, 2016
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -2894,7 +2915,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               July 20, 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -2919,7 +2943,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               December 15, 2014
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -2974,7 +3001,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 April 16, 2014
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3003,7 +3033,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 February 21, 2014
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3032,7 +3065,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 February 1, 2013
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3061,7 +3097,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 January 23, 2012
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -3086,7 +3125,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 September 23, 2011
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3115,7 +3157,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 June 10, 2011
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3144,7 +3189,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 December 30, 2010
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3173,7 +3221,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 November 16, 2010
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3202,7 +3253,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 August 19, 2009
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3231,7 +3285,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 June 17, 2009
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3260,7 +3317,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 July 27, 2006
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3289,7 +3349,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 June 9, 2006
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3318,7 +3381,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 June 13, 2003
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3347,7 +3413,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 November 21, 2002
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -3376,7 +3445,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 July 6, 2000
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -3401,7 +3473,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 January 20, 1998
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -3426,7 +3501,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 May 14, 1997
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -3451,7 +3529,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 December 20, 1994
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -3537,7 +3618,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               January 27, 2023
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -3566,7 +3650,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               August 30, 2021
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -3595,7 +3682,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 26, 2016
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -3624,7 +3714,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               October 28, 2008
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -3703,7 +3796,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               June 3, 2021
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -3728,7 +3824,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               May 28, 2021
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -3753,7 +3852,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 27, 2019
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -3778,7 +3880,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               May 7, 2019
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -3803,7 +3908,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               June 1, 2018
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -3854,7 +3962,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 November 28, 2016
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -3879,7 +3990,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 April 1, 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -3904,7 +4018,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 July 24, 2014
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -3929,7 +4046,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 December 27, 2013
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -3954,7 +4074,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 June 18, 2013
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -3979,7 +4102,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 March 29, 2013
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4004,7 +4130,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 November 18, 2011
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4029,7 +4158,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 September 28, 2011
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4054,7 +4186,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 September 20, 2011
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4079,7 +4214,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 August 31, 2011
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4104,7 +4242,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 June 17, 2011
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4129,7 +4270,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 September 10, 2010
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4154,7 +4298,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 July 9, 2010
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4240,7 +4387,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               October 17, 2022
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4265,7 +4415,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               January 6, 2021
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4290,7 +4443,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               October 5, 2018
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4315,7 +4471,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               January 18, 2017
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4340,7 +4499,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 10, 2016
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4391,7 +4553,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 July 8, 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4416,7 +4581,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 January 2014
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4441,7 +4609,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 December 2013
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4466,7 +4637,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 April 25, 2013
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4491,7 +4665,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 February 2013
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4560,7 +4737,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               September 3, 1992
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4631,7 +4811,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             target="_blank"
                           >
                             <!--v-if-->
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -4750,7 +4933,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               December 16, 2022
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4775,7 +4961,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 3, 2021
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4800,7 +4989,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               August 30, 2021
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4825,7 +5017,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               January 22, 2020
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4850,7 +5045,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               2020
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -4901,7 +5099,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 August 17, 2017
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4926,7 +5127,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 February 2017
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4951,7 +5155,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 February 2017
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -4976,7 +5183,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 February 2017
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5001,7 +5211,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 February 2017
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5026,7 +5239,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 February 2017
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5051,7 +5267,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 June 1, 2016
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -5080,7 +5299,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 May 26, 2016
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -5109,7 +5331,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 April 25, 2016
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5134,7 +5359,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 February 2016
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5159,7 +5387,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 December 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5184,7 +5415,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 August 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5209,7 +5443,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 June 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5234,7 +5471,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 May 20, 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -5263,7 +5503,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 May 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -5292,7 +5535,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 March 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5317,7 +5563,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 March 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5342,7 +5591,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 March 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5367,7 +5619,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 February 19, 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5392,7 +5647,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 January 2015
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5417,7 +5675,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 July 2014
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5442,7 +5703,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 September 22, 2008
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5467,7 +5731,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 May 10, 2004
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -5496,7 +5763,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 May 2003
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5521,7 +5791,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 April 8, 1997
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -5550,7 +5823,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               >
                                 December 19, 1996
                               </span>
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5571,7 +5847,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               target="_blank"
                             >
                               <!--v-if-->
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -5596,7 +5875,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               target="_blank"
                             >
                               <!--v-if-->
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <span
                                 class="supplemental-content-title"
                               >
@@ -5621,7 +5903,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               target="_blank"
                             >
                               <!--v-if-->
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5642,7 +5927,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               target="_blank"
                             >
                               <!--v-if-->
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5663,7 +5951,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               target="_blank"
                             >
                               <!--v-if-->
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5684,7 +5975,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                               target="_blank"
                             >
                               <!--v-if-->
-                              <!--v-if-->
+                              <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                               <!--v-if-->
                               <div
                                 class="supplemental-content-description supplemental-content-external-link"
@@ -5770,7 +6064,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               May 6, 2022
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -5795,7 +6092,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               January 20, 2022
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -5820,7 +6120,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 2020
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -5895,7 +6198,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 12, 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -5920,7 +6226,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 12, 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -5945,7 +6254,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 2013
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -5970,7 +6282,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               October 1, 2011
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -6085,7 +6400,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               July 31, 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -6160,7 +6478,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               2021
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -6275,7 +6596,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 10, 2011
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -6411,7 +6735,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                     target="_blank"
                   >
                     <!--v-if-->
-                    <!--v-if-->
+                    <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                     <span
                       class="supplemental-content-title"
                     >
@@ -6436,7 +6763,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                     target="_blank"
                   >
                     <!--v-if-->
-                    <!--v-if-->
+                    <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                     <span
                       class="supplemental-content-title"
                     >
@@ -6461,7 +6791,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                     target="_blank"
                   >
                     <!--v-if-->
-                    <!--v-if-->
+                    <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                     <span
                       class="supplemental-content-title"
                     >
@@ -6486,7 +6819,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                     target="_blank"
                   >
                     <!--v-if-->
-                    <!--v-if-->
+                    <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                     <span
                       class="supplemental-content-title"
                     >
@@ -9146,7 +9482,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             December 27, 2022
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <span
                             class="supplemental-content-title"
                           >
@@ -9175,7 +9514,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             August 1, 2022
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <span
                             class="supplemental-content-title"
                           >
@@ -9204,7 +9546,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             December 30, 2016
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <span
                             class="supplemental-content-title"
                           >
@@ -9233,7 +9578,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             July 20, 2015
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -9258,7 +9606,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             December 15, 2014
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <span
                             class="supplemental-content-title"
                           >
@@ -9313,7 +9664,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               April 16, 2014
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9342,7 +9696,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 21, 2014
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9371,7 +9728,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 1, 2013
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9400,7 +9760,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               January 23, 2012
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -9425,7 +9788,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               September 23, 2011
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9454,7 +9820,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               June 10, 2011
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9483,7 +9852,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               December 30, 2010
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9512,7 +9884,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 16, 2010
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9541,7 +9916,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               August 19, 2009
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9570,7 +9948,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               June 17, 2009
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9599,7 +9980,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               July 27, 2006
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9628,7 +10012,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               June 9, 2006
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9657,7 +10044,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               June 13, 2003
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9686,7 +10076,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 21, 2002
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -9715,7 +10108,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               July 6, 2000
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -9740,7 +10136,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               January 20, 1998
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -9765,7 +10164,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               May 14, 1997
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -9790,7 +10192,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               December 20, 1994
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -9876,7 +10281,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             January 27, 2023
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <span
                             class="supplemental-content-title"
                           >
@@ -9905,7 +10313,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             August 30, 2021
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <span
                             class="supplemental-content-title"
                           >
@@ -9934,7 +10345,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             February 26, 2016
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <span
                             class="supplemental-content-title"
                           >
@@ -9963,7 +10377,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             October 28, 2008
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <span
                             class="supplemental-content-title"
                           >
@@ -10042,7 +10459,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             June 3, 2021
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10067,7 +10487,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             May 28, 2021
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10092,7 +10515,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             November 27, 2019
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10117,7 +10543,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             May 7, 2019
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10142,7 +10571,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             June 1, 2018
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10193,7 +10625,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 28, 2016
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10218,7 +10653,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               April 1, 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10243,7 +10681,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               July 24, 2014
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10268,7 +10709,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               December 27, 2013
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10293,7 +10737,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               June 18, 2013
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10318,7 +10765,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               March 29, 2013
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10343,7 +10793,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               November 18, 2011
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10368,7 +10821,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               September 28, 2011
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10393,7 +10849,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               September 20, 2011
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10418,7 +10877,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               August 31, 2011
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10443,7 +10905,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               June 17, 2011
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10468,7 +10933,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               September 10, 2010
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10493,7 +10961,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               July 9, 2010
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10579,7 +11050,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             October 17, 2022
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10604,7 +11078,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             January 6, 2021
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10629,7 +11106,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             October 5, 2018
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10654,7 +11134,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             January 18, 2017
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10679,7 +11162,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             November 10, 2016
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10730,7 +11216,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               July 8, 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10755,7 +11244,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               January 2014
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10780,7 +11272,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               December 2013
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10805,7 +11300,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               April 25, 2013
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10830,7 +11328,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 2013
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -10899,7 +11400,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             September 3, 1992
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -10970,7 +11474,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           target="_blank"
                         >
                           <!--v-if-->
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <span
                             class="supplemental-content-title"
                           >
@@ -11089,7 +11596,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             December 16, 2022
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -11114,7 +11624,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             November 3, 2021
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -11139,7 +11652,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             August 30, 2021
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -11164,7 +11680,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             January 22, 2020
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -11189,7 +11708,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             2020
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -11240,7 +11762,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               August 17, 2017
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11265,7 +11790,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 2017
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11290,7 +11818,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 2017
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11315,7 +11846,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 2017
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11340,7 +11874,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 2017
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11365,7 +11902,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 2017
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11390,7 +11930,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               June 1, 2016
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -11419,7 +11962,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               May 26, 2016
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -11448,7 +11994,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               April 25, 2016
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11473,7 +12022,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 2016
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11498,7 +12050,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               December 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11523,7 +12078,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               August 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11548,7 +12106,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               June 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11573,7 +12134,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               May 20, 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -11602,7 +12166,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               May 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -11631,7 +12198,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               March 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11656,7 +12226,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               March 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11681,7 +12254,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               March 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11706,7 +12282,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               February 19, 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11731,7 +12310,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               January 2015
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11756,7 +12338,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               July 2014
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11781,7 +12366,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               September 22, 2008
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11806,7 +12394,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               May 10, 2004
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -11835,7 +12426,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               May 2003
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11860,7 +12454,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               April 8, 1997
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -11889,7 +12486,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             >
                               December 19, 1996
                             </span>
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11910,7 +12510,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             target="_blank"
                           >
                             <!--v-if-->
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -11935,7 +12538,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             target="_blank"
                           >
                             <!--v-if-->
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <span
                               class="supplemental-content-title"
                             >
@@ -11960,7 +12566,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             target="_blank"
                           >
                             <!--v-if-->
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -11981,7 +12590,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             target="_blank"
                           >
                             <!--v-if-->
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -12002,7 +12614,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             target="_blank"
                           >
                             <!--v-if-->
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -12023,7 +12638,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                             target="_blank"
                           >
                             <!--v-if-->
-                            <!--v-if-->
+                            <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                             <!--v-if-->
                             <div
                               class="supplemental-content-description supplemental-content-external-link"
@@ -12109,7 +12727,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             May 6, 2022
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -12134,7 +12755,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             January 20, 2022
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -12159,7 +12783,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             November 2020
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -12234,7 +12861,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             November 12, 2015
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -12259,7 +12889,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             November 12, 2015
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -12284,7 +12917,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             February 2013
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -12309,7 +12945,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             October 1, 2011
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -12424,7 +13063,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             July 31, 2015
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -12499,7 +13141,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             2021
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <!--v-if-->
                           <div
                             class="supplemental-content-description supplemental-content-external-link"
@@ -12614,7 +13259,10 @@ exports[`Supplemental Content > Checks to see if the snap shot matches 1`] = `
                           >
                             November 10, 2011
                           </span>
-                          <!--v-if-->
+                          <!-- DivisionLabel
+                v-if="docType === 'internal' && division"
+                :division="division"
+            /-->
                           <span
                             class="supplemental-content-title"
                           >


### PR DESCRIPTION
Resolves [EREGCSC-2636](https://jiraent.cms.gov/browse/EREGCSC-2636)

**Description**

On internal files, we display an "uploaded by xyz" message. This will soon be refactored to display information about visibility that will be styled and displayed in the same way, so for now we are simply commenting out this component where it is used, and a future story will refactor it to display "Visible to xyz" information instead.

It will also be informative if we remove this message and people miss it.

**This pull request changes:**

- Comments out `<DivisionLabel />` using HTML comment syntax: `<!-- DivisionLabel / -->`
- Updates snapshot to reflect this change 

**Steps to manually verify this change:**

1. Green check marks
2. Visit experimental deployment
3. Visit the admin panel and view Uploaded Documents.  You should see at least one doc.  Verify that the doc includes a Division and a Group.
4. Visit Subject page, filter by internal documents, and view existing document
5. Ensure that this document does not have an "Uploaded by xyz" label, even though the document has an attached Division and Group
6. Visit the Related Regulation Citation
7. Ensure that the uploaded document does not have an "Uploaded by xyz" label when viewed in the right sidebar

