### PR TITLE
EREGCSC 2672 -- Add "Manage Content" link to Account dropdown menu

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/header.html
+++ b/solution/backend/regulations/templates/regulations/partials/header.html
@@ -21,7 +21,7 @@
         </template>
         <template #sign-in>
             {% if user.is_authenticated %}
-                <header-user-widget home-url="{% url 'homepage' %}">
+                <header-user-widget admin-url="{% url 'admin:index' %}">
                     <template #username>
                         {{ user.username }}
                     </template>

--- a/solution/backend/regulations/templates/regulations/partials/header.html
+++ b/solution/backend/regulations/templates/regulations/partials/header.html
@@ -25,6 +25,9 @@
                     <template #username>
                         {{ user.username }}
                     </template>
+                    <template #account-links>
+                        <a href="/" rel="noopener noreferrer">Manage Content</a>
+                    </template>
                     <template #sign-out-link>
                         {% include "regulations/partials/logout_form.html" %}
                     </template>

--- a/solution/backend/regulations/templates/regulations/partials/header.html
+++ b/solution/backend/regulations/templates/regulations/partials/header.html
@@ -26,7 +26,7 @@
                         {{ user.username }}
                     </template>
                     <template #account-links>
-                        <a href="/" rel="noopener noreferrer">Manage Content</a>
+                        <a href="{% url 'homepage' %}admin" rel="noopener noreferrer">Manage Content</a>
                     </template>
                     <template #sign-out-link>
                         {% include "regulations/partials/logout_form.html" %}

--- a/solution/backend/regulations/templates/regulations/partials/header.html
+++ b/solution/backend/regulations/templates/regulations/partials/header.html
@@ -21,12 +21,9 @@
         </template>
         <template #sign-in>
             {% if user.is_authenticated %}
-                <header-user-widget>
+                <header-user-widget home-url="{% url 'homepage' %}">
                     <template #username>
                         {{ user.username }}
-                    </template>
-                    <template #account-links>
-                        <a href="{% url 'homepage' %}admin" rel="noopener noreferrer">Manage Content</a>
                     </template>
                     <template #sign-out-link>
                         {% include "regulations/partials/logout_form.html" %}

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -11,6 +11,7 @@
 {% block body %}
 <div
     id="vite-app"
+    data-admin-url="{% url 'admin:index' %}"
     data-api-url="{{ API_BASE }}"
     data-about-url="{% url 'about' %}"
     data-custom-login-url="{% url 'custom_login' %}"

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -16,6 +16,7 @@
 {% block body %}
 <div
     id="vite-app"
+    data-admin-url="{% url 'admin:index' %}"
     data-api-url="{{ API_BASE }}"
     data-about-url="{% url 'about' %}"
     data-custom-login-url="{% url 'custom_login' %}"

--- a/solution/backend/regulations/templates/regulations/subjects.html
+++ b/solution/backend/regulations/templates/regulations/subjects.html
@@ -11,6 +11,7 @@
 {% block body %}
 <div
     id="vite-app"
+    data-admin-url="{% url 'admin:index' %}"
     data-api-url="{{ API_BASE }}"
     data-about-url="{% url 'about' %}"
     data-custom-login-url="{% url 'custom_login' %}"

--- a/solution/ui/e2e/cypress/e2e/sign-in-out.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/sign-in-out.spec.cy.js
@@ -9,6 +9,17 @@ describe("Login and Logout Validation", { scrollBehavior: "center" }, () => {
         });
     });
 
+    it("checks a11y for sign in elements", () => {
+        cy.viewport("macbook-15");
+        cy.eregsLogin({ username, password, landingPage: "/" });
+        cy.get("button[data-testid='user-account-button']").click({
+            force: true,
+        });
+        cy.checkLinkRel();
+        cy.injectAxe();
+        cy.checkAccessibility();
+    });
+
     it("should have a Sign In link at the top right corner of the header", () => {
         cy.viewport("macbook-15");
         cy.visit("/");

--- a/solution/ui/e2e/cypress/e2e/sign-in-out.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/sign-in-out.spec.cy.js
@@ -12,9 +12,7 @@ describe("Login and Logout Validation", { scrollBehavior: "center" }, () => {
     it("should have a Sign In link at the top right corner of the header", () => {
         cy.viewport("macbook-15");
         cy.visit("/");
-        cy.get(".header--sign-in a").should(
-            "be.visible"
-        );
+        cy.get(".header--sign-in a").should("be.visible");
         cy.get(".header--sign-in").should("not.have.class", "active");
         cy.get(".header--sign-in a").click();
         cy.url().should("include", "/?next=/");
@@ -53,14 +51,17 @@ describe("Login and Logout Validation", { scrollBehavior: "center" }, () => {
         cy.get(".dropdown-menu__container.dropdown-menu--account").should(
             "be.visible"
         );
+        cy.get("a[data-testid='manage-content-link']")
+            .contains("Manage Content")
+            .should("be.visible")
+            .and("have.attr", "href")
+            .and("include", "admin");
         cy.get("form#oidc_logout").should("be.visible");
         cy.get("form#oidc_logout").submit();
         cy.get(".dropdown-menu__container.dropdown-menu--account").should(
             "not.exist"
         );
-        cy.get(".header--sign-in a").should(
-            "be.visible"
-        );
+        cy.get(".header--sign-in a").should("be.visible");
     });
 
     it("should have an account info dropdown menu with Sign Out button and hidden Sign Out form on Single Page App page when logged in", () => {
@@ -98,8 +99,6 @@ describe("Login and Logout Validation", { scrollBehavior: "center" }, () => {
         cy.get(".dropdown-menu__container.dropdown-menu--account").should(
             "not.exist"
         );
-        cy.get(".header--sign-in a").should(
-            "be.visible"
-        );
+        cy.get(".header--sign-in a").should("be.visible");
     });
 });

--- a/solution/ui/regulations/css/scss/partials/_header.scss
+++ b/solution/ui/regulations/css/scss/partials/_header.scss
@@ -443,6 +443,7 @@ header {
 
                     .account-info__container {
                         padding: 0.5rem;
+                        padding-bottom: 0;
                         display: inline-block;
                         min-width: 145px;
                         max-width: 340px;
@@ -459,6 +460,24 @@ header {
                                 width: 0;
                                 margin: 0.25rem 0;
                                 font-size: $font-size-sm;
+                            }
+                        }
+
+                        .account-info--links {
+                            margin: 0.75rem 0;
+
+                            a {
+                                @include header__anchor--bold;
+
+                                color: $primary_link_color;
+                                transition: none;
+
+                                &:hover,
+                                &:focus,
+                                &.active {
+                                    @include header__anchor--active-bold;
+                                    padding: 0;
+                                }
                             }
                         }
                     }

--- a/solution/ui/regulations/css/scss/partials/_header.scss
+++ b/solution/ui/regulations/css/scss/partials/_header.scss
@@ -376,12 +376,6 @@ header {
                     @include header__anchor--active-bold;
                     padding: 0;
                 }
-
-                a {
-                    @include header__anchor--active-bold;
-                    padding: 0;
-                    pointer-events: none;
-                }
             }
 
             span.disabled {

--- a/solution/ui/regulations/eregs-vite/src/App.vue
+++ b/solution/ui/regulations/eregs-vite/src/App.vue
@@ -5,6 +5,10 @@ export default {
     components: {},
 
     props: {
+        adminUrl: {
+            type: String,
+            default: "/admin/",
+        },
         apiUrl: {
             type: String,
             default: "/v2/",
@@ -64,6 +68,7 @@ export default {
 <template>
     <v-app>
         <router-view
+            :admin-url="adminUrl"
             :api-url="apiUrl"
             :about-url="aboutUrl"
             :custom-login-url="customLoginUrl"

--- a/solution/ui/regulations/eregs-vite/src/components/header/HeaderUserWidget.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/header/HeaderUserWidget.vue
@@ -6,6 +6,13 @@ import useDropdownMenu from "composables/dropdownMenu";
 import HeaderDropdownMenu from "./HeaderDropdownMenu.vue";
 import UserIconSvg from "../svgs/user-icon.vue";
 
+const props = defineProps({
+    homeUrl: {
+        type: String,
+        default: "/",
+    },
+});
+
 const { menuExpanded, toggleClick, closeClick } = useDropdownMenu();
 
 const formLogout = () => {
@@ -46,7 +53,9 @@ const iconClasses = computed(() => ({
                     </div>
                 </div>
                 <div class="account-info--links">
-                    <slot name="account-links"></slot>
+                    <a :href="homeUrl + 'admin'" rel="noopener noreferrer"
+                        >Manage Content</a
+                    >
                 </div>
             </div>
             <hr />

--- a/solution/ui/regulations/eregs-vite/src/components/header/HeaderUserWidget.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/header/HeaderUserWidget.vue
@@ -23,6 +23,8 @@ const iconClasses = computed(() => ({
     "user-account__button": true,
     "user-account__button--expanded": menuExpanded.value,
 }));
+
+const adminUrl = computed(() => `${props.homeUrl}admin`);
 </script>
 
 <template>
@@ -53,7 +55,7 @@ const iconClasses = computed(() => ({
                     </div>
                 </div>
                 <div class="account-info--links">
-                    <a :href="homeUrl + 'admin'" rel="noopener noreferrer"
+                    <a :href="adminUrl" rel="noopener noreferrer"
                         >Manage Content</a
                     >
                 </div>

--- a/solution/ui/regulations/eregs-vite/src/components/header/HeaderUserWidget.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/header/HeaderUserWidget.vue
@@ -44,7 +44,9 @@ const iconClasses = computed(() => ({
                         While signed in, you can access documents
                         <strong>internal to CMCS</strong>.
                     </div>
-                    <slot name="user-account-content"></slot>
+                </div>
+                <div class="account-info--links">
+                    <slot name="account-links"></slot>
                 </div>
             </div>
             <hr />

--- a/solution/ui/regulations/eregs-vite/src/components/header/HeaderUserWidget.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/header/HeaderUserWidget.vue
@@ -55,7 +55,10 @@ const adminUrl = computed(() => `${props.homeUrl}admin`);
                     </div>
                 </div>
                 <div class="account-info--links">
-                    <a :href="adminUrl" rel="noopener noreferrer"
+                    <a
+                        :href="adminUrl"
+                        rel="noopener noreferrer"
+                        data-testid="manage-content-link"
                         >Manage Content</a
                     >
                 </div>

--- a/solution/ui/regulations/eregs-vite/src/components/header/HeaderUserWidget.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/header/HeaderUserWidget.vue
@@ -7,9 +7,9 @@ import HeaderDropdownMenu from "./HeaderDropdownMenu.vue";
 import UserIconSvg from "../svgs/user-icon.vue";
 
 const props = defineProps({
-    homeUrl: {
+    adminUrl: {
         type: String,
-        default: "/",
+        default: "/admin/",
     },
 });
 
@@ -23,8 +23,6 @@ const iconClasses = computed(() => ({
     "user-account__button": true,
     "user-account__button--expanded": menuExpanded.value,
 }));
-
-const adminUrl = computed(() => `${props.homeUrl}admin`);
 </script>
 
 <template>

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -15,7 +15,7 @@
                     <HeaderSearch :search-url="searchUrl" />
                 </template>
                 <template v-if="isAuthenticated" #sign-in>
-                    <HeaderUserWidget>
+                    <HeaderUserWidget :home-url="homeUrl">
                         <template #username>
                             {{ username }}
                         </template>

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -15,7 +15,7 @@
                     <HeaderSearch :search-url="searchUrl" />
                 </template>
                 <template v-if="isAuthenticated" #sign-in>
-                    <HeaderUserWidget :home-url="homeUrl">
+                    <HeaderUserWidget :admin-url="adminUrl">
                         <template #username>
                             {{ username }}
                         </template>
@@ -238,6 +238,10 @@ export default {
     },
 
     props: {
+        adminUrl: {
+            type: String,
+            default: "/admin/",
+        },
         aboutUrl: {
             type: String,
             default: "/about/",

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -20,6 +20,10 @@ import JumpTo from "@/components/JumpTo.vue";
 import HeaderUserWidget from "@/components/header/HeaderUserWidget.vue";
 
 const props = defineProps({
+    adminUrl: {
+        type: String,
+        default: "/admin/",
+    },
     aboutUrl: {
         type: String,
         default: "/about/",
@@ -178,7 +182,7 @@ getStatutesArray();
                     <HeaderSearch :search-url="searchUrl" />
                 </template>
                 <template v-if="isAuthenticated" #sign-in>
-                    <HeaderUserWidget :home-url="homeUrl">
+                    <HeaderUserWidget :admin-url="adminUrl">
                         <template #username>
                             {{ username }}
                         </template>

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -178,7 +178,7 @@ getStatutesArray();
                     <HeaderSearch :search-url="searchUrl" />
                 </template>
                 <template v-if="isAuthenticated" #sign-in>
-                    <HeaderUserWidget>
+                    <HeaderUserWidget :home-url="homeUrl">
                         <template #username>
                             {{ username }}
                         </template>

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -33,6 +33,10 @@ import SubjectSelector from "@/components/subjects/SubjectSelector.vue";
 import SubjectTOC from "@/components/subjects/SubjectTOC.vue";
 
 const props = defineProps({
+    adminUrl: {
+        type: String,
+        default: "/admin/",
+    },
     aboutUrl: {
         type: String,
         default: "/about/",
@@ -384,7 +388,7 @@ getDocSubjects();
                     <HeaderSearch :search-url="searchUrl" />
                 </template>
                 <template v-if="isAuthenticated" #sign-in>
-                    <HeaderUserWidget :home-url="homeUrl">
+                    <HeaderUserWidget :admin-url="adminUrl">
                         <template #username>
                             {{ username }}
                         </template>

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -384,7 +384,7 @@ getDocSubjects();
                     <HeaderSearch :search-url="searchUrl" />
                 </template>
                 <template v-if="isAuthenticated" #sign-in>
-                    <HeaderUserWidget>
+                    <HeaderUserWidget :home-url="homeUrl">
                         <template #username>
                             {{ username }}
                         </template>


### PR DESCRIPTION
Resolves [EREGCSC-2672](https://jiraent.cms.gov/browse/EREGCSC-2672)

**Description**

When signed in, the top right menu should have a "Manage Content" link that goes to the admin panel homepage.

[Figma design](https://www.figma.com/file/kGg6wtaPK2yxtAayP6JZUb/Authentication-status?node-id=534-23425&mode=dev)
[Figma prototype](https://www.figma.com/proto/kGg6wtaPK2yxtAayP6JZUb/Authentication-status?page-id=1%3A57&type=design&node-id=102-18030&t=iIASmNGP7zeQo5yx-0&scaling=min-zoom&starting-point-node-id=259%3A24273)

**This pull request changes:**

- Adds "Manage Content" link to account dropdown menu and styles per Figma design

**Steps to manually verify this change:**

1. Green check marks
2. Visit [experimental deployment](https://h32gdnvzu2.execute-api.us-east-1.amazonaws.com/dev1290) and log in
3. When logged in, click the Account button at the top right of the screen to show the Account Info dropdown
4. Make sure "Manage Content" link exists, is styled per the Figma comps above, and goes to the `admin` page when clicked
5. Click "Manage Content" from a bunch of different places -- Search, Statutes, Subjects, Reader View, etc -- to make sure it works in every place

