### PR TITLE
EREGCSC-2518 - list related subjects

### DIFF
--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -29,6 +29,7 @@ ALLOWED_HOSTS = [os.environ.get('ALLOWED_HOST'),
                  'localhost',
                  'regulations-pilot.cms.gov',
                  'eregulations.cms.gov',
+                 'testserver'      
                  'host.docker.internal']
 
 # Application definition

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -29,7 +29,6 @@ ALLOWED_HOSTS = [os.environ.get('ALLOWED_HOST'),
                  'localhost',
                  'regulations-pilot.cms.gov',
                  'eregulations.cms.gov',
-                 'testserver'
                  'host.docker.internal']
 
 # Application definition

--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -29,7 +29,7 @@ ALLOWED_HOSTS = [os.environ.get('ALLOWED_HOST'),
                  'localhost',
                  'regulations-pilot.cms.gov',
                  'eregulations.cms.gov',
-                 'testserver'      
+                 'testserver'
                  'host.docker.internal']
 
 # Application definition

--- a/solution/backend/file_manager/serializers/groupings.py
+++ b/solution/backend/file_manager/serializers/groupings.py
@@ -13,6 +13,10 @@ class SubjectSerializer(serializers.Serializer):
     abbreviation = serializers.CharField()
 
 
+class SubjectCountsSerializer(SubjectSerializer):
+    count = serializers.IntegerField()
+
+
 class SubjectDetailsSerializer(SubjectSerializer):
     content = serializers.SerializerMethodField()
     internal_content = serializers.IntegerField()

--- a/solution/backend/file_manager/tests/test_views.py
+++ b/solution/backend/file_manager/tests/test_views.py
@@ -66,9 +66,9 @@ class TestTopSubjectsByLocation:
         assert len(results) == 2, "Should return 2 subjects"
         # results count should be 4 and 3
         assert results[0]['full_name'] == "Health Coverage"
-        assert results[0]['count'] == 3, "Medicaid Policies should appear three times"
+        assert results[0]['count'] == 3, "Health Coverage should appear three times"
         assert results[1]['full_name'] == "Medicaid Policies"
-        assert results[1]['count'] == 2, "Health Coverage should appear two times"
+        assert results[1]['count'] == 2, "Medicaid Policies should appear two times"
 
     def test_all_sections_included(self):
         """Test with all sections included."""

--- a/solution/backend/file_manager/tests/test_views.py
+++ b/solution/backend/file_manager/tests/test_views.py
@@ -48,8 +48,11 @@ class TestTopSubjectsByLocation:
             locations_param += f"&min_count={min_count}"
         return self.client.get(f"{self.url}?{locations_param}")
 
-    def test_distict_resources(self):
-        """Test correct subject counts with distinct resources."""
+    def test_subject_counts_reflect_distinct_resources_only(self):
+        """ Ensure that the count of subjects returned only reflects counts from distinct resources.
+        This test checks that subjects linked to multiple resources are counted once per unique resource,
+        ensuring that duplicate resources for a subject do not inflate their count.
+        """
         response = self.get_response(self.subparts, 5)
         assert response.status_code == status.HTTP_200_OK
         results = response.json()
@@ -57,9 +60,9 @@ class TestTopSubjectsByLocation:
         assert len(results) == 2, "Should return 2 subjects"
         # results count should be 4 and 3
         assert results[0]['full_name'] == "Health Coverage"
-        assert results[0]['count'] == 4, "Medicaid Policies should appear four times"
+        assert results[0]['count'] == 3, "Medicaid Policies should appear three times"
         assert results[1]['full_name'] == "Medicaid Policies"
-        assert results[1]['count'] == 3, "Health Coverage should appear three times"
+        assert results[1]['count'] == 2, "Health Coverage should appear two times"
 
     def test_all_sections_included(self):
         """Test with all sections included."""
@@ -69,9 +72,9 @@ class TestTopSubjectsByLocation:
 
         assert len(results) == 2, "Should return 2 subjects"
         assert results[0]['full_name'] == "Health Coverage"
-        assert results[0]['count'] == 4, "Medicaid Policies should appear four times"
+        assert results[0]['count'] == 3, "Medicaid Policies should appear three times"
         assert results[1]['full_name'] == "Medicaid Policies"
-        assert results[1]['count'] == 3, "Health Coverage should appear three times"
+        assert results[1]['count'] == 2, "Health Coverage should appear two times"
 
     def test_location_by_title(self):
         """Test with a location by title only."""

--- a/solution/backend/file_manager/tests/test_views.py
+++ b/solution/backend/file_manager/tests/test_views.py
@@ -103,3 +103,11 @@ def test_top_subjects_by_location():
 
     for subject in results:
         assert subject['count'] >= 1, f"Subject {subject['full_name']} should have a count <= 2"
+
+
+    # Ensure the counts reflect distinct resources
+    assert len(results) == 2, "Should return 2 subjects"
+
+    subject_counts = {result['full_name']: result['count'] for result in results}
+    assert subject_counts['Medicaid Policies'] == 3, "Medicaid Policies should be associated with 3 unique resources"
+    assert subject_counts['Health Coverage'] == 2, "Health Coverage should be associated with 2 unique resources"

--- a/solution/backend/file_manager/tests/test_views.py
+++ b/solution/backend/file_manager/tests/test_views.py
@@ -61,7 +61,6 @@ class TestTopSubjectsByLocation:
         assert results[1]['full_name'] == "Medicaid Policies"
         assert results[1]['count'] == 3, "Health Coverage should appear three times"
 
-
     def test_all_sections_included(self):
         """Test with all sections included."""
         response = self.get_response(self.sections, 5)

--- a/solution/backend/file_manager/tests/test_views.py
+++ b/solution/backend/file_manager/tests/test_views.py
@@ -20,6 +20,7 @@ class TestTopSubjectsByLocation:
         subpart1 = Subpart.objects.create(title=42, part=433, subpart_id="A")
         section1 = Section.objects.create(title=42, part=433, section_id=110, parent=subpart1)
         section2 = Section.objects.create(title=42, part=433, section_id=120, parent=subpart1)
+        section3 = Section.objects.create(title=45, part=1, section_id=100)
 
         resource1 = AbstractResource.objects.create()
         resource1.subjects.add(subject1, subject2)
@@ -36,7 +37,12 @@ class TestTopSubjectsByLocation:
         resource3.locations.add(subpart1)
         resource3.save()
 
-        self.sections = [section1, section2]
+        resource4 = AbstractResource.objects.create()
+        resource4.subjects.add(subject1)
+        resource4.locations.add(section3)
+        resource4.save()
+
+        self.sections = [section1, section2, section3]
         self.subparts = [subpart1]
 
     def get_response(self, locations, top_x, min_count=1):
@@ -71,10 +77,10 @@ class TestTopSubjectsByLocation:
         results = response.json()
 
         assert len(results) == 2, "Should return 2 subjects"
-        assert results[0]['full_name'] == "Health Coverage"
+        assert results[0]['full_name'] == "Medicaid Policies"
         assert results[0]['count'] == 3, "Medicaid Policies should appear three times"
-        assert results[1]['full_name'] == "Medicaid Policies"
-        assert results[1]['count'] == 2, "Health Coverage should appear two times"
+        assert results[1]['full_name'] == "Health Coverage"
+        assert results[1]['count'] == 3, "Health Coverage should appear three times"
 
     def test_location_by_title(self):
         """Test with a location by title only."""
@@ -87,7 +93,7 @@ class TestTopSubjectsByLocation:
         assert response.status_code == status.HTTP_200_OK
         results = response.json()
         assert len(results) == 1, "Should return 1 subject"
-        assert results[0]['full_name'] == "Health Coverage", "Should return Health Coverage"
+        assert results[0]['full_name'] == "Medicaid Policies", "Should return Health Coverage"
 
     def test_min_count_parameter(self):
         """Ensure the returned subjects have counts >= min_count."""

--- a/solution/backend/file_manager/tests/test_views.py
+++ b/solution/backend/file_manager/tests/test_views.py
@@ -51,7 +51,7 @@ def test_top_subjects_by_location():
 
     # Set up resources
     resources = create_resources()
-    subjects, sections = resources["subjects"], resources["sections"]
+    sections = resources["sections"]
 
     # Initialize API client
     client = APIClient()

--- a/solution/backend/file_manager/tests/test_views.py
+++ b/solution/backend/file_manager/tests/test_views.py
@@ -2,9 +2,10 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
-from resources.models import AbstractResource
+
 from file_manager.models import Subject
-from resources.models import Subpart, Section
+from resources.models import AbstractResource, Section, Subpart
+
 
 @pytest.mark.django_db
 def test_top_subjects_by_location():

--- a/solution/backend/file_manager/tests/test_views.py
+++ b/solution/backend/file_manager/tests/test_views.py
@@ -1,0 +1,61 @@
+from django.test import TestCase
+from django.urls import reverse from rest_framework.test import APIClient
+from rest_framework import status
+from file_manager.models import Subject, Location
+from file_manager.serializers.groupings import SubjectSerializer
+
+class TopSubjectsByLocationTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+        # Creating locations
+        self.location_part_433 = Location.objects.create(name="42 CFR 433")
+        self.location_section_436_110 = Location.objects.create(name="42 CFR 436.110")
+        self.location_subpart_433_A = Location.objects.create(name="42 CFR 433 Subpart A")
+        self.location_section_440_305 = Location.objects.create(name="42 CFR 440.305")
+        self.location_subpart_95_A = Location.objects.create(name="45 CFR 95 Subpart A")
+
+        # Create subjects and associate them with locations
+        self.subjects = [
+            Subject.objects.create(name="Medicaid Eligibility"),
+            Subject.objects.create(name="Health Coverage"),
+            Subject.objects.create(name="Provider Reimbursements"),
+            Subject.objects.create(name="State Funding"),
+            Subject.objects.create(name="Federal Support")
+        ]
+        for subject in self.subjects:
+            subject.locations.add(self.location_part_433)
+
+        self.url = reverse('top-subjects-by-location')  # Update with the actual URL name if necessary
+
+    def test_top_subjects_default(self):
+        """
+        Test that the endpoint returns the default top 5 subjects when no specific count is provided.
+        """
+        response = self.client.get(f"{self.url}?locations={self.location_part_433.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+
+    def test_top_subjects_specific_count(self):
+        """
+        Test that the endpoint returns the correct number of subjects when a specific count is requested.
+        """
+        response = self.client.get(f"{self.url}?locations={self.location_part_433.id}&top_x=3")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 3)
+
+    def test_top_subjects_exceeding_available(self):
+        """
+        Test that the endpoint returns all available subjects when the requested count exceeds the available number.
+        """
+        response = self.client.get(f"{self.url}?locations={self.location_part_433.id}&top_x=10")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), len(self.subjects))  # Assuming all subjects are linked to the location
+
+    def test_top_subjects_no_subjects(self):
+        """
+        Test that the endpoint returns an empty list when there are no subjects associated with the location.
+        """
+        response = self.client.get(f"{self.url}?locations={self.location_subpart_95_A.id}&top_x=5")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertListEqual(response.data, [])

--- a/solution/backend/file_manager/tests/test_views.py
+++ b/solution/backend/file_manager/tests/test_views.py
@@ -80,9 +80,6 @@ def test_top_subjects_by_location():
 
     results = response.json()
 
-    # Check specific count of subjects in this case
-    assert len(results) == 2, "Should return 2 subject by location title"
-
     # check top_x parameter is working
     response = get_response(client, url, sections, 1)
     assert response.status_code == status.HTTP_200_OK

--- a/solution/backend/file_manager/urls.py
+++ b/solution/backend/file_manager/urls.py
@@ -7,6 +7,7 @@ from .views import (
     RepositoryCategoryTreeViewSet,
     SubjectViewset,
     UploadedFileViewset,
+    TopSubjectsByLocationViewSet,
 )
 
 urlpatterns = [
@@ -19,6 +20,9 @@ urlpatterns = [
     path("subjects", SubjectViewset.as_view({
         "get": "list",
     })),
+    path("subjects/top_by_location", TopSubjectsByLocationViewSet.as_view({
+        "get": "list",
+    }), name='top-subjects-by-location'),
     path("groups", GroupViewset.as_view({
         "get": "list",
     })),

--- a/solution/backend/file_manager/urls.py
+++ b/solution/backend/file_manager/urls.py
@@ -6,8 +6,8 @@ from .views import (
     RepoCategoryViewSet,
     RepositoryCategoryTreeViewSet,
     SubjectViewset,
-    UploadedFileViewset,
     TopSubjectsByLocationViewSet,
+    UploadedFileViewset,
 )
 
 urlpatterns = [

--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -33,7 +33,7 @@ from file_manager.serializers.groups import (
     DivisionWithGroupSerializer,
     GroupWithDivisionSerializer,
 )
-from resources.models import AbstractLocation
+from resources.models import AbstractLocation, AbstractResource
 from resources.views.mixins import LocationExplorerViewSetMixin, LocationFiltererMixin, OptionalPaginationMixin
 
 from .functions import get_upload_link

--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -284,8 +284,11 @@ class TopSubjectsByLocationViewSet(LocationFiltererMixin, viewsets.ReadOnlyModel
         # Fetch the 'top_x' parameter from the query parameters or use 5 as default
         top_x = int(self.request.GET.get("top_x", 5))
         min_count = int(self.request.GET.get("min_count", 1))
-        # resources = AbstractResource.objects.filter(self.get_location_filter(locations)).distinct().values_list('pk', flat=True)
-        resources = AbstractResource.objects.annotate(subjects_count=Count("subjects")).filter(subjects_count__lt=10)
+
+        resources = AbstractResource.objects\
+            .annotate(subjects_count=Count("subjects"))\
+            .filter(subjects_count__lt=10).filter(self.get_location_filter(locations)).distinct()\
+            .values_list('pk', flat=True)
 
         # Apply location filter to the Subject queryset
         query = Subject.objects.filter(resources__pk__in=resources)

--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -283,10 +283,11 @@ class TopSubjectsByLocationViewSet(LocationFiltererMixin, viewsets.ReadOnlyModel
 
         # Fetch the 'top_x' parameter from the query parameters or use 5 as default
         top_x = int(self.request.GET.get("top_x", 5))
-
+        min_count = int(self.request.GET.get("min_count", 1))
         # Apply location filter to the Subject queryset
         query = Subject.objects.filter(self.get_location_filter(locations))
         # Annotate each Subject with a count of primary keys and order by this count
-        query = query.annotate(count=Count('pk')).order_by('-count')
+        query = query.annotate(count=Count('pk')).filter(count__gte=min_count).order_by('-count')
+
         # Return only the top 5 subjects
         return query[:top_x]

--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -33,7 +33,6 @@ from file_manager.serializers.groups import (
     DivisionWithGroupSerializer,
     GroupWithDivisionSerializer,
 )
-
 from resources.models import AbstractLocation, AbstractResource
 from resources.views.mixins import LocationExplorerViewSetMixin, LocationFiltererMixin, OptionalPaginationMixin
 

--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -12,7 +12,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from django.db.models import Count
+
 from common.api import OpenApiQueryParameter
 from common.constants import QUOTE_TYPES
 from common.functions import establish_client
@@ -26,6 +26,7 @@ from file_manager.serializers.groupings import (
     AbstractRepositoryCategoryPolymorphicSerializer,
     MetaRepositoryCategorySerializer,
     RepositoryCategoryTreeSerializer,
+    SubjectCountsSerializer,
     SubjectDetailsSerializer,
 )
 from file_manager.serializers.groups import (
@@ -33,8 +34,7 @@ from file_manager.serializers.groups import (
     GroupWithDivisionSerializer,
 )
 from resources.models import AbstractLocation
-from resources.views.mixins import LocationExplorerViewSetMixin, OptionalPaginationMixin, LocationFiltererMixin
-from file_manager.serializers.groupings import SubjectCountsSerializer
+from resources.views.mixins import LocationExplorerViewSetMixin, LocationFiltererMixin, OptionalPaginationMixin
 
 from .functions import get_upload_link
 from .models import (

--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -33,7 +33,7 @@ from file_manager.serializers.groups import (
     DivisionWithGroupSerializer,
     GroupWithDivisionSerializer,
 )
-from resources.models import AbstractLocation, AbstractResource
+from resources.models import AbstractLocation
 from resources.views.mixins import LocationExplorerViewSetMixin, LocationFiltererMixin, OptionalPaginationMixin
 
 from .functions import get_upload_link
@@ -269,7 +269,7 @@ class TopSubjectsByLocationViewSet(LocationFiltererMixin, viewsets.ReadOnlyModel
     ViewSet for retrieving top subjects based on location.
     Uses LocationFiltererMixin to apply location-based filters.
     """
-    location_filter_prefix = "locations__"
+    location_filter_prefix = "resources__locations__"
     serializer_class = SubjectCountsSerializer
 
     def get_queryset(self):
@@ -284,11 +284,8 @@ class TopSubjectsByLocationViewSet(LocationFiltererMixin, viewsets.ReadOnlyModel
         # Fetch the 'top_x' parameter from the query parameters or use 5 as default
         top_x = int(self.request.GET.get("top_x", 5))
         min_count = int(self.request.GET.get("min_count", 1))
-        resources = AbstractResource.objects.filter(self.get_location_filter(locations)).distinct().values_list('pk', flat=True)
-
-
         # Apply location filter to the Subject queryset
-        query = Subject.objects.filter(resources__pk__in=resources)
+        query = Subject.objects.filter(self.get_location_filter(locations))
         # Annotate each Subject with a count of primary keys and order by this count
         query = query.annotate(count=Count('pk')).filter(count__gte=min_count).order_by('-count')
 

--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -33,7 +33,7 @@ from file_manager.serializers.groups import (
     DivisionWithGroupSerializer,
     GroupWithDivisionSerializer,
 )
-from resources.models import AbstractLocation, AbstractResource
+from resources.models import AbstractLocation
 from resources.views.mixins import LocationExplorerViewSetMixin, LocationFiltererMixin, OptionalPaginationMixin
 
 from .functions import get_upload_link

--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -33,7 +33,8 @@ from file_manager.serializers.groups import (
     DivisionWithGroupSerializer,
     GroupWithDivisionSerializer,
 )
-from resources.models import AbstractLocation
+
+from resources.models import AbstractLocation, AbstractResource
 from resources.views.mixins import LocationExplorerViewSetMixin, LocationFiltererMixin, OptionalPaginationMixin
 
 from .functions import get_upload_link
@@ -269,7 +270,7 @@ class TopSubjectsByLocationViewSet(LocationFiltererMixin, viewsets.ReadOnlyModel
     ViewSet for retrieving top subjects based on location.
     Uses LocationFiltererMixin to apply location-based filters.
     """
-    location_filter_prefix = "resources__locations__"
+    location_filter_prefix = "locations__"
     serializer_class = SubjectCountsSerializer
 
     def get_queryset(self):
@@ -284,8 +285,12 @@ class TopSubjectsByLocationViewSet(LocationFiltererMixin, viewsets.ReadOnlyModel
         # Fetch the 'top_x' parameter from the query parameters or use 5 as default
         top_x = int(self.request.GET.get("top_x", 5))
         min_count = int(self.request.GET.get("min_count", 1))
+        # resources = AbstractResource.objects.filter(self.get_location_filter(locations)).distinct().values_list('pk', flat=True)
+        resources = AbstractResource.objects.annotate(subjects_count=Count("subjects")).filter(subjects_count__lt=10)
+
         # Apply location filter to the Subject queryset
-        query = Subject.objects.filter(self.get_location_filter(locations))
+        query = Subject.objects.filter(resources__pk__in=resources)
+
         # Annotate each Subject with a count of primary keys and order by this count
         query = query.annotate(count=Count('pk')).filter(count__gte=min_count).order_by('-count')
 

--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -34,7 +34,7 @@ from file_manager.serializers.groups import (
 )
 from resources.models import AbstractLocation
 from resources.views.mixins import LocationExplorerViewSetMixin, OptionalPaginationMixin, LocationFiltererMixin
-from file_manager.serializers.groupings import SubjectSerializer
+from file_manager.serializers.groupings import SubjectCountsSerializer
 
 from .functions import get_upload_link
 from .models import (
@@ -270,7 +270,7 @@ class TopSubjectsByLocationViewSet(LocationFiltererMixin, viewsets.ReadOnlyModel
     Uses LocationFiltererMixin to apply location-based filters.
     """
     location_filter_prefix = "resources__locations__"
-    serializer_class = SubjectSerializer
+    serializer_class = SubjectCountsSerializer
 
     def get_queryset(self):
         """

--- a/solution/backend/file_manager/views.py
+++ b/solution/backend/file_manager/views.py
@@ -33,7 +33,7 @@ from file_manager.serializers.groups import (
     DivisionWithGroupSerializer,
     GroupWithDivisionSerializer,
 )
-from resources.models import AbstractLocation
+from resources.models import AbstractLocation, AbstractResource
 from resources.views.mixins import LocationExplorerViewSetMixin, LocationFiltererMixin, OptionalPaginationMixin
 
 from .functions import get_upload_link
@@ -269,7 +269,7 @@ class TopSubjectsByLocationViewSet(LocationFiltererMixin, viewsets.ReadOnlyModel
     ViewSet for retrieving top subjects based on location.
     Uses LocationFiltererMixin to apply location-based filters.
     """
-    location_filter_prefix = "resources__locations__"
+    location_filter_prefix = "locations__"
     serializer_class = SubjectCountsSerializer
 
     def get_queryset(self):
@@ -284,8 +284,11 @@ class TopSubjectsByLocationViewSet(LocationFiltererMixin, viewsets.ReadOnlyModel
         # Fetch the 'top_x' parameter from the query parameters or use 5 as default
         top_x = int(self.request.GET.get("top_x", 5))
         min_count = int(self.request.GET.get("min_count", 1))
+        resources = AbstractResource.objects.filter(self.get_location_filter(locations)).distinct().values_list('pk', flat=True)
+
+
         # Apply location filter to the Subject queryset
-        query = Subject.objects.filter(self.get_location_filter(locations))
+        query = Subject.objects.filter(resources__pk__in=resources)
         # Annotate each Subject with a count of primary keys and order by this count
         query = query.annotate(count=Count('pk')).filter(count__gte=min_count).order_by('-count')
 

--- a/solution/backend/resources/views/mixins.py
+++ b/solution/backend/resources/views/mixins.py
@@ -55,7 +55,10 @@ class LocationFiltererMixin:
                     q &= (
                         Q(**{f"{self.location_filter_prefix}section__section_id": split[2]})
                         if is_int(split[2])
-                        else Q(**{f"{self.location_filter_prefix}subpart__subpart_id": split[2]})
+                        else (
+                            Q(**{f"{self.location_filter_prefix}subpart__subpart_id": split[2]}) |
+                            Q(**{f"{self.location_filter_prefix}section__parent__subpart__subpart_id": split[2]})
+                        )
                     )
 
             queries.append(q)


### PR DESCRIPTION
Resolves #EREGCSC-2518 - List related subjects

**Description-**
Given a regulation part, subpart, or section, we want to be able to display the top X subjects associated with resources in that part, subpart, or section. We imagine we could do this by taking the associated resources for the part, subpart, or section (FR docs and supplemental content) and counting the subjects attached to those documents.

We want to look into whether we could calculate this reasonably fast for display in sidebars. It could be cached, since it probably wouldn't change very often.

endpoints to include top_x and min_count parameters
top_x will determine the top of the given number of subjects. For example if you pass top_x=5, it will display the top 5. Default value is 5.

min_count will return subjects that are greater than or equal to the min_count. For example if you set min_count to 3, it will return subjects with a count of 3 or more. 

Example locations:

[Part: 42 CFR 433](https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.433)
[Section: 42 CFR 436.110](https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.436.110)
[Subpart: 42 CFR 433 Subpart A](https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.433.A)
[Section: 42 CFR 440.305](https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.440.305)
[Subpart: 45 CFR 95 Subpart A](https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=45.95.A)

**Example of top x:**
https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.433&top_x=20
(remember the min_count default value is 1) 

**Example of min_count**
https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.433&min_count=3
(remember the top_x default is 5) 

**Example of top_x and min_count**
https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.433&top_x=20&min_count=3

**This pull request changes...**

expected change 

- solution/backend/file_manager/serializers/groupings.py
Add count to the serializer

- solution/backend/file_manager/tests/test_views.py
Add tests

- solution/backend/file_manager/urls.py
Add the routes

- solution/backend/file_manager/views.py
Create TopSubjectsByLocation viewset

- solution/backend/resources/views/mixins.py
Update Mixin


**Steps to manually verify this change...**


Visit:
https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.433

https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.436.110

https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.433.A

https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=42.440.305

https://dkw5vc8shj.execute-api.us-east-1.amazonaws.com/dev1280/v3/file-manager/subjects/top_by_location?locations=45.95.A