### PR TITLE
EREGCSC-2667 -- Reloading a subject page causes it to have the wrong <title> value

### DIFF
--- a/solution/ui/e2e/cypress/e2e/title-tags.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/title-tags.spec.cy.js
@@ -55,5 +55,17 @@ describe("Updated HTML Title Tags", { scrollBehavior: "center" }, () => {
             "eq",
             "Find by Subject | Medicaid & CHIP eRegulations"
         );
+
+        cy.visit("/subjects/?subjects=1");
+        cy.title().should(
+            "eq",
+            "Cures Act | Find by Subject | Medicaid & CHIP eRegulations"
+        );
+
+        cy.visit("/subjects/?subjects=18");
+        cy.title().should(
+            "eq",
+            "Collateral Contacts | Find by Subject | Medicaid & CHIP eRegulations"
+        );
     });
 });

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
@@ -109,12 +109,16 @@ const subjectClick = (event) => {
     });
 };
 
-const subjectClasses = (subjectId) => ({
-    "sidebar-li__button": true,
-    "sidebar-li__button--selected": $route.query.subjects?.includes(
-        subjectId.toString()
-    ),
-});
+const subjectClasses = (subjectId) => {
+    const routeArr = _isArray($route.query.subjects)
+        ? $route.query.subjects
+        : [$route.query.subjects];
+
+    return {
+        "sidebar-li__button": true,
+        "sidebar-li__button--selected": routeArr.includes(subjectId.toString()),
+    };
+};
 
 const filterResetClasses = computed(() => ({
     "subjects__filter-reset": true,

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -266,7 +266,7 @@ const getDocSubjects = async () => {
         // set title if needed
         if (policyDocSubjects.value.results.length && $route.query.subjects) {
             setDocumentTitle(
-                $route.query.subjects[0],
+                $route.query.subjects,
                 policyDocSubjects.value.results
             );
         }


### PR DESCRIPTION
Resolves [EREGCSC-2667](https://jiraent.cms.gov/browse/EREGCSC-2667)

**Description**

Document title is sometimes incorrect on load when visiting the subject page with a subject included in the URL.

The issue: 

**This pull request changes:**

- Fixes bug where only the first digit of a subject ID was used on page load to set the Document Title (ex: 25 Dental would be interpreted as 2 ABP)
- Adds Cypress end to end test to validate this change
- Fixes issue with Subject Selector highlighting/bolding where multiple subjects could be bolded

**Steps to manually verify this change:**

1. Green check marks
2. Visit the [Subjects page on the experimental deployment](https://tuncmlts43.execute-api.us-east-1.amazonaws.com/dev1287/subjects/)
   - select and deselect a few subjects from both the Table of Contents (the right side of the page) and the Subject Selector (in the left sidebar) and make sure the Document Title updates correctly each time
   - Make sure the correct subject is highlighted/bolded in the Subject Selector in the left sidebar
3. Visit the Subjects page with a subject already in the URL. Example: [25 Dental](https://tuncmlts43.execute-api.us-east-1.amazonaws.com/dev1287/subjects/?subjects=25)
   - Ensure that the Document Title is correct (Dental)
   - Ensure that only Dental is highlighted/Bold in the Subject Selector in the left sidebar

