### PR TITLE
[Hotfix] Handle subject groups when fetching Reader View sidebar resources

### DIFF
--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
@@ -210,13 +210,13 @@ export default {
                     this.categories = formatResourceCategories({
                         apiUrl: this.apiUrl,
                         categories: rawCategories,
-                        resources: response.results
+                        resources: response.results,
                     });
                 } else {
                     this.categories = formatResourceCategories({
                         apiUrl: this.apiUrl,
                         categories: rawCategories,
-                        resources: subpartResponse.results
+                        resources: subpartResponse.results,
                     });
                 }
             } catch (error) {
@@ -232,7 +232,16 @@ export default {
                 this.part,
                 this.subparts[0]
             );
-            const secList = sections.map((section) => section.identifier[1]);
+
+            const getSectionsRecursive = (sectionList) =>
+                sectionList.flatMap((section) => {
+                    if (section.type !== "section")
+                        return getSectionsRecursive(section.children);
+                    return section.identifier[1];
+                });
+
+            const secList = getSectionsRecursive(sections);
+
             this.partDict[this.part] = {
                 title: this.title,
                 subparts: this.subparts,


### PR DESCRIPTION
**Description**

Subject groups are not being taken into account when fetching resources in the right sidebar of the Reader View.

https://eregulations.cms.gov/42/431/Subpart-E/2024-04-08/

The above link only shows 11 resources in the right sidebar.  That count is highly suspect; while working on another story, manual validation of this subpart indicates that there should be more.  Many more.

Further inspection revealed that the API call includes a list of locations with `undefined` instead of a section:

```https://eregulations.cms.gov/v3/resources/?&locations=42.431.E&locations=42.431.undefined&locations=42.431.undefined&locations=42.431.undefined&locations=42.431.undefined&locations=42.431.undefined&category_details=true&location_details=true&start=undefined&max_results=1000&sort=newest&paginate=true&page_size=1000&page=1&fr_grouping=true```

Those `undefined` values definitely shouldn't be there, so something is wrong with how we're creating the list of locations for this Subpart.  

**This pull request changes:**

- Better handles drilling down to `sections` if the exist in nested `children` fields by using a recursive function

**Steps to manually verify this change:**

1. Green check marks
2. Visit 42 CFR 431 Subpart E on the experimental deployment
3. Notice that there are now 55 resources instead of 11
4. Inspect the resources API call and ensure it does not include any `undefined` values in the list of locations

