### PR TITLE
EREGCSC-2602 If SearchHeadline can't generate a highlighted headline, show nothing

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -13,6 +13,67 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  deploy-static:
+    environment:
+      name: "dev"
+      url: ${{ steps.deploy-regulations-site-server.outputs.url }}
+    runs-on: ubuntu-22.04
+    steps:
+      # Checkout the code
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      # Find the PR number.  This is not always trivial which is why this uses an existign action
+      - name: Find PR number
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        with:
+          # Can be "open", "closed", or "all".  Defaults to "open".
+          state: open
+      # should build first and save the artifact
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.14
+      # setup python
+      - uses: actions/setup-python@v4
+        if: success() && steps.findPr.outputs.number
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./solution/static-assets/requirements.txt
+      # build the static assets for the website
+      - name: build static assets
+        if: success() && steps.findPr.outputs.number
+        env:
+          STATIC_URL: http://localhost:8888/
+          STATIC_ROOT: ../static-assets/regulations
+          VITE_ENV: dev${{ steps.findPr.outputs.pr }}
+        run: |
+          pushd solution/backend
+          python manage.py collectstatic --noinput
+          cd ..
+          popd
+      # Configure AWS credentials for GitHub Actions
+      - name: Configure AWS credentials for GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+      # deploy static assets to AWS
+      - name: deploy static assets
+        if: success() && steps.findPr.outputs.number
+        env:
+          PR: ${{ steps.findPr.outputs.pr }}
+        run: |
+          pushd solution/static-assets
+          npm install serverless -g
+          npm install
+          serverless deploy --stage dev${PR}
+          popd
   deploy-text-extractor:
     environment:
       name: "dev"
@@ -54,7 +115,7 @@ jobs:
     outputs:
       url: ${{ steps.deploy-regulations-site-server.outputs.url }}
     runs-on: ubuntu-22.04
-    needs: deploy-text-extractor
+    needs: [deploy-static, deploy-text-extractor]
     steps:
       # Checkout the code
       - name: Checkout
@@ -148,7 +209,7 @@ jobs:
         working-directory: ./solution/backend
         run: |
           DJANGO_SETTINGS_MODULE="cmcs_regulations.settings.test_settings" pytest -vv
-  build-and-deploy-static-assets:
+  build-and-deploy-vue:
     environment:
       name: "dev"
     runs-on: ubuntu-22.04
@@ -177,22 +238,6 @@ jobs:
         if: success() && steps.findPr.outputs.number
         with:
           python-version: "3.12"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r ./solution/static-assets/requirements.txt
-      # build the static assets for the website
-      - name: Run collectstatic
-        if: success() && steps.findPr.outputs.number
-        env:
-          STATIC_URL: http://localhost:8888/
-          STATIC_ROOT: ../static-assets/regulations
-          VITE_ENV: dev${{ steps.findPr.outputs.pr }}
-        run: |
-          pushd solution/backend
-          python manage.py collectstatic --noinput
-          cd ..
-          popd
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:
@@ -200,7 +245,7 @@ jobs:
           directory: solution/ui/regulations/eregs-vite
           file_name: .env
       # build the static assets for the website
-      - name: Build static assets
+      - name: build static assets
         if: success() && steps.findPr.outputs.number
         env:
           STATIC_URL: http://localhost:8888/
@@ -217,7 +262,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1
       # deploy static assets to AWS
-      - name: Deploy static assets
+      - name: deploy static assets
         if: success() && steps.findPr.outputs.number
         env:
           PR: ${{ steps.findPr.outputs.pr }}
@@ -306,7 +351,7 @@ jobs:
     environment:
       name: "dev"
     runs-on: ubuntu-22.04
-    needs: [deploy-go, deploy-django, build-and-deploy-static-assets]
+    needs: [deploy-go, deploy-django, build-and-deploy-vue]
     steps:
       # Checkout the code
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,13 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1
+      - name: deploy static assets
+        run: |
+          pushd solution/static-assets
+          npm install serverless -g
+          npm install
+          serverless deploy --stage ${{ matrix.environment }}
+          popd
       - name: deploy text extractor lambda
         run: |
           pushd solution/text-extractor
@@ -109,8 +116,6 @@ jobs:
           make regulations
           popd
           pushd solution/static-assets
-          npm install serverless -g
-          npm install
           serverless deploy --stage ${{ matrix.environment }}
           popd
       - uses: actions/setup-go@v2

--- a/solution/backend/cmcs_regulations/settings/local.py
+++ b/solution/backend/cmcs_regulations/settings/local.py
@@ -20,7 +20,7 @@ DATABASES = {
     },
     'postgres': {
         'ENGINE': 'django.db.backends.postgresql',
-        'USER': os.environ.get('DB_USER', 'eregs'),
+        'USER': os.environ.get('DB_USER', 'eregsuser'),
         'PASSWORD': os.environ.get('DB_PASSWORD', 'sgere'),
         'HOST': os.environ.get('DB_HOST', 'db'),
         'PORT': os.environ.get('DB_PORT', '5432'),

--- a/solution/backend/cmcs_regulations/settings/test_settings.py
+++ b/solution/backend/cmcs_regulations/settings/test_settings.py
@@ -36,7 +36,7 @@ LOGOUT_REDIRECT_URL = '/logout'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'USER': os.environ.get('DB_USER', 'eregs'),
+        'USER': os.environ.get('DB_USER', 'eregsuser'),
         'PASSWORD': os.environ.get('DB_PASSWORD', 'sgere'),
         'HOST': os.environ.get('DB_HOST', 'db'),
         'PORT': os.environ.get('DB_PORT', '5432'),

--- a/solution/backend/common/fields.py
+++ b/solution/backend/common/fields.py
@@ -186,7 +186,15 @@ class HeadlineField(serializers.Field):
         self.model_name = model_name
         kwargs["source"] = '*'
         kwargs["read_only"] = True
+        if "blank_when_no_highlight" in kwargs:
+            self.blank_when_no_highlight = kwargs["blank_when_no_highlight"]
+            del kwargs["blank_when_no_highlight"]
+        else:
+            self.blank_when_no_highlight = False
         super().__init__(**kwargs)
 
     def to_representation(self, obj):
-        return getattr(obj, f"{self.model_name}_{self.field_name}", getattr(obj, self.field_name, None))
+        text = getattr(obj, f"{self.model_name}_{self.field_name}", getattr(obj, self.field_name, None))
+        if text and "<span class='search-highlight'>" not in text and self.blank_when_no_highlight:
+            return None
+        return text

--- a/solution/backend/common/tests/test_fields.py
+++ b/solution/backend/common/tests/test_fields.py
@@ -50,8 +50,10 @@ class VariableDateFieldTest(unittest.TestCase):
 class HeadlineFieldTest(unittest.TestCase):
     def test_with_highlight(self):
         value = "hello <span class='search-highlight'>world</span>"
+
         def fake_obj():
             return None
+
         fake_obj.test_field = value
 
         field = HeadlineField()
@@ -64,8 +66,10 @@ class HeadlineFieldTest(unittest.TestCase):
 
     def test_without_highlight(self):
         value = "hello world"
+
         def fake_obj():
             return None
+
         fake_obj.test_field = value
 
         field = HeadlineField()

--- a/solution/backend/common/tests/test_fields.py
+++ b/solution/backend/common/tests/test_fields.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 from django.core.exceptions import ValidationError
 
-from common.fields import VariableDateField
+from common.fields import HeadlineField, VariableDateField
 from file_manager.models import Subject
 
 
@@ -45,6 +45,36 @@ class VariableDateFieldTest(unittest.TestCase):
                 value["error_message"],
                 str(context.exception),
             )
+
+
+class HeadlineFieldTest(unittest.TestCase):
+    def test_with_highlight(self):
+        value = "hello <span class='search-highlight'>world</span>"
+        def fake_obj():
+            return None
+        fake_obj.test_field = value
+
+        field = HeadlineField()
+        field.field_name = "test_field"
+        self.assertEqual(field.to_representation(fake_obj), value)
+
+        field = HeadlineField(blank_when_no_highlight=True)
+        field.field_name = "test_field"
+        self.assertEqual(field.to_representation(fake_obj), value)
+
+    def test_without_highlight(self):
+        value = "hello world"
+        def fake_obj():
+            return None
+        fake_obj.test_field = value
+
+        field = HeadlineField()
+        field.field_name = "test_field"
+        self.assertEqual(field.to_representation(fake_obj), value)
+
+        field = HeadlineField(blank_when_no_highlight=True)
+        field.field_name = "test_field"
+        self.assertEqual(field.to_representation(fake_obj), None)
 
 
 def clean_up():

--- a/solution/backend/content_search/models.py
+++ b/solution/backend/content_search/models.py
@@ -45,7 +45,7 @@ class ContentIndexQuerySet(models.QuerySet):
             summary_headline=SearchHeadline(
                 "summary_string",
                 query_object,
-                start_sel='<span class="search-highlight">',
+                start_sel="<span class='search-highlight'>",
                 stop_sel='</span>',
                 min_words=self.min_words,
                 max_words=self.max_words,

--- a/solution/backend/content_search/serializers.py
+++ b/solution/backend/content_search/serializers.py
@@ -25,7 +25,7 @@ class ContentListSerializer(DetailsSerializer, serializers.Serializer, ):
 class ContentSearchSerializer(ContentListSerializer, ):
     document_name_headline = HeadlineField()
     summary_headline = HeadlineField()
-    content_headline = HeadlineField()
+    content_headline = HeadlineField(blank_when_no_highlight=True)
 
 
 class ContentUpdateSerializer(serializers.Serializer):

--- a/solution/backend/content_search/tests/test_search.py
+++ b/solution/backend/content_search/tests/test_search.py
@@ -195,6 +195,6 @@ class SearchTest(TestCase):
                    "n class='search-highlight'>act</span>"
         self.assertEqual(expected, data["results"][0]["document_name_headline"])
 
-        expected = 'this is an <span class="search-highlight">affordable</span> <span class="search-highlight">care</span> <span'\
-                   ' class="search-highlight">act</span> document'
+        expected = "this is an <span class='search-highlight'>affordable</span> <span class='search-highlight'>care</span> <span"\
+                   " class='search-highlight'>act</span> document"
         self.assertEqual(expected, data["results"][0]["summary_headline"])

--- a/solution/backend/content_search/tests/test_search.py
+++ b/solution/backend/content_search/tests/test_search.py
@@ -205,5 +205,4 @@ class SearchTest(TestCase):
         self.login()
         response = self.client.get("/v3/content-search/?q=reference")
         data = get_paginated_data(response)
-        data = data["results"][0]
         self.assertEqual(data["results"][0]["content_headline"], None)

--- a/solution/backend/content_search/tests/test_search.py
+++ b/solution/backend/content_search/tests/test_search.py
@@ -198,3 +198,12 @@ class SearchTest(TestCase):
         expected = "this is an <span class='search-highlight'>affordable</span> <span class='search-highlight'>care</span> <span"\
                    " class='search-highlight'>act</span> document"
         self.assertEqual(expected, data["results"][0]["summary_headline"])
+
+    # Search for "reference" returns a file that does not have the word "reference" in its content field
+    # So the content_headline field should be blank instead of the text of the content field.
+    def test_no_highlight_blanking(self):
+        self.login()
+        response = self.client.get("/v3/content-search/?q=reference")
+        data = get_paginated_data(response)
+        data = data["results"][0]
+        self.assertEqual(data["results"][0]["content_headline"], None)


### PR DESCRIPTION
Resolves #2602

**Description-**

By default, `SearchHeadline` will return the beginning of the text of the field of interest if the search term is not contained within that field. Although this can be useful behavior, in our case we want to display nothing instead. This PR solves that by adding a boolean option to the `HeadlineField` field we created, `blank_when_no_highlight`. When set to `True` the field will check for the existence of the `<span>` in the headline results, and if it doesn't exist, it will set the resulting field to `None`.

**This pull request changes...**

- Added option `blank_when_no_highlight` to `HeadlineField`.
- `blank_when_no_highlight` is set to `True` for the `content_headline` field.
- Added a test for both conditions (when `blank_when_no_highlight` is true and false, 4 tests total).
- Fixed a local issue where we had multiple usernames for the database: `eregs` in some places and `eregsuser` in others. It is now `eregsuser` everywhere.
- Reverted changes to Github Actions deploy yml files. Turns out we were deploying static assets twice for a reason: a circular dependency between reg site and static assets. Vite needs to know Django's URL to build, and Django needs to know the static assets URL. So we were building static assets sans vite first, then deploying it to have a valid URL, then deploying Django, then building vite and deploying static assets again.

**Steps to manually verify this change...**

In the experimental deploy, I have created a sample uploaded file with the name "This is a test file", summary "Test file", and content of the text file is "Hello world".

1. Go to https://unkbr9td91.execute-api.us-east-1.amazonaws.com/dev1278/v3/content-search/?q=test%20file and you should see my test file show up with an empty "content_headline" field. Note that this file is at the bottom of the first page of results.
2. Go to https://unkbr9td91.execute-api.us-east-1.amazonaws.com/dev1278/search/?q=test+file and note that my file shows up at the bottom of the search results, showing no excerpt from the document's text.
3. Go to https://unkbr9td91.execute-api.us-east-1.amazonaws.com/dev1278/subjects?q=test+file and note that my file shows up at the bottom of the search results, showing no excerpt from the document's text.