### PR TITLE
EREGCSC-2403 -- Subjects page pagination

### DIFF
--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -26,6 +26,23 @@ const _beforeEach = () => {
     }).as("subjects");
 };
 
+const _beforePaginate = () => {
+    cy.intercept(
+        "**/v3/content-search/?resource-type=external&page_size=50&paginate=true**",
+        {
+            fixture: "policy-docs-50-p1.json",
+        }
+    ).as("initialPage");
+
+    cy.intercept("**/v3/content-search/?resource-type=external&page=1**", {
+        fixture: "policy-docs-50-p1.json",
+    }).as("page1");
+
+    cy.intercept("**/v3/content-search/?resource-type=external&page=2**", {
+        fixture: "policy-docs-50-p2.json",
+    }).as("page2");
+};
+
 Cypress.Commands.add("getPolicyDocs", ({ username, password }) => {
     cy.intercept("**/v3/content-search/?q=mock**", {
         fixture: "policy-docs.json",
@@ -62,8 +79,7 @@ describe("Find by Subjects", () => {
         cy.viewport("macbook-15");
         cy.visit("/resources?q=test");
         cy.url().should("not.include", "/resources");
-        cy.url().should("include", "/subjects/")
-            .and("not.include", "q=test");
+        cy.url().should("include", "/subjects/").and("not.include", "q=test");
         cy.get(".div__login-sidebar a")
             .should("have.attr", "href")
             .and("include", "next")
@@ -143,7 +159,9 @@ describe("Find by Subjects", () => {
         });
         cy.visit("/subjects");
         cy.url().should("include", "/subjects/");
-        cy.get("button[data-testid='user-account-button']").should("be.visible");
+        cy.get("button[data-testid='user-account-button']").should(
+            "be.visible"
+        );
         cy.get(".subject__heading").should("not.exist");
         cy.get(
             ".subj-toc__list li[data-testid=subject-toc-li-3] a"
@@ -514,7 +532,9 @@ describe("Find by Subjects", () => {
     });
 
     it("should display and fetch the correct search query on load if it is included in URL", () => {
-        cy.intercept("**/v3/content-search/?q=streamlined%20modular%20certification**").as("qFiles");
+        cy.intercept(
+            "**/v3/content-search/?q=streamlined%20modular%20certification**"
+        ).as("qFiles");
         cy.viewport("macbook-15");
         cy.eregsLogin({
             username,
@@ -525,7 +545,10 @@ describe("Find by Subjects", () => {
         cy.wait("@qFiles").then((interception) => {
             expect(interception.response.statusCode).to.eq(200);
         });
-        cy.get("input#main-content").should("have.value", "streamlined modular certification");
+        cy.get("input#main-content").should(
+            "have.value",
+            "streamlined modular certification"
+        );
         cy.get(".subject__heading").should("not.exist");
     });
 
@@ -654,5 +677,75 @@ describe("Find by Subjects", () => {
             .find("input")
             .should("not.be.checked")
             .and("be.disabled");
+    });
+});
+
+describe("Subjects Page -- Pagination", () => {
+    beforeEach(() => {
+        _beforeEach();
+        _beforePaginate();
+    });
+
+    it("Goes to the second page of results when clicking the Next button", () => {
+        cy.viewport("macbook-15");
+        cy.eregsLogin({ username, password, landingPage: "/" });
+        cy.visit("/subjects");
+        cy.get(".doc-type__toggle fieldset > div")
+            .eq(1)
+            .find("input")
+            .uncheck({ force: true });
+        cy.get(".current-page.selected").contains("1");
+        cy.get(".pagination-control.left-control > .back-btn").should(
+            "have.class",
+            "disabled"
+        );
+        cy.wait("@initialPage").then((interception) => {
+            const count = interception.response.body.count;
+            cy.get(".search-results-count").contains(`1 - 50 of ${count} documents`);
+        });
+        cy.get(".pagination-control.right-control")
+            .contains("Next")
+            .click({ force: true });
+        cy.wait("@page2").then((interception) => {
+            const count = interception.response.body.count;
+            cy.url().should("include", "page=2");
+            cy.get(".search-results-count").contains(`51 - 100 of ${count} documents`);
+            cy.get(".current-page.selected").contains("2");
+        });
+    });
+
+    it("Goes to the second page of results when clicking on page 2", () => {
+        cy.viewport("macbook-15");
+        cy.eregsLogin({ username, password, landingPage: "/" });
+        cy.visit("/subjects");
+        cy.get(".doc-type__toggle fieldset > div")
+            .eq(1)
+            .find("input")
+            .uncheck({ force: true });
+        cy.get(".current-page.selected").contains("1");
+        cy.get(".page-number-li.unselected")
+            .contains("2")
+            .click({ force: true });
+        cy.wait("@page2").then((interception) => {
+            const count = interception.response.body.count;
+            cy.url().should("include", "page=2");
+            cy.get(".search-results-count").contains(
+                `51 - 100 of ${count} documents`
+            );
+            cy.get(".current-page.selected").contains("2");
+        });
+    });
+
+    it("Goes to the second page of results on load when page=2 in the URL", () => {
+        cy.viewport("macbook-15");
+        cy.eregsLogin({ username, password, landingPage: "/" });
+        cy.visit("/subjects/?type=external&page=2");
+        cy.wait("@page2").then((interception) => {
+            const count = interception.response.body.count;
+            cy.get(".search-results-count").contains(
+                `51 - 100 of ${count} documents`
+            );
+            cy.get(".current-page.selected").contains("2");
+        });
     });
 });

--- a/solution/ui/e2e/cypress/fixtures/policy-docs-50-p1.json
+++ b/solution/ui/e2e/cypress/fixtures/policy-docs-50-p1.json
@@ -1,0 +1,8636 @@
+{
+    "count": 2967,
+    "next": "https://bvswm5lqi3.execute-api.us-east-1.amazonaws.com/dev1295/v3/content-search/?category_details=true&location_details=true&page=2&page_size=50&paginate=true&resource-type=external",
+    "previous": null,
+    "results": [
+        {
+            "doc_name_string": "89 FR 40542",
+            "file_name_string": null,
+            "date_string": "2024-05-10",
+            "summary_string": "Medicaid Program; Ensuring Access to Medicaid Services",
+            "locations": [
+                {
+                    "id": 13,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 12,
+                    "parent": 851
+                },
+                {
+                    "id": 155,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 408,
+                    "parent": 991
+                },
+                {
+                    "id": 3884,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 72,
+                    "parent": 1086
+                },
+                {
+                    "id": 392,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 301,
+                    "parent": 1149
+                },
+                {
+                    "id": 425,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": 1149
+                },
+                {
+                    "id": 426,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 303,
+                    "parent": 1149
+                },
+                {
+                    "id": 3885,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 311,
+                    "parent": 1149
+                },
+                {
+                    "id": 3886,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 312,
+                    "parent": 1149
+                },
+                {
+                    "id": 3887,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 313,
+                    "parent": 1149
+                },
+                {
+                    "id": 395,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 450,
+                    "parent": 1158
+                },
+                {
+                    "id": 432,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 464,
+                    "parent": 1158
+                },
+                {
+                    "id": 1168,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 474,
+                    "parent": 1158
+                },
+                {
+                    "id": 3888,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 486,
+                    "parent": 1158
+                },
+                {
+                    "id": 437,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 540,
+                    "parent": 1174
+                },
+                {
+                    "id": 440,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 555,
+                    "parent": 1174
+                },
+                {
+                    "id": 698,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 570,
+                    "parent": 1174
+                },
+                {
+                    "id": 699,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 580,
+                    "parent": 1174
+                },
+                {
+                    "id": 697,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 585,
+                    "parent": 1174
+                },
+                {
+                    "id": 3889,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 595,
+                    "parent": 1174
+                },
+                {
+                    "id": 442,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 725,
+                    "parent": 1177
+                },
+                {
+                    "id": 456,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 745,
+                    "parent": 1177
+                },
+                {
+                    "id": 3890,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 750,
+                    "parent": 1177
+                },
+                {
+                    "id": 470,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 203,
+                    "parent": 1198
+                },
+                {
+                    "id": 471,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 204,
+                    "parent": 1198
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/05/10/2024-08363/medicaid-program-ensuring-access-to-medicaid-services",
+            "id": 13667,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 40876",
+            "file_name_string": null,
+            "date_string": "2024-05-10",
+            "summary_string": "Medicare and Medicaid Programs; Minimum Staffing Standards for Long-Term Care Facilities and Medicaid Institutional Payment Transparency Reporting",
+            "locations": [
+                {
+                    "id": 3884,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 72,
+                    "parent": 1086
+                },
+                {
+                    "id": 3951,
+                    "title": 42,
+                    "part": 442,
+                    "type": "section",
+                    "section_id": 43,
+                    "parent": 1180
+                },
+                {
+                    "id": 1703,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 5,
+                    "parent": 7889
+                },
+                {
+                    "id": 1704,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 7889
+                },
+                {
+                    "id": 1705,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": 7889
+                },
+                {
+                    "id": 1730,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 35,
+                    "parent": 7889
+                },
+                {
+                    "id": 1731,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 40,
+                    "parent": 7889
+                },
+                {
+                    "id": 1706,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 45,
+                    "parent": 7889
+                },
+                {
+                    "id": 1732,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 55,
+                    "parent": 7889
+                },
+                {
+                    "id": 1733,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": 7889
+                },
+                {
+                    "id": 1734,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 65,
+                    "parent": 7889
+                },
+                {
+                    "id": 1708,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 70,
+                    "parent": 7889
+                },
+                {
+                    "id": 3952,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 71,
+                    "parent": 7889
+                },
+                {
+                    "id": 1709,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 75,
+                    "parent": 7889
+                },
+                {
+                    "id": 1735,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 80,
+                    "parent": 7889
+                },
+                {
+                    "id": 1736,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 95,
+                    "parent": 7889
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/05/10/2024-08273/medicare-and-medicaid-programs-minimum-staffing-standards-for-long-term-care-facilities-and-medicaid",
+            "id": 13669,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 41002",
+            "file_name_string": null,
+            "date_string": "2024-05-10",
+            "summary_string": "Medicaid Program; Medicaid and Children's Health Insurance Program (CHIP) Managed Care Access, Finance, and Quality",
+            "locations": [
+                {
+                    "id": 958,
+                    "title": 42,
+                    "part": 430,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 955
+                },
+                {
+                    "id": 348,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": 1071
+                },
+                {
+                    "id": 332,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 1071
+                },
+                {
+                    "id": 359,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 6,
+                    "parent": 1071
+                },
+                {
+                    "id": 360,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 7,
+                    "parent": 1071
+                },
+                {
+                    "id": 361,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 8,
+                    "parent": 1071
+                },
+                {
+                    "id": 329,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 1071
+                },
+                {
+                    "id": 3874,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 16,
+                    "parent": 1071
+                },
+                {
+                    "id": 334,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 66,
+                    "parent": 1086
+                },
+                {
+                    "id": 362,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 68,
+                    "parent": 1086
+                },
+                {
+                    "id": 658,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 74,
+                    "parent": 1086
+                },
+                {
+                    "id": 364,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 206,
+                    "parent": 1112
+                },
+                {
+                    "id": 365,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 207,
+                    "parent": 1112
+                },
+                {
+                    "id": 645,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 214,
+                    "parent": 1112
+                },
+                {
+                    "id": 372,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 310,
+                    "parent": 1116
+                },
+                {
+                    "id": 373,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 1116
+                },
+                {
+                    "id": 375,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 334,
+                    "parent": 1116
+                },
+                {
+                    "id": 376,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 340,
+                    "parent": 1116
+                },
+                {
+                    "id": 352,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 350,
+                    "parent": 1116
+                },
+                {
+                    "id": 638,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 354,
+                    "parent": 1116
+                },
+                {
+                    "id": 639,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 358,
+                    "parent": 1116
+                },
+                {
+                    "id": 659,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 360,
+                    "parent": 1116
+                },
+                {
+                    "id": 644,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 362,
+                    "parent": 1116
+                },
+                {
+                    "id": 640,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 364,
+                    "parent": 1116
+                },
+                {
+                    "id": 3876,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 500,
+                    "parent": 1118
+                },
+                {
+                    "id": 3877,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 505,
+                    "parent": 1118
+                },
+                {
+                    "id": 3878,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 510,
+                    "parent": 1118
+                },
+                {
+                    "id": 3879,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 515,
+                    "parent": 1118
+                },
+                {
+                    "id": 3880,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 520,
+                    "parent": 1118
+                },
+                {
+                    "id": 3881,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 525,
+                    "parent": 1118
+                },
+                {
+                    "id": 3882,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 530,
+                    "parent": 1118
+                },
+                {
+                    "id": 3883,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 535,
+                    "parent": 1118
+                },
+                {
+                    "id": 719,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 602,
+                    "parent": 858
+                },
+                {
+                    "id": 661,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 608,
+                    "parent": 858
+                },
+                {
+                    "id": 554,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 1361
+                },
+                {
+                    "id": 559,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1200,
+                    "parent": 1407
+                },
+                {
+                    "id": 173,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1201,
+                    "parent": 1407
+                },
+                {
+                    "id": 174,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1203,
+                    "parent": 1407
+                },
+                {
+                    "id": 175,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1207,
+                    "parent": 1407
+                },
+                {
+                    "id": 576,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1230,
+                    "parent": 1407
+                },
+                {
+                    "id": 598,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1240,
+                    "parent": 1407
+                },
+                {
+                    "id": 599,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1250,
+                    "parent": 1407
+                },
+                {
+                    "id": 751,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1285,
+                    "parent": 1407
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/05/10/2024-08085/medicaid-program-medicaid-and-childrens-health-insurance-program-chip-managed-care-access-finance",
+            "id": 13668,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 39392",
+            "file_name_string": null,
+            "date_string": "2024-05-08",
+            "summary_string": "Clarifying the Eligibility of Deferred Action for Childhood Arrivals (DACA) Recipients and Certain Other Noncitizens for a Qualified Health Plan through an Exchange, Advance Payments of the Premium Tax Credit, Cost-Sharing Reductions, and a Basic Health Program",
+            "locations": [
+                {
+                    "id": 241,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": 1046
+                },
+                {
+                    "id": 113,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 406,
+                    "parent": 1499
+                },
+                {
+                    "id": 548,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 320,
+                    "parent": 1376
+                },
+                {
+                    "id": 3056,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 5,
+                    "parent": 3103
+                },
+                {
+                    "id": 3865,
+                    "title": 45,
+                    "part": 152,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": null
+                },
+                {
+                    "id": 1572,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 20,
+                    "parent": 3308
+                },
+                {
+                    "id": 3866,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 30,
+                    "parent": 3308
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/05/08/2024-09661/clarifying-the-eligibility-of-deferred-action-for-childhood-arrivals-daca-recipients-and-certain",
+            "id": 13657,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 37522",
+            "file_name_string": null,
+            "date_string": "2024-05-06",
+            "summary_string": "Nondiscrimination in Health Programs and Activities",
+            "locations": [
+                {
+                    "id": 332,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 1071
+                },
+                {
+                    "id": 364,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 206,
+                    "parent": 1112
+                },
+                {
+                    "id": 763,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 262,
+                    "parent": 1125
+                },
+                {
+                    "id": 575,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 495,
+                    "parent": 1377
+                },
+                {
+                    "id": 1450,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 98,
+                    "parent": 1446
+                },
+                {
+                    "id": 1457,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 112,
+                    "parent": 1455
+                },
+                {
+                    "id": 1914,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 1,
+                    "parent": null
+                },
+                {
+                    "id": 1915,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": null
+                },
+                {
+                    "id": 1916,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": null
+                },
+                {
+                    "id": 1917,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": null
+                },
+                {
+                    "id": 1918,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 5,
+                    "parent": null
+                },
+                {
+                    "id": 1919,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 6,
+                    "parent": null
+                },
+                {
+                    "id": 3022,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 7,
+                    "parent": null
+                },
+                {
+                    "id": 3023,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 8,
+                    "parent": null
+                },
+                {
+                    "id": 3024,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 9,
+                    "parent": null
+                },
+                {
+                    "id": 3025,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": null
+                },
+                {
+                    "id": 3026,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 11,
+                    "parent": null
+                },
+                {
+                    "id": 1920,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 101,
+                    "parent": null
+                },
+                {
+                    "id": 3028,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 201,
+                    "parent": null
+                },
+                {
+                    "id": 3029,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 202,
+                    "parent": null
+                },
+                {
+                    "id": 3030,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 203,
+                    "parent": null
+                },
+                {
+                    "id": 3031,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 204,
+                    "parent": null
+                },
+                {
+                    "id": 3032,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 205,
+                    "parent": null
+                },
+                {
+                    "id": 3033,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 206,
+                    "parent": null
+                },
+                {
+                    "id": 3034,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 207,
+                    "parent": null
+                },
+                {
+                    "id": 3035,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 208,
+                    "parent": null
+                },
+                {
+                    "id": 3036,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 209,
+                    "parent": null
+                },
+                {
+                    "id": 3037,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 210,
+                    "parent": null
+                },
+                {
+                    "id": 3038,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 211,
+                    "parent": null
+                },
+                {
+                    "id": 3039,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 301,
+                    "parent": null
+                },
+                {
+                    "id": 3040,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": null
+                },
+                {
+                    "id": 3041,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 303,
+                    "parent": null
+                },
+                {
+                    "id": 3042,
+                    "title": 45,
+                    "part": 92,
+                    "type": "section",
+                    "section_id": 304,
+                    "parent": null
+                },
+                {
+                    "id": 1925,
+                    "title": 45,
+                    "part": 147,
+                    "type": "section",
+                    "section_id": 104,
+                    "parent": null
+                },
+                {
+                    "id": 1926,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 120,
+                    "parent": 3310
+                },
+                {
+                    "id": 1927,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 220,
+                    "parent": 3322
+                },
+                {
+                    "id": 1928,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 200,
+                    "parent": 3831
+                },
+                {
+                    "id": 1929,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 1230,
+                    "parent": 3950
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/05/06/2024-08711/nondiscrimination-in-health-programs-and-activities",
+            "id": 13653,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 35934",
+            "file_name_string": null,
+            "date_string": "2024-05-02",
+            "summary_string": "Medicare and Medicaid Programs and the Children's Health Insurance Program; Hospital Inpatient Prospective Payment Systems for Acute Care Hospitals and the Long-Term Care Hospital Prospective Payment System and Policy Changes and Fiscal Year 2025 Rates; Quality Programs Requirements; and Other Policy Changes",
+            "locations": [
+                {
+                    "id": 7991,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 1845,
+                    "parent": null
+                },
+                {
+                    "id": 2304,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 1,
+                    "parent": null
+                },
+                {
+                    "id": 2133,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": null
+                },
+                {
+                    "id": 2135,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 23,
+                    "parent": null
+                },
+                {
+                    "id": 2849,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 88,
+                    "parent": null
+                },
+                {
+                    "id": 2325,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 90,
+                    "parent": null
+                },
+                {
+                    "id": 2306,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 96,
+                    "parent": null
+                },
+                {
+                    "id": 2142,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 101,
+                    "parent": null
+                },
+                {
+                    "id": 2307,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 103,
+                    "parent": null
+                },
+                {
+                    "id": 2851,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 104,
+                    "parent": null
+                },
+                {
+                    "id": 2059,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 105,
+                    "parent": null
+                },
+                {
+                    "id": 2143,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 106,
+                    "parent": null
+                },
+                {
+                    "id": 2144,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 108,
+                    "parent": null
+                },
+                {
+                    "id": 2145,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 113,
+                    "parent": null
+                },
+                {
+                    "id": 2308,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 140,
+                    "parent": null
+                },
+                {
+                    "id": 2147,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 230,
+                    "parent": null
+                },
+                {
+                    "id": 2150,
+                    "title": 42,
+                    "part": 412,
+                    "type": "section",
+                    "section_id": 273,
+                    "parent": null
+                },
+                {
+                    "id": 2163,
+                    "title": 42,
+                    "part": 413,
+                    "type": "section",
+                    "section_id": 75,
+                    "parent": null
+                },
+                {
+                    "id": 2062,
+                    "title": 42,
+                    "part": 413,
+                    "type": "section",
+                    "section_id": 78,
+                    "parent": null
+                },
+                {
+                    "id": 2330,
+                    "title": 42,
+                    "part": 413,
+                    "type": "section",
+                    "section_id": 79,
+                    "parent": null
+                },
+                {
+                    "id": 185,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 954,
+                    "parent": 854
+                },
+                {
+                    "id": 2182,
+                    "title": 42,
+                    "part": 482,
+                    "type": "section",
+                    "section_id": 42,
+                    "parent": null
+                },
+                {
+                    "id": 2187,
+                    "title": 42,
+                    "part": 485,
+                    "type": "section",
+                    "section_id": 640,
+                    "parent": null
+                },
+                {
+                    "id": 2319,
+                    "title": 42,
+                    "part": 495,
+                    "type": "section",
+                    "section_id": 24,
+                    "parent": null
+                },
+                {
+                    "id": 7992,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 500,
+                    "parent": null
+                },
+                {
+                    "id": 7993,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 505,
+                    "parent": null
+                },
+                {
+                    "id": 7994,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 515,
+                    "parent": null
+                },
+                {
+                    "id": 7995,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 520,
+                    "parent": null
+                },
+                {
+                    "id": 7996,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 522,
+                    "parent": null
+                },
+                {
+                    "id": 7997,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 525,
+                    "parent": null
+                },
+                {
+                    "id": 7998,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 535,
+                    "parent": null
+                },
+                {
+                    "id": 7999,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 537,
+                    "parent": null
+                },
+                {
+                    "id": 8000,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 540,
+                    "parent": null
+                },
+                {
+                    "id": 8001,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 545,
+                    "parent": null
+                },
+                {
+                    "id": 8002,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 547,
+                    "parent": null
+                },
+                {
+                    "id": 8003,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 550,
+                    "parent": null
+                },
+                {
+                    "id": 8004,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 552,
+                    "parent": null
+                },
+                {
+                    "id": 8005,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 555,
+                    "parent": null
+                },
+                {
+                    "id": 8006,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 560,
+                    "parent": null
+                },
+                {
+                    "id": 8007,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 561,
+                    "parent": null
+                },
+                {
+                    "id": 8008,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 562,
+                    "parent": null
+                },
+                {
+                    "id": 8009,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 563,
+                    "parent": null
+                },
+                {
+                    "id": 8010,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 564,
+                    "parent": null
+                },
+                {
+                    "id": 8011,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 565,
+                    "parent": null
+                },
+                {
+                    "id": 8012,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 568,
+                    "parent": null
+                },
+                {
+                    "id": 8013,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 570,
+                    "parent": null
+                },
+                {
+                    "id": 8014,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 575,
+                    "parent": null
+                },
+                {
+                    "id": 8015,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 576,
+                    "parent": null
+                },
+                {
+                    "id": 8016,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 580,
+                    "parent": null
+                },
+                {
+                    "id": 8017,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 582,
+                    "parent": null
+                },
+                {
+                    "id": 8018,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 584,
+                    "parent": null
+                },
+                {
+                    "id": 8019,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 586,
+                    "parent": null
+                },
+                {
+                    "id": 8020,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 588,
+                    "parent": null
+                },
+                {
+                    "id": 8021,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 590,
+                    "parent": null
+                },
+                {
+                    "id": 8022,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 592,
+                    "parent": null
+                },
+                {
+                    "id": 8023,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 594,
+                    "parent": null
+                },
+                {
+                    "id": 8024,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 595,
+                    "parent": null
+                },
+                {
+                    "id": 8025,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 596,
+                    "parent": null
+                },
+                {
+                    "id": 8026,
+                    "title": 42,
+                    "part": 512,
+                    "type": "section",
+                    "section_id": 598,
+                    "parent": null
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/05/02/2024-07567/medicare-and-medicaid-programs-and-the-childrens-health-insurance-program-hospital-inpatient",
+            "id": 13647,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-04-25",
+            "summary_string": "Identifying Deceased Medicaid Enrollees",
+            "locations": [
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 102,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 945,
+                    "parent": 888
+                },
+                {
+                    "id": 105,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 952,
+                    "parent": 888
+                },
+                {
+                    "id": 577,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 343,
+                    "parent": 1376
+                },
+                {
+                    "id": 171,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 380,
+                    "parent": 1376
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 235,
+                    "full_name": "Program Integrity",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 239,
+                    "full_name": "Eligibility Verification",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 5,
+                "name": "Subregulatory Guidance",
+                "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                "order": 400,
+                "show_if_empty": true,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.medicaid.gov/media/176086",
+            "id": 13607,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 30448",
+            "file_name_string": null,
+            "date_string": "2024-04-23",
+            "summary_string": "Medicare Program; Changes to the Medicare Advantage and the Medicare Prescription Drug Benefit Program for Contract Year 2024-Remaining Provisions and Contract Year 2025 Policy and Technical Changes to the Medicare Advantage Program, Medicare Prescription Drug Benefit Program, Medicare Cost Plan Program, and Programs of All-Inclusive Care for the Elderly (PACE)",
+            "locations": [
+                {
+                    "id": 3210,
+                    "title": 42,
+                    "part": 417,
+                    "type": "section",
+                    "section_id": 460,
+                    "parent": null
+                },
+                {
+                    "id": 2091,
+                    "title": 42,
+                    "part": 417,
+                    "type": "section",
+                    "section_id": 472,
+                    "parent": null
+                },
+                {
+                    "id": 1936,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": null
+                },
+                {
+                    "id": 3211,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": null
+                },
+                {
+                    "id": 2401,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 52,
+                    "parent": null
+                },
+                {
+                    "id": 1937,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": null
+                },
+                {
+                    "id": 2402,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 62,
+                    "parent": null
+                },
+                {
+                    "id": 2755,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 66,
+                    "parent": null
+                },
+                {
+                    "id": 2403,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 68,
+                    "parent": null
+                },
+                {
+                    "id": 3212,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 74,
+                    "parent": null
+                },
+                {
+                    "id": 1938,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 100,
+                    "parent": null
+                },
+                {
+                    "id": 2321,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 101,
+                    "parent": null
+                },
+                {
+                    "id": 1939,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 102,
+                    "parent": null
+                },
+                {
+                    "id": 1940,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 111,
+                    "parent": null
+                },
+                {
+                    "id": 3215,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 114,
+                    "parent": null
+                },
+                {
+                    "id": 2406,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 116,
+                    "parent": null
+                },
+                {
+                    "id": 7876,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 125,
+                    "parent": null
+                },
+                {
+                    "id": 3216,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 137,
+                    "parent": null
+                },
+                {
+                    "id": 1944,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 164,
+                    "parent": null
+                },
+                {
+                    "id": 1945,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 166,
+                    "parent": null
+                },
+                {
+                    "id": 1948,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 254,
+                    "parent": null
+                },
+                {
+                    "id": 2761,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 260,
+                    "parent": null
+                },
+                {
+                    "id": 1969,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 310,
+                    "parent": null
+                },
+                {
+                    "id": 1970,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 311,
+                    "parent": null
+                },
+                {
+                    "id": 2345,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 500,
+                    "parent": null
+                },
+                {
+                    "id": 2346,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 502,
+                    "parent": null
+                },
+                {
+                    "id": 2347,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 503,
+                    "parent": null
+                },
+                {
+                    "id": 1672,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 504,
+                    "parent": null
+                },
+                {
+                    "id": 2765,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 510,
+                    "parent": null
+                },
+                {
+                    "id": 2410,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 514,
+                    "parent": null
+                },
+                {
+                    "id": 7877,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 516,
+                    "parent": null
+                },
+                {
+                    "id": 3220,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 528,
+                    "parent": null
+                },
+                {
+                    "id": 3221,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 529,
+                    "parent": null
+                },
+                {
+                    "id": 2348,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 530,
+                    "parent": null
+                },
+                {
+                    "id": 2349,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 550,
+                    "parent": null
+                },
+                {
+                    "id": 2352,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 582,
+                    "parent": null
+                },
+                {
+                    "id": 2353,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 584,
+                    "parent": null
+                },
+                {
+                    "id": 7878,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 626,
+                    "parent": null
+                },
+                {
+                    "id": 1934,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 633,
+                    "parent": null
+                },
+                {
+                    "id": 2322,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 760,
+                    "parent": null
+                },
+                {
+                    "id": 2364,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 2267,
+                    "parent": null
+                },
+                {
+                    "id": 2366,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 2274,
+                    "parent": null
+                },
+                {
+                    "id": 2367,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": null
+                },
+                {
+                    "id": 2522,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 32,
+                    "parent": null
+                },
+                {
+                    "id": 2524,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 36,
+                    "parent": null
+                },
+                {
+                    "id": 2413,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 38,
+                    "parent": null
+                },
+                {
+                    "id": 2414,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 40,
+                    "parent": null
+                },
+                {
+                    "id": 2525,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 44,
+                    "parent": null
+                },
+                {
+                    "id": 1958,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 100,
+                    "parent": null
+                },
+                {
+                    "id": 2368,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 104,
+                    "parent": null
+                },
+                {
+                    "id": 1935,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 120,
+                    "parent": null
+                },
+                {
+                    "id": 2369,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 128,
+                    "parent": null
+                },
+                {
+                    "id": 7879,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 129,
+                    "parent": null
+                },
+                {
+                    "id": 2534,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 150,
+                    "parent": null
+                },
+                {
+                    "id": 1959,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 153,
+                    "parent": null
+                },
+                {
+                    "id": 2537,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 165,
+                    "parent": null
+                },
+                {
+                    "id": 1961,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 184,
+                    "parent": null
+                },
+                {
+                    "id": 1962,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 186,
+                    "parent": null
+                },
+                {
+                    "id": 2370,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 265,
+                    "parent": null
+                },
+                {
+                    "id": 2544,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 293,
+                    "parent": null
+                },
+                {
+                    "id": 3223,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 294,
+                    "parent": null
+                },
+                {
+                    "id": 2546,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 308,
+                    "parent": null
+                },
+                {
+                    "id": 2551,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 346,
+                    "parent": null
+                },
+                {
+                    "id": 2565,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 501,
+                    "parent": null
+                },
+                {
+                    "id": 2372,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 503,
+                    "parent": null
+                },
+                {
+                    "id": 2374,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 505,
+                    "parent": null
+                },
+                {
+                    "id": 2567,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 507,
+                    "parent": null
+                },
+                {
+                    "id": 2568,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 508,
+                    "parent": null
+                },
+                {
+                    "id": 2569,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 509,
+                    "parent": null
+                },
+                {
+                    "id": 2375,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 514,
+                    "parent": null
+                },
+                {
+                    "id": 3225,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 521,
+                    "parent": null
+                },
+                {
+                    "id": 3226,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 522,
+                    "parent": null
+                },
+                {
+                    "id": 3227,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 530,
+                    "parent": null
+                },
+                {
+                    "id": 2376,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 551,
+                    "parent": null
+                },
+                {
+                    "id": 2575,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 562,
+                    "parent": null
+                },
+                {
+                    "id": 2379,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 578,
+                    "parent": null
+                },
+                {
+                    "id": 2380,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 582,
+                    "parent": null
+                },
+                {
+                    "id": 2381,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 584,
+                    "parent": null
+                },
+                {
+                    "id": 2383,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 600,
+                    "parent": null
+                },
+                {
+                    "id": 2384,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 760,
+                    "parent": null
+                },
+                {
+                    "id": 2323,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 2267,
+                    "parent": null
+                },
+                {
+                    "id": 2396,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 2274,
+                    "parent": null
+                },
+                {
+                    "id": 621,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 12,
+                    "parent": 1414
+                },
+                {
+                    "id": 1415,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 18,
+                    "parent": 1414
+                },
+                {
+                    "id": 3237,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 19,
+                    "parent": 1414
+                },
+                {
+                    "id": 1416,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 20,
+                    "parent": 1414
+                },
+                {
+                    "id": 1435,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 64,
+                    "parent": 1432
+                },
+                {
+                    "id": 1438,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 71,
+                    "parent": 1432
+                },
+                {
+                    "id": 1450,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 98,
+                    "parent": 1446
+                },
+                {
+                    "id": 1452,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 102,
+                    "parent": 1446
+                },
+                {
+                    "id": 1453,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 104,
+                    "parent": 1446
+                },
+                {
+                    "id": 1454,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 106,
+                    "parent": 1446
+                },
+                {
+                    "id": 1457,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 112,
+                    "parent": 1455
+                },
+                {
+                    "id": 7880,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 119,
+                    "parent": 1455
+                },
+                {
+                    "id": 1461,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 120,
+                    "parent": 1455
+                },
+                {
+                    "id": 1462,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 121,
+                    "parent": 1455
+                },
+                {
+                    "id": 1489,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 194,
+                    "parent": 1486
+                },
+                {
+                    "id": 3238,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 198,
+                    "parent": 1486
+                },
+                {
+                    "id": 1493,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 202,
+                    "parent": 1491
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 384,
+                    "full_name": "Programs of All-Inclusive Care for the Elderly",
+                    "short_name": null,
+                    "abbreviation": "PACE"
+                },
+                {
+                    "id": 450,
+                    "full_name": "Low-income Subsidy",
+                    "short_name": null,
+                    "abbreviation": "LIS"
+                },
+                {
+                    "id": 389,
+                    "full_name": "Dual Eligibles",
+                    "short_name": "Duals",
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/04/23/2024-07105/medicare-program-changes-to-the-medicare-advantage-and-the-medicare-prescription-drug-benefit",
+            "id": 13378,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Fact Sheet",
+            "file_name_string": null,
+            "date_string": "2024-04-22",
+            "summary_string": "Medicare and Medicaid Programs: Minimum Staffing Standards for Long-Term Care Facilities and Medicaid Institutional Payment Transparency Reporting Final Rule (CMS 3442-F)",
+            "locations": [
+                {
+                    "id": 3884,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 72,
+                    "parent": 1086
+                },
+                {
+                    "id": 3951,
+                    "title": 42,
+                    "part": 442,
+                    "type": "section",
+                    "section_id": 43,
+                    "parent": 1180
+                },
+                {
+                    "id": 1703,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 5,
+                    "parent": 7889
+                },
+                {
+                    "id": 1704,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 7889
+                },
+                {
+                    "id": 1705,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": 7889
+                },
+                {
+                    "id": 1730,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 35,
+                    "parent": 7889
+                },
+                {
+                    "id": 1731,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 40,
+                    "parent": 7889
+                },
+                {
+                    "id": 1706,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 45,
+                    "parent": 7889
+                },
+                {
+                    "id": 1732,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 55,
+                    "parent": 7889
+                },
+                {
+                    "id": 1733,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": 7889
+                },
+                {
+                    "id": 1734,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 65,
+                    "parent": 7889
+                },
+                {
+                    "id": 1708,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 70,
+                    "parent": 7889
+                },
+                {
+                    "id": 3952,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 71,
+                    "parent": 7889
+                },
+                {
+                    "id": 1709,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 75,
+                    "parent": 7889
+                },
+                {
+                    "id": 1735,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 80,
+                    "parent": 7889
+                },
+                {
+                    "id": 1736,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 95,
+                    "parent": 7889
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 393,
+                    "full_name": "Direct Support Workforce",
+                    "short_name": null,
+                    "abbreviation": "DSW"
+                },
+                {
+                    "id": 458,
+                    "full_name": "Reports and Evaluations",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 143,
+                    "full_name": "Institutional and Nursing Facility Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 115,
+                    "full_name": "Provider Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 53,
+                    "full_name": "Intermediate Care Facilities for Individuals with Intellectual Disabilities",
+                    "short_name": null,
+                    "abbreviation": "ICF IID"
+                },
+                {
+                    "id": 408,
+                    "full_name": "Workforce Recruitment and Retention",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 61,
+                    "full_name": "Long-Term Services and Supports",
+                    "short_name": null,
+                    "abbreviation": "LTSS"
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.cms.gov/newsroom/fact-sheets/medicare-and-medicaid-programs-minimum-staffing-standards-long-term-care-facilities-and-medicaid-0",
+            "id": 13301,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Fact Sheet",
+            "file_name_string": null,
+            "date_string": "2024-04-22",
+            "summary_string": "Ensuring Access to Medicaid Services Final Rule (CMS-2442-F)",
+            "locations": [
+                {
+                    "id": 2815,
+                    "title": 42,
+                    "part": 3,
+                    "type": "section",
+                    "section_id": 404,
+                    "parent": null
+                },
+                {
+                    "id": 13,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 12,
+                    "parent": 851
+                },
+                {
+                    "id": 155,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 408,
+                    "parent": 991
+                },
+                {
+                    "id": 3884,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 72,
+                    "parent": 1086
+                },
+                {
+                    "id": 392,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 301,
+                    "parent": 1149
+                },
+                {
+                    "id": 425,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": 1149
+                },
+                {
+                    "id": 426,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 303,
+                    "parent": 1149
+                },
+                {
+                    "id": 3885,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 311,
+                    "parent": 1149
+                },
+                {
+                    "id": 3886,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 312,
+                    "parent": 1149
+                },
+                {
+                    "id": 3887,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 313,
+                    "parent": 1149
+                },
+                {
+                    "id": 395,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 450,
+                    "parent": 1158
+                },
+                {
+                    "id": 432,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 464,
+                    "parent": 1158
+                },
+                {
+                    "id": 1168,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 474,
+                    "parent": 1158
+                },
+                {
+                    "id": 3888,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 486,
+                    "parent": 1158
+                },
+                {
+                    "id": 437,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 540,
+                    "parent": 1174
+                },
+                {
+                    "id": 440,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 555,
+                    "parent": 1174
+                },
+                {
+                    "id": 698,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 570,
+                    "parent": 1174
+                },
+                {
+                    "id": 699,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 580,
+                    "parent": 1174
+                },
+                {
+                    "id": 697,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 585,
+                    "parent": 1174
+                },
+                {
+                    "id": 3889,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 595,
+                    "parent": 1174
+                },
+                {
+                    "id": 442,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 725,
+                    "parent": 1177
+                },
+                {
+                    "id": 456,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 745,
+                    "parent": 1177
+                },
+                {
+                    "id": 3890,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 750,
+                    "parent": 1177
+                },
+                {
+                    "id": 470,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 203,
+                    "parent": 1198
+                },
+                {
+                    "id": 471,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 204,
+                    "parent": 1198
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 3,
+                    "full_name": "Access to Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 295,
+                    "full_name": "Primary Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 393,
+                    "full_name": "Direct Support Workforce",
+                    "short_name": null,
+                    "abbreviation": "DSW"
+                },
+                {
+                    "id": 458,
+                    "full_name": "Reports and Evaluations",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 331,
+                    "full_name": "Person-centered Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 461,
+                    "full_name": "Authorized Representative",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 109,
+                    "full_name": "Public Notice and Tribal Consultation",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 499,
+                    "full_name": "Community Engagement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 115,
+                    "full_name": "Provider Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.cms.gov/newsroom/fact-sheets/ensuring-access-medicaid-services-final-rule-cms-2442-f",
+            "id": 13303,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Fact Sheet",
+            "file_name_string": null,
+            "date_string": "2024-04-22",
+            "summary_string": "Medicaid and Children’s Health Insurance Program Managed Care Access, Finance, and Quality Final Rule (CMS-2439-F)",
+            "locations": [
+                {
+                    "id": 958,
+                    "title": 42,
+                    "part": 430,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 955
+                },
+                {
+                    "id": 348,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": 1071
+                },
+                {
+                    "id": 332,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 1071
+                },
+                {
+                    "id": 359,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 6,
+                    "parent": 1071
+                },
+                {
+                    "id": 360,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 7,
+                    "parent": 1071
+                },
+                {
+                    "id": 361,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 8,
+                    "parent": 1071
+                },
+                {
+                    "id": 329,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 1071
+                },
+                {
+                    "id": 3874,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 16,
+                    "parent": 1071
+                },
+                {
+                    "id": 334,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 66,
+                    "parent": 1086
+                },
+                {
+                    "id": 362,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 68,
+                    "parent": 1086
+                },
+                {
+                    "id": 658,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 74,
+                    "parent": 1086
+                },
+                {
+                    "id": 364,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 206,
+                    "parent": 1112
+                },
+                {
+                    "id": 365,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 207,
+                    "parent": 1112
+                },
+                {
+                    "id": 645,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 214,
+                    "parent": 1112
+                },
+                {
+                    "id": 372,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 310,
+                    "parent": 1116
+                },
+                {
+                    "id": 373,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 1116
+                },
+                {
+                    "id": 375,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 334,
+                    "parent": 1116
+                },
+                {
+                    "id": 376,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 340,
+                    "parent": 1116
+                },
+                {
+                    "id": 352,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 350,
+                    "parent": 1116
+                },
+                {
+                    "id": 638,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 354,
+                    "parent": 1116
+                },
+                {
+                    "id": 639,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 358,
+                    "parent": 1116
+                },
+                {
+                    "id": 659,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 360,
+                    "parent": 1116
+                },
+                {
+                    "id": 644,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 362,
+                    "parent": 1116
+                },
+                {
+                    "id": 640,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 364,
+                    "parent": 1116
+                },
+                {
+                    "id": 3876,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 500,
+                    "parent": 1118
+                },
+                {
+                    "id": 3877,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 505,
+                    "parent": 1118
+                },
+                {
+                    "id": 3878,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 510,
+                    "parent": 1118
+                },
+                {
+                    "id": 3879,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 515,
+                    "parent": 1118
+                },
+                {
+                    "id": 3880,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 520,
+                    "parent": 1118
+                },
+                {
+                    "id": 3881,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 525,
+                    "parent": 1118
+                },
+                {
+                    "id": 3882,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 530,
+                    "parent": 1118
+                },
+                {
+                    "id": 3883,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 535,
+                    "parent": 1118
+                },
+                {
+                    "id": 719,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 602,
+                    "parent": 858
+                },
+                {
+                    "id": 661,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 608,
+                    "parent": 858
+                },
+                {
+                    "id": 554,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 1361
+                },
+                {
+                    "id": 559,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1200,
+                    "parent": 1407
+                },
+                {
+                    "id": 173,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1201,
+                    "parent": 1407
+                },
+                {
+                    "id": 174,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1203,
+                    "parent": 1407
+                },
+                {
+                    "id": 175,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1207,
+                    "parent": 1407
+                },
+                {
+                    "id": 636,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1218,
+                    "parent": 1407
+                },
+                {
+                    "id": 576,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1230,
+                    "parent": 1407
+                },
+                {
+                    "id": 598,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1240,
+                    "parent": 1407
+                },
+                {
+                    "id": 599,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1250,
+                    "parent": 1407
+                },
+                {
+                    "id": 751,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1285,
+                    "parent": 1407
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 3,
+                    "full_name": "Access to Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 356,
+                    "full_name": "Social Determinants of Health",
+                    "short_name": null,
+                    "abbreviation": "SDOH"
+                },
+                {
+                    "id": 357,
+                    "full_name": "In Lieu of Services and Settings",
+                    "short_name": null,
+                    "abbreviation": "ILOS"
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 424,
+                    "full_name": "State Financial Share",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 199,
+                    "full_name": "State Directed Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 325,
+                    "full_name": "Budget and Expenditures",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 235,
+                    "full_name": "Program Integrity",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 335,
+                    "full_name": "Network Adequacy",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 338,
+                    "full_name": "Encounter Data",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 343,
+                    "full_name": "Transformed Medicaid Statistical Information System",
+                    "short_name": null,
+                    "abbreviation": "T-MSIS"
+                },
+                {
+                    "id": 61,
+                    "full_name": "Long-Term Services and Supports",
+                    "short_name": null,
+                    "abbreviation": "LTSS"
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.cms.gov/newsroom/fact-sheets/medicaid-and-childrens-health-insurance-program-managed-care-access-finance-and-quality-final-rule",
+            "id": 13304,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-04-22",
+            "summary_string": "Exercise of Enforcement Discretion until Calendar Year 2028 for Existing Health Care-Related Tax Programs with Hold Harmless Arrangements Involving the Redistribution of Medicaid Payments",
+            "locations": [
+                {
+                    "id": 226,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 68,
+                    "parent": 1029
+                },
+                {
+                    "id": 359,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 6,
+                    "parent": 1071
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 424,
+                    "full_name": "State Financial Share",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 199,
+                    "full_name": "State Directed Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/cib042224.pdf",
+            "id": 13606,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 26218",
+            "file_name_string": null,
+            "date_string": "2024-04-15",
+            "summary_string": "Patient Protection and Affordable Care Act, HHS Notice of Benefit and Payment Parameters for 2025; Updating Section 1332 Waiver Public Notice Procedures; Medicaid; Consumer Operated and Oriented Plan (CO-OP) Program; and Basic Health Program",
+            "locations": [
+                {
+                    "id": 3077,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 320,
+                    "parent": 3106
+                },
+                {
+                    "id": 3629,
+                    "title": 45,
+                    "part": 153,
+                    "type": "section",
+                    "section_id": 620,
+                    "parent": null
+                },
+                {
+                    "id": 1573,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 105,
+                    "parent": 3310
+                },
+                {
+                    "id": 3312,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 106,
+                    "parent": 3310
+                },
+                {
+                    "id": 3321,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 170,
+                    "parent": 3310
+                },
+                {
+                    "id": 1575,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 205,
+                    "parent": 3322
+                },
+                {
+                    "id": 1927,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 220,
+                    "parent": 3322
+                },
+                {
+                    "id": 3333,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 221,
+                    "parent": 3322
+                },
+                {
+                    "id": 1580,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": 3351
+                },
+                {
+                    "id": 1581,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 305,
+                    "parent": 3351
+                },
+                {
+                    "id": 1583,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 315,
+                    "parent": 3351
+                },
+                {
+                    "id": 1584,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 320,
+                    "parent": 3351
+                },
+                {
+                    "id": 1585,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 3351
+                },
+                {
+                    "id": 1586,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 335,
+                    "parent": 3351
+                },
+                {
+                    "id": 1590,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 400,
+                    "parent": 3373
+                },
+                {
+                    "id": 3379,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 410,
+                    "parent": 3373
+                },
+                {
+                    "id": 1591,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 420,
+                    "parent": 3373
+                },
+                {
+                    "id": 1592,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 430,
+                    "parent": 3373
+                },
+                {
+                    "id": 3492,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 1050,
+                    "parent": 3473
+                },
+                {
+                    "id": 3528,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 1312,
+                    "parent": 3515
+                },
+                {
+                    "id": 1847,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 1320,
+                    "parent": 3515
+                },
+                {
+                    "id": 3600,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 111,
+                    "parent": 3830
+                },
+                {
+                    "id": 3601,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 115,
+                    "parent": 3830
+                },
+                {
+                    "id": 3662,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 122,
+                    "parent": 3830
+                },
+                {
+                    "id": 3590,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 202,
+                    "parent": 3831
+                },
+                {
+                    "id": 3806,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 520,
+                    "parent": 3834
+                },
+                {
+                    "id": 3642,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 1215,
+                    "parent": 3950
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 193,
+                    "full_name": "Non-MAGI Eligibility",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 365,
+                    "full_name": "Basic Health Program",
+                    "short_name": null,
+                    "abbreviation": "BHP"
+                },
+                {
+                    "id": 367,
+                    "full_name": "State-based Exchange",
+                    "short_name": null,
+                    "abbreviation": "SBE"
+                },
+                {
+                    "id": 20,
+                    "full_name": "Comparability",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 157,
+                    "full_name": "Essential Health Benefit",
+                    "short_name": null,
+                    "abbreviation": "EHB"
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/04/15/2024-07274/patient-protection-and-affordable-care-act-hhs-notice-of-benefit-and-payment-parameters-for-2025",
+            "id": 13089,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-04-11",
+            "summary_string": "2024 Home and Community-Based Services (HCBS) Quality Measure Set (QMS)",
+            "locations": [
+                {
+                    "id": 425,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": 1149
+                },
+                {
+                    "id": 426,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 303,
+                    "parent": 1149
+                },
+                {
+                    "id": 446,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 353,
+                    "parent": 1150
+                },
+                {
+                    "id": 704,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 365,
+                    "parent": 1150
+                },
+                {
+                    "id": 1157,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 404,
+                    "parent": 1154
+                },
+                {
+                    "id": 1168,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 474,
+                    "parent": 1158
+                },
+                {
+                    "id": 697,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 585,
+                    "parent": 1174
+                },
+                {
+                    "id": 456,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 745,
+                    "parent": 1177
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/cib041124.pdf",
+            "id": 12673,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-04-11",
+            "summary_string": "Home and Community-Based Services (HCBS) Quality Measure Set (QMS) Reporting Requirements for Money Follows the Person (MFP) Demonstration Grant Recipients",
+            "locations": [
+                {
+                    "id": 373,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 1116
+                },
+                {
+                    "id": 425,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": 1149
+                },
+                {
+                    "id": 426,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 303,
+                    "parent": 1149
+                },
+                {
+                    "id": 446,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 353,
+                    "parent": 1150
+                },
+                {
+                    "id": 704,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 365,
+                    "parent": 1150
+                },
+                {
+                    "id": 1157,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 404,
+                    "parent": 1154
+                },
+                {
+                    "id": 1168,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 474,
+                    "parent": 1158
+                },
+                {
+                    "id": 697,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 585,
+                    "parent": 1174
+                },
+                {
+                    "id": 456,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 745,
+                    "parent": 1177
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 61,
+                    "full_name": "Long-Term Services and Supports",
+                    "short_name": null,
+                    "abbreviation": "LTSS"
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/cib04112024.pdf",
+            "id": 12677,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-04-05",
+            "summary_string": "Medicaid School-Based Services",
+            "locations": [
+                {
+                    "id": 203,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": 1026
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 83,
+                    "full_name": "School-based Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 223,
+                    "full_name": "Administrative Claiming",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 10,
+                "name": "Frequently Asked Questions (FAQs)",
+                "description": "",
+                "order": 400,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/resources-for-states/medicaid-state-technical-assistance/medicaid-and-school-based-services/medicaid-school-based-services-frequently-asked-questions-faqs/index.html",
+            "id": 12517,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 22780",
+            "file_name_string": null,
+            "date_string": "2024-04-02",
+            "summary_string": "Medicaid Program; Streamlining the Medicaid, Children's Health Insurance Program, and Basic Health Program Application, Eligibility Determination, Enrollment, and Renewal Processes",
+            "locations": [
+                {
+                    "id": 6,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 851
+                },
+                {
+                    "id": 19,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 17,
+                    "parent": 851
+                },
+                {
+                    "id": 49,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 213,
+                    "parent": 853
+                },
+                {
+                    "id": 130,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 231,
+                    "parent": 853
+                },
+                {
+                    "id": 258,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 222,
+                    "parent": 875
+                },
+                {
+                    "id": 1562,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 223,
+                    "parent": 875
+                },
+                {
+                    "id": 245,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 407,
+                    "parent": 1499
+                },
+                {
+                    "id": 108,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 601,
+                    "parent": 1506
+                },
+                {
+                    "id": 680,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 608,
+                    "parent": 1506
+                },
+                {
+                    "id": 683,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 831,
+                    "parent": 1511
+                },
+                {
+                    "id": 111,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 907,
+                    "parent": 888
+                },
+                {
+                    "id": 112,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 911,
+                    "parent": 888
+                },
+                {
+                    "id": 98,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 912,
+                    "parent": 888
+                },
+                {
+                    "id": 260,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 914,
+                    "parent": 888
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 1566,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 919,
+                    "parent": 888
+                },
+                {
+                    "id": 101,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 940,
+                    "parent": 888
+                },
+                {
+                    "id": 105,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 952,
+                    "parent": 888
+                },
+                {
+                    "id": 106,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 956,
+                    "parent": 888
+                },
+                {
+                    "id": 97,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 1200,
+                    "parent": 1526
+                },
+                {
+                    "id": 1093,
+                    "title": 42,
+                    "part": 436,
+                    "type": "section",
+                    "section_id": 608,
+                    "parent": 1091
+                },
+                {
+                    "id": 794,
+                    "title": 42,
+                    "part": 436,
+                    "type": "section",
+                    "section_id": 831,
+                    "parent": 1096
+                },
+                {
+                    "id": 493,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 56,
+                    "parent": 1195
+                },
+                {
+                    "id": 165,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 65,
+                    "parent": 1361
+                },
+                {
+                    "id": 169,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 340,
+                    "parent": 1376
+                },
+                {
+                    "id": 3102,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 344,
+                    "parent": 1376
+                },
+                {
+                    "id": 561,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 348,
+                    "parent": 1376
+                },
+                {
+                    "id": 170,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 350,
+                    "parent": 1376
+                },
+                {
+                    "id": 592,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 480,
+                    "parent": 1377
+                },
+                {
+                    "id": 579,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 570,
+                    "parent": 1384
+                },
+                {
+                    "id": 582,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 805,
+                    "parent": 1393
+                },
+                {
+                    "id": 571,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 810,
+                    "parent": 1393
+                },
+                {
+                    "id": 1403,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 960,
+                    "parent": 1395
+                },
+                {
+                    "id": 1404,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 965,
+                    "parent": 1395
+                },
+                {
+                    "id": 586,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1140,
+                    "parent": 954
+                },
+                {
+                    "id": 589,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1170,
+                    "parent": 954
+                },
+                {
+                    "id": 590,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1180,
+                    "parent": 954
+                },
+                {
+                    "id": 3078,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 3106
+                },
+                {
+                    "id": 3094,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 525,
+                    "parent": 3108
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 232,
+                    "full_name": "Premiums and Cost Sharing",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 239,
+                    "full_name": "Eligibility Verification",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 241,
+                    "full_name": "Enrollment",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 342,
+                    "full_name": "Single Streamlined Application (or Alternative)",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 248,
+                    "full_name": "Targeted Low-Income Child",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/04/02/2024-06566/medicaid-program-streamlining-the-medicaid-childrens-health-insurance-program-and-basic-health",
+            "id": 12525,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Fact Sheet",
+            "file_name_string": null,
+            "date_string": "2024-04-02",
+            "summary_string": "HHS Notice of Benefit and Payment Parameters for 2025 Final Rule",
+            "locations": [
+                {
+                    "id": 3492,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 1050,
+                    "parent": 3473
+                },
+                {
+                    "id": 3593,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 230,
+                    "parent": 3831
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 193,
+                    "full_name": "Non-MAGI Eligibility",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 3,
+                    "full_name": "Access to Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 358,
+                    "full_name": "Income and Resources",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 361,
+                    "full_name": "Special Enrollment Periods",
+                    "short_name": null,
+                    "abbreviation": "SEPs"
+                },
+                {
+                    "id": 364,
+                    "full_name": "Qualified Health Plans",
+                    "short_name": null,
+                    "abbreviation": "QHPs"
+                },
+                {
+                    "id": 365,
+                    "full_name": "Basic Health Program",
+                    "short_name": null,
+                    "abbreviation": "BHP"
+                },
+                {
+                    "id": 367,
+                    "full_name": "State-based Exchange",
+                    "short_name": null,
+                    "abbreviation": "SBE"
+                },
+                {
+                    "id": 463,
+                    "full_name": "Federally Facilitated Exchange",
+                    "short_name": null,
+                    "abbreviation": "FFE"
+                },
+                {
+                    "id": 241,
+                    "full_name": "Enrollment",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 335,
+                    "full_name": "Network Adequacy",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 239,
+                    "full_name": "Eligibility Verification",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 368,
+                    "full_name": "Call Centers",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 150,
+                    "full_name": "Prescription Drugs",
+                    "short_name": "Drugs",
+                    "abbreviation": null
+                },
+                {
+                    "id": 439,
+                    "full_name": "Health Equity",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 25,
+                    "full_name": "Dental Services and Oral Health",
+                    "short_name": "Dental",
+                    "abbreviation": null
+                },
+                {
+                    "id": 157,
+                    "full_name": "Essential Health Benefit",
+                    "short_name": null,
+                    "abbreviation": "EHB"
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.cms.gov/newsroom/fact-sheets/hhs-notice-benefit-and-payment-parameters-2025-final-rule",
+            "id": 12515,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-04",
+            "summary_string": "Long-Term Services and Supports (LTSS) Quality Measures: Technical Specifications and Resource Manual",
+            "locations": [
+                {
+                    "id": 373,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 1116
+                },
+                {
+                    "id": 425,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": 1149
+                },
+                {
+                    "id": 426,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 303,
+                    "parent": 1149
+                },
+                {
+                    "id": 446,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 353,
+                    "parent": 1150
+                },
+                {
+                    "id": 704,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 365,
+                    "parent": 1150
+                },
+                {
+                    "id": 1157,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 404,
+                    "parent": 1154
+                },
+                {
+                    "id": 1168,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 474,
+                    "parent": 1158
+                },
+                {
+                    "id": 697,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 585,
+                    "parent": 1174
+                },
+                {
+                    "id": 456,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 745,
+                    "parent": 1177
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 297,
+                    "full_name": "Mental Health Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 458,
+                    "full_name": "Reports and Evaluations",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 427,
+                    "full_name": "Diagnosis and Procedure Codes",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 331,
+                    "full_name": "Person-centered Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 464,
+                    "full_name": "Aged, Blind, Disabled",
+                    "short_name": null,
+                    "abbreviation": "ABD"
+                },
+                {
+                    "id": 155,
+                    "full_name": "Substance Use Disorder",
+                    "short_name": null,
+                    "abbreviation": "SUD"
+                },
+                {
+                    "id": 61,
+                    "full_name": "Long-Term Services and Supports",
+                    "short_name": null,
+                    "abbreviation": "LTSS"
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/medicaid/managed-care/downloads/mltss-tech-specs-res-manual.pdf?t=1712861368",
+            "id": 12678,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-03-28",
+            "summary_string": "Temporary Special Enrollment Period (SEP) for Consumers Losing Medicaid or Children’s \r\nHealth Insurance Program (CHIP) Coverage Due to Unwinding of the Medicaid Continuous \r\nEnrollment Condition Operations for Plan Year 2024",
+            "locations": [
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 577,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 343,
+                    "parent": 1376
+                },
+                {
+                    "id": 1591,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 420,
+                    "parent": 3373
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 361,
+                    "full_name": "Special Enrollment Periods",
+                    "short_name": null,
+                    "abbreviation": "SEPs"
+                },
+                {
+                    "id": 241,
+                    "full_name": "Enrollment",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 141,
+                "name": "CCIIO Technical Guidance",
+                "description": "",
+                "order": 5,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/resources-for-states/downloads/extn-sep-cnsmrs-lsg-chip-cvrg-adndm-faq.pdf",
+            "id": 11955,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "SMD #24-002",
+            "file_name_string": null,
+            "date_string": "2024-03-15",
+            "summary_string": "RE: Initial Core Set Mandatory Reporting Guidance for the Health Home Core Quality Measure Sets \r\nand Federal Fiscal Year 2025 Updates to the Health Home Core Quality Measure Sets",
+            "locations": [
+                {
+                    "id": 3050,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 5604
+                },
+                {
+                    "id": 3051,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": 5604
+                },
+                {
+                    "id": 3052,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 20,
+                    "parent": 5604
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 49,
+                    "full_name": "Health Homes for Enrollees with Chronic Conditions",
+                    "short_name": "Health Homes",
+                    "abbreviation": null
+                },
+                {
+                    "id": 458,
+                    "full_name": "Reports and Evaluations",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-03/smd24002.pdf",
+            "id": 13325,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-03-15",
+            "summary_string": "Change Healthcare Cybersecurity Incident – CMS Response and State Flexibilities",
+            "locations": [
+                {
+                    "id": 3,
+                    "title": 42,
+                    "part": 430,
+                    "type": "section",
+                    "section_id": 30,
+                    "parent": 857
+                },
+                {
+                    "id": 221,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 32,
+                    "parent": 1026
+                },
+                {
+                    "id": 84,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 312,
+                    "parent": 1038
+                },
+                {
+                    "id": 85,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 316,
+                    "parent": 1038
+                },
+                {
+                    "id": 86,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 320,
+                    "parent": 1038
+                },
+                {
+                    "id": 212,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 322,
+                    "parent": 1038
+                },
+                {
+                    "id": 332,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 1071
+                },
+                {
+                    "id": 491,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 45,
+                    "parent": 1195
+                },
+                {
+                    "id": 497,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 57,
+                    "parent": 1195
+                },
+                {
+                    "id": 472,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 205,
+                    "parent": 1198
+                },
+                {
+                    "id": 2298,
+                    "title": 45,
+                    "part": 95,
+                    "type": "section",
+                    "section_id": 13,
+                    "parent": 3268
+                },
+                {
+                    "id": 3272,
+                    "title": 45,
+                    "part": 95,
+                    "type": "section",
+                    "section_id": 19,
+                    "parent": 3268
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 232,
+                    "full_name": "Premiums and Cost Sharing",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 235,
+                    "full_name": "Program Integrity",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 109,
+                    "full_name": "Public Notice and Tribal Consultation",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 115,
+                    "full_name": "Provider Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 277,
+                    "full_name": "Pharmacy",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-03/cib031524.pdf",
+            "id": 11375,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-03-15",
+            "summary_string": "Conducting Medicaid and CHIP Renewals During the Unwinding Period and Beyond: Essential Reminders",
+            "locations": [
+                {
+                    "id": 112,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 911,
+                    "parent": 888
+                },
+                {
+                    "id": 99,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 917,
+                    "parent": 888
+                },
+                {
+                    "id": 773,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 930,
+                    "parent": 888
+                },
+                {
+                    "id": 169,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 340,
+                    "parent": 1376
+                },
+                {
+                    "id": 577,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 343,
+                    "parent": 1376
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 75,
+                    "full_name": "Notices",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 460,
+                    "full_name": "Language Access",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 239,
+                    "full_name": "Eligibility Verification",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-03/cib03152024.pdf",
+            "id": 11838,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-03-07",
+            "summary_string": "Strategies to Improve Delivery of Tobacco Cessation Services",
+            "locations": [
+                {
+                    "id": 51,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 130,
+                    "parent": 1124
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 2,
+                    "full_name": "Alternative Benefit Plan",
+                    "short_name": null,
+                    "abbreviation": "ABP"
+                },
+                {
+                    "id": 3,
+                    "full_name": "Access to Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 36,
+                    "full_name": "Early and Periodic Screening, Diagnostic, and Treatment",
+                    "short_name": null,
+                    "abbreviation": "EPSDT"
+                },
+                {
+                    "id": 100,
+                    "full_name": "Preventive Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 135,
+                    "full_name": "Tobacco Cessation",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 439,
+                    "full_name": "Health Equity",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 380,
+                    "full_name": "Federal Medical Assistance Percentage",
+                    "short_name": "FMAP",
+                    "abbreviation": null
+                },
+                {
+                    "id": 157,
+                    "full_name": "Essential Health Benefit",
+                    "short_name": null,
+                    "abbreviation": "EHB"
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-03/cib03072024.pdf",
+            "id": 11051,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-03",
+            "summary_string": "Illustrative Examples of Processes Not Permitted Under Medicaid and CHIP Renewal Requirements",
+            "locations": [
+                {
+                    "id": 112,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 911,
+                    "parent": 888
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 99,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 917,
+                    "parent": 888
+                },
+                {
+                    "id": 773,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 930,
+                    "parent": 888
+                },
+                {
+                    "id": 105,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 952,
+                    "parent": 888
+                },
+                {
+                    "id": 97,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 1200,
+                    "parent": 1526
+                },
+                {
+                    "id": 169,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 340,
+                    "parent": 1376
+                },
+                {
+                    "id": 577,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 343,
+                    "parent": 1376
+                },
+                {
+                    "id": 171,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 380,
+                    "parent": 1376
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 75,
+                    "full_name": "Notices",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 460,
+                    "full_name": "Language Access",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 239,
+                    "full_name": "Eligibility Verification",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 245,
+                    "full_name": "Coordination with Other Programs",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-03/pro-renewal-pract-slides.pdf",
+            "id": 11839,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-03",
+            "summary_string": "Understanding Medicaid Fair Hearings",
+            "locations": [
+                {
+                    "id": 39,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 205,
+                    "parent": 853
+                },
+                {
+                    "id": 40,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 206,
+                    "parent": 853
+                },
+                {
+                    "id": 125,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 220,
+                    "parent": 853
+                },
+                {
+                    "id": 126,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 221,
+                    "parent": 853
+                },
+                {
+                    "id": 154,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 224,
+                    "parent": 853
+                },
+                {
+                    "id": 129,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 230,
+                    "parent": 853
+                },
+                {
+                    "id": 130,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 231,
+                    "parent": 853
+                },
+                {
+                    "id": 133,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 240,
+                    "parent": 853
+                },
+                {
+                    "id": 135,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 242,
+                    "parent": 853
+                },
+                {
+                    "id": 137,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 244,
+                    "parent": 853
+                },
+                {
+                    "id": 138,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 245,
+                    "parent": 853
+                },
+                {
+                    "id": 139,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 246,
+                    "parent": 853
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 73,
+                    "full_name": "Non-Discrimination",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 419,
+                    "full_name": "Appeals and Fair Hearings",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 460,
+                    "full_name": "Language Access",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/media/174536",
+            "id": 11958,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "SMD #24-001",
+            "file_name_string": null,
+            "date_string": "2024-02-26",
+            "summary_string": "RE: Administrative Claiming for Nurse Advice Lines and for Skilled Professional Medical Personnel for \r\nCertain Behavioral Health Professionals",
+            "locations": [
+                {
+                    "id": 198,
+                    "title": 42,
+                    "part": 432,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": 1017
+                },
+                {
+                    "id": 199,
+                    "title": 42,
+                    "part": 432,
+                    "type": "section",
+                    "section_id": 50,
+                    "parent": 1023
+                },
+                {
+                    "id": 332,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 1071
+                },
+                {
+                    "id": 380,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": 1071
+                },
+                {
+                    "id": 3417,
+                    "title": 45,
+                    "part": 75,
+                    "type": "section",
+                    "section_id": 402,
+                    "parent": 3413
+                },
+                {
+                    "id": 3418,
+                    "title": 45,
+                    "part": 75,
+                    "type": "section",
+                    "section_id": 403,
+                    "parent": 3413
+                },
+                {
+                    "id": 3420,
+                    "title": 45,
+                    "part": 75,
+                    "type": "section",
+                    "section_id": 404,
+                    "parent": 3413
+                },
+                {
+                    "id": 3422,
+                    "title": 45,
+                    "part": 75,
+                    "type": "section",
+                    "section_id": 405,
+                    "parent": 3413
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 176,
+                    "full_name": "Behavioral Health",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 223,
+                    "full_name": "Administrative Claiming",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 447,
+                    "full_name": "Federal Financial Participation",
+                    "short_name": null,
+                    "abbreviation": "FFP"
+                }
+            ],
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-02/smd24001.pdf",
+            "id": 10620,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 13916",
+            "file_name_string": null,
+            "date_string": "2024-02-23",
+            "summary_string": "Medicaid Program; Disproportionate Share Hospital Third-Party Payer Rule",
+            "locations": [
+                {
+                    "id": 85,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 316,
+                    "parent": 1038
+                },
+                {
+                    "id": 483,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 294,
+                    "parent": 1204
+                },
+                {
+                    "id": 484,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 295,
+                    "parent": 1204
+                },
+                {
+                    "id": 485,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 297,
+                    "parent": 1204
+                },
+                {
+                    "id": 487,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 299,
+                    "parent": 1204
+                },
+                {
+                    "id": 840,
+                    "title": 42,
+                    "part": 455,
+                    "type": "section",
+                    "section_id": 301,
+                    "parent": 1223
+                },
+                {
+                    "id": 164,
+                    "title": 42,
+                    "part": 455,
+                    "type": "section",
+                    "section_id": 304,
+                    "parent": 1223
+                },
+                {
+                    "id": 782,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 609,
+                    "parent": 1388
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 171,
+                    "full_name": "Disproportionate Share Hospital Payments",
+                    "short_name": null,
+                    "abbreviation": "DSH"
+                },
+                {
+                    "id": 133,
+                    "full_name": "Third Party Liability",
+                    "short_name": null,
+                    "abbreviation": "TPL"
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/02/23/2024-03542/medicaid-program-disproportionate-share-hospital-third-party-payer-rule",
+            "id": 13538,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-02-13",
+            "summary_string": "Improving Behavioral Health Follow-up Care Measures for Quality Improvement",
+            "locations": [
+                {
+                    "id": 57,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 70,
+                    "parent": 1124
+                },
+                {
+                    "id": 51,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 130,
+                    "parent": 1124
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 176,
+                    "full_name": "Behavioral Health",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 433,
+                    "full_name": "Care and Delivery System Models",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 442,
+                    "full_name": "Care Coordination",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 414,
+                    "full_name": "Electronic Health Information",
+                    "short_name": null,
+                    "abbreviation": "EHI"
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-02/bhfua-measures-qi.pdf",
+            "id": 10290,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-02-13",
+            "summary_string": "State Medicaid and CHIP Improving Behavioral Health Follow Up Care Driver Diagram and Change Ideas",
+            "locations": [
+                {
+                    "id": 51,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 130,
+                    "parent": 1124
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 356,
+                    "full_name": "Social Determinants of Health",
+                    "short_name": null,
+                    "abbreviation": "SDOH"
+                },
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 176,
+                    "full_name": "Behavioral Health",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 433,
+                    "full_name": "Care and Delivery System Models",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 442,
+                    "full_name": "Care Coordination",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-02/bhfua-drvr-dgrm-cng-ideas.pdf",
+            "id": 10291,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 9776",
+            "file_name_string": null,
+            "date_string": "2024-02-12",
+            "summary_string": "Medicare and Medicaid Programs; CY 2024 Payment Policies Under the Physician Fee Schedule and Other Changes to Part B Payment and Coverage Policies; Medicare Shared Savings Program Requirements; Medicare Advantage; Medicare and Medicaid Provider and Supplier Enrollment Policies; and Basic Health Program; Corrections",
+            "locations": [
+                {
+                    "id": 2995,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1405,
+                    "parent": null
+                },
+                {
+                    "id": 3936,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 541,
+                    "parent": null
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/02/12/2024-02705/medicare-and-medicaid-programs-cy-2024-payment-policies-under-the-physician-fee-schedule-and-other",
+            "id": 11280,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "State Buy-in Manual",
+            "file_name_string": null,
+            "date_string": "2024-02-09",
+            "summary_string": "Program Overview and Policy, Chapter 1",
+            "locations": [
+                {
+                    "id": 1357,
+                    "title": 42,
+                    "part": 400,
+                    "type": "section",
+                    "section_id": 200,
+                    "parent": 1356
+                },
+                {
+                    "id": 1635,
+                    "title": 42,
+                    "part": 406,
+                    "type": "section",
+                    "section_id": 21,
+                    "parent": null
+                },
+                {
+                    "id": 1645,
+                    "title": 42,
+                    "part": 407,
+                    "type": "section",
+                    "section_id": 40,
+                    "parent": null
+                },
+                {
+                    "id": 1559,
+                    "title": 42,
+                    "part": 407,
+                    "type": "section",
+                    "section_id": 42,
+                    "parent": null
+                },
+                {
+                    "id": 238,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 119,
+                    "parent": 876
+                },
+                {
+                    "id": 259,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 120,
+                    "parent": 876
+                },
+                {
+                    "id": 234,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 121,
+                    "parent": 876
+                },
+                {
+                    "id": 1657,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 123,
+                    "parent": 876
+                },
+                {
+                    "id": 1658,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 124,
+                    "parent": 876
+                },
+                {
+                    "id": 1660,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 126,
+                    "parent": 876
+                },
+                {
+                    "id": 247,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 236,
+                    "parent": 875
+                },
+                {
+                    "id": 256,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 301,
+                    "parent": 877
+                },
+                {
+                    "id": 113,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 406,
+                    "parent": 1499
+                },
+                {
+                    "id": 245,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 407,
+                    "parent": 1499
+                },
+                {
+                    "id": 108,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 601,
+                    "parent": 1506
+                },
+                {
+                    "id": 690,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 909,
+                    "parent": 888
+                },
+                {
+                    "id": 112,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 911,
+                    "parent": 888
+                },
+                {
+                    "id": 98,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 912,
+                    "parent": 888
+                },
+                {
+                    "id": 254,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 915,
+                    "parent": 888
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 99,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 917,
+                    "parent": 888
+                },
+                {
+                    "id": 102,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 945,
+                    "parent": 888
+                },
+                {
+                    "id": 105,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 952,
+                    "parent": 888
+                },
+                {
+                    "id": 106,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 956,
+                    "parent": 888
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 184,
+                    "full_name": "Medicare Savings Programs",
+                    "short_name": null,
+                    "abbreviation": "MSPs"
+                },
+                {
+                    "id": 450,
+                    "full_name": "Low-income Subsidy",
+                    "short_name": null,
+                    "abbreviation": "LIS"
+                },
+                {
+                    "id": 348,
+                    "full_name": "Supplemental Security Income",
+                    "short_name": null,
+                    "abbreviation": "SSI"
+                },
+                {
+                    "id": 239,
+                    "full_name": "Eligibility Verification",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 5,
+                "name": "Subregulatory Guidance",
+                "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                "order": 400,
+                "show_if_empty": true,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.cms.gov/files/document/chapter-1-program-overview-and-policy.pdf",
+            "id": 10352,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "89 FR 8758",
+            "file_name_string": null,
+            "date_string": "2024-02-08",
+            "summary_string": "Medicare and Medicaid Programs; Patient Protection and Affordable Care Act; Advancing Interoperability and Improving Prior Authorization Processes for Medicare Advantage Organizations, Medicaid Managed Care Plans, State Medicaid Agencies, Children's Health Insurance Program (CHIP) Agencies and CHIP Managed Care Entities, Issuers of Qualified Health Plans on the Federally-Facilitated Exchanges, Merit-Based Incentive Payment System (MIPS) Eligible Clinicians, and Eligible Hospitals and Critical Access Hospitals in the Medicare Promoting Interoperability Program",
+            "locations": [
+                {
+                    "id": 1670,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 119,
+                    "parent": null
+                },
+                {
+                    "id": 3207,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 121,
+                    "parent": null
+                },
+                {
+                    "id": 3208,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 122,
+                    "parent": null
+                },
+                {
+                    "id": 2350,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 568,
+                    "parent": null
+                },
+                {
+                    "id": 2351,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 570,
+                    "parent": null
+                },
+                {
+                    "id": 1954,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 631,
+                    "parent": null
+                },
+                {
+                    "id": 177,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": 985
+                },
+                {
+                    "id": 1661,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 61,
+                    "parent": 985
+                },
+                {
+                    "id": 1662,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 80,
+                    "parent": 985
+                },
+                {
+                    "id": 33,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 201,
+                    "parent": 853
+                },
+                {
+                    "id": 125,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 220,
+                    "parent": 853
+                },
+                {
+                    "id": 99,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 917,
+                    "parent": 888
+                },
+                {
+                    "id": 382,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 9,
+                    "parent": 1071
+                },
+                {
+                    "id": 679,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 62,
+                    "parent": 1086
+                },
+                {
+                    "id": 370,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 210,
+                    "parent": 1112
+                },
+                {
+                    "id": 337,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 242,
+                    "parent": 1112
+                },
+                {
+                    "id": 55,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 230,
+                    "parent": 1125
+                },
+                {
+                    "id": 575,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 495,
+                    "parent": 1377
+                },
+                {
+                    "id": 1392,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 700,
+                    "parent": 1391
+                },
+                {
+                    "id": 595,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 730,
+                    "parent": 1391
+                },
+                {
+                    "id": 1663,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 731,
+                    "parent": 1391
+                },
+                {
+                    "id": 1664,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 732,
+                    "parent": 1391
+                },
+                {
+                    "id": 594,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1206,
+                    "parent": 1407
+                },
+                {
+                    "id": 576,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1230,
+                    "parent": 1407
+                },
+                {
+                    "id": 2878,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 221,
+                    "parent": 3831
+                },
+                {
+                    "id": 1666,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 222,
+                    "parent": 3831
+                },
+                {
+                    "id": 1667,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 223,
+                    "parent": 3831
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 128,
+                    "full_name": "Sufficiency",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 102,
+                    "full_name": "Prior Authorization",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 273,
+                    "full_name": "Provider Directory",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 414,
+                    "full_name": "Electronic Health Information",
+                    "short_name": null,
+                    "abbreviation": "EHI"
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2024/02/08/2024-00895/medicare-and-medicaid-programs-patient-protection-and-affordable-care-act-advancing-interoperability",
+            "id": 11286,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Report to Congress",
+            "file_name_string": null,
+            "date_string": "2024-02",
+            "summary_string": "Best Practices in the Money Follows the Person (MFP) Demonstration",
+            "locations": [
+                {
+                    "id": 73,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 180,
+                    "parent": 1124
+                },
+                {
+                    "id": 17,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 181,
+                    "parent": 1124
+                },
+                {
+                    "id": 18,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 182,
+                    "parent": 1124
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 159,
+                    "full_name": "Indian/Tribal Health",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 416,
+                    "full_name": "Demonstrations and Waivers",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 223,
+                    "full_name": "Administrative Claiming",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 424,
+                    "full_name": "State Financial Share",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 331,
+                    "full_name": "Person-centered Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 51,
+                    "full_name": "Housing Support Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 380,
+                    "full_name": "Federal Medical Assistance Percentage",
+                    "short_name": "FMAP",
+                    "abbreviation": null
+                },
+                {
+                    "id": 61,
+                    "full_name": "Long-Term Services and Supports",
+                    "short_name": null,
+                    "abbreviation": "LTSS"
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 135,
+                "name": "HHS and CMS Reports to Congress",
+                "description": "",
+                "order": 210,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 19,
+                    "name": "Briefs and Reports",
+                    "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                    "order": 550,
+                    "show_if_empty": false,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-03/mfp-best-practices-rtc-feb2024.pdf",
+            "id": 11265,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-02",
+            "summary_string": "Coverage and Payment of Vaccines and Vaccine Administration under Medicaid, the Children’s Health Insurance Program, and Basic Health Program",
+            "locations": [
+                {
+                    "id": 661,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 608,
+                    "parent": 858
+                },
+                {
+                    "id": 27,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": 1124
+                },
+                {
+                    "id": 51,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 130,
+                    "parent": 1124
+                },
+                {
+                    "id": 60,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 347,
+                    "parent": 1128
+                },
+                {
+                    "id": 664,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 605,
+                    "parent": 1175
+                },
+                {
+                    "id": 751,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1285,
+                    "parent": 1407
+                },
+                {
+                    "id": 3084,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 405,
+                    "parent": 3107
+                },
+                {
+                    "id": 3601,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 115,
+                    "parent": 3830
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 417,
+                    "full_name": "Natural Disaster/Public Emergency",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 36,
+                    "full_name": "Early and Periodic Screening, Diagnostic, and Treatment",
+                    "short_name": null,
+                    "abbreviation": "EPSDT"
+                },
+                {
+                    "id": 294,
+                    "full_name": "Scope of Practice",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 40,
+                    "full_name": "Federally Qualified Health Centers",
+                    "short_name": null,
+                    "abbreviation": "FQHC"
+                },
+                {
+                    "id": 106,
+                    "full_name": "Provider Screening and Enrollment",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 139,
+                    "full_name": "Vaccinations and Immunizations",
+                    "short_name": "Vaccinations",
+                    "abbreviation": null
+                },
+                {
+                    "id": 115,
+                    "full_name": "Provider Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 439,
+                    "full_name": "Health Equity",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                },
+                {
+                    "id": 121,
+                    "full_name": "Rural Health Clinics",
+                    "short_name": null,
+                    "abbreviation": "RHC"
+                },
+                {
+                    "id": 91,
+                    "full_name": "Other Licensed Practitioner",
+                    "short_name": null,
+                    "abbreviation": "OLP"
+                },
+                {
+                    "id": 380,
+                    "full_name": "Federal Medical Assistance Percentage",
+                    "short_name": "FMAP",
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 15,
+                "name": "Toolkits",
+                "description": "",
+                "order": 500,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-02/vacines-coverage-payment.pdf",
+            "id": 10293,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-02",
+            "summary_string": "Section 223 Certified Community Behavioral Health Clinic (CCBHC) Demonstration Prospective Payment System (PPS) Guidance",
+            "locations": [
+                {
+                    "id": 203,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": 1026
+                },
+                {
+                    "id": 221,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 32,
+                    "parent": 1026
+                },
+                {
+                    "id": 359,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 6,
+                    "parent": 1071
+                },
+                {
+                    "id": 756,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": 1086
+                },
+                {
+                    "id": 492,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 46,
+                    "parent": 1195
+                },
+                {
+                    "id": 3360,
+                    "title": 45,
+                    "part": 75,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": 3357
+                },
+                {
+                    "id": 3413,
+                    "title": 45,
+                    "part": 75,
+                    "type": "subpart",
+                    "subpart_id": "E"
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 159,
+                    "full_name": "Indian/Tribal Health",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 389,
+                    "full_name": "Dual Eligibles",
+                    "short_name": "Duals",
+                    "abbreviation": null
+                },
+                {
+                    "id": 40,
+                    "full_name": "Federally Qualified Health Centers",
+                    "short_name": null,
+                    "abbreviation": "FQHC"
+                },
+                {
+                    "id": 10,
+                    "full_name": "Certified Community Behavioral Health Clinics",
+                    "short_name": null,
+                    "abbreviation": "CCBHCs"
+                },
+                {
+                    "id": 14,
+                    "full_name": "Clinic Services",
+                    "short_name": "Clinics",
+                    "abbreviation": null
+                },
+                {
+                    "id": 115,
+                    "full_name": "Provider Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 93,
+                    "full_name": "Out of State Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 380,
+                    "full_name": "Federal Medical Assistance Percentage",
+                    "short_name": "FMAP",
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 447,
+                    "full_name": "Federal Financial Participation",
+                    "short_name": null,
+                    "abbreviation": "FFP"
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-02/section-223-ccbh-pps-prop-updates-022024.pdf",
+            "id": 10353,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-02",
+            "summary_string": "Highlights from the Improving Postpartum Care Affinity Group",
+            "locations": [
+                {
+                    "id": 11,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 170,
+                    "parent": 876
+                },
+                {
+                    "id": 51,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 130,
+                    "parent": 1124
+                },
+                {
+                    "id": 64,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 365,
+                    "parent": 1128
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 100,
+                    "full_name": "Preventive Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 167,
+                    "full_name": "Postpartum Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 15,
+                    "full_name": "Case Management",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 19,
+                    "full_name": "Community Health Workers",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 442,
+                    "full_name": "Care Coordination",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 31,
+                    "full_name": "Doula Services",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 139,
+                "name": "Topic Briefs and Reports",
+                "description": "",
+                "order": 310,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 19,
+                    "name": "Briefs and Reports",
+                    "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                    "order": 550,
+                    "show_if_empty": false,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-02/postpart-car-aff-grp-highlits.pdf",
+            "id": 10443,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-02",
+            "summary_string": "Medicaid and CHIP Coverage of New Treatments and Opportunities to Improve Care for Sickle Cell Disease",
+            "locations": [
+                {
+                    "id": 23,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 52,
+                    "parent": 985
+                },
+                {
+                    "id": 44,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 120,
+                    "parent": 1124
+                },
+                {
+                    "id": 55,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 230,
+                    "parent": 1125
+                },
+                {
+                    "id": 575,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 495,
+                    "parent": 1377
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 128,
+                    "full_name": "Sufficiency",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 160,
+                    "full_name": "Drug Rebate",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 8,
+                    "full_name": "Blood Disorders",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 115,
+                    "full_name": "Provider Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 150,
+                    "full_name": "Prescription Drugs",
+                    "short_name": "Drugs",
+                    "abbreviation": null
+                },
+                {
+                    "id": 93,
+                    "full_name": "Out of State Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 222,
+                    "full_name": "Transportation",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 223,
+                    "full_name": "Administrative Claiming",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/media/173381",
+            "id": 11262,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-02",
+            "summary_string": "State Medicaid & CHIP Telehealth Toolkit",
+            "locations": [
+                {
+                    "id": 57,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 70,
+                    "parent": 1124
+                },
+                {
+                    "id": 2,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 90,
+                    "parent": 1124
+                },
+                {
+                    "id": 436,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 535,
+                    "parent": 1174
+                },
+                {
+                    "id": 441,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 720,
+                    "parent": 1177
+                },
+                {
+                    "id": 1246,
+                    "title": 42,
+                    "part": 456,
+                    "type": "section",
+                    "section_id": 127,
+                    "parent": 1230
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 3,
+                    "full_name": "Access to Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 131,
+                    "full_name": "Telemedicine/Telehealth",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 133,
+                    "full_name": "Third Party Liability",
+                    "short_name": null,
+                    "abbreviation": "TPL"
+                },
+                {
+                    "id": 12,
+                    "full_name": "Community First Choice",
+                    "short_name": null,
+                    "abbreviation": "CFC"
+                },
+                {
+                    "id": 14,
+                    "full_name": "Clinic Services",
+                    "short_name": "Clinics",
+                    "abbreviation": null
+                },
+                {
+                    "id": 272,
+                    "full_name": "Children's Health Insurance Program Reauthorization Act",
+                    "short_name": null,
+                    "abbreviation": "CHIPRA"
+                },
+                {
+                    "id": 404,
+                    "full_name": "Scope of Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 408,
+                    "full_name": "Workforce Recruitment and Retention",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 414,
+                    "full_name": "Electronic Health Information",
+                    "short_name": null,
+                    "abbreviation": "EHI"
+                },
+                {
+                    "id": 159,
+                    "full_name": "Indian/Tribal Health",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 161,
+                    "full_name": "Former Foster Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 36,
+                    "full_name": "Early and Periodic Screening, Diagnostic, and Treatment",
+                    "short_name": null,
+                    "abbreviation": "EPSDT"
+                },
+                {
+                    "id": 40,
+                    "full_name": "Federally Qualified Health Centers",
+                    "short_name": null,
+                    "abbreviation": "FQHC"
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 64,
+                    "full_name": "Maternal Health",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 460,
+                    "full_name": "Language Access",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 83,
+                    "full_name": "School-based Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 91,
+                    "full_name": "Other Licensed Practitioner",
+                    "short_name": null,
+                    "abbreviation": "OLP"
+                },
+                {
+                    "id": 115,
+                    "full_name": "Provider Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 121,
+                    "full_name": "Rural Health Clinics",
+                    "short_name": null,
+                    "abbreviation": "RHC"
+                },
+                {
+                    "id": 383,
+                    "full_name": "Preadmission Screening and Resident Review",
+                    "short_name": null,
+                    "abbreviation": "PASRR"
+                }
+            ],
+            "category": {
+                "id": 15,
+                "name": "Toolkits",
+                "description": "",
+                "order": 500,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-02/telehealth-toolkt.pdf",
+            "id": 11840,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Fact Sheet",
+            "file_name_string": null,
+            "date_string": "2024-01-30",
+            "summary_string": "Cell and Gene Therapy (CGT) Access Model Overview",
+            "locations": [],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 8,
+                    "full_name": "Blood Disorders",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 150,
+                    "full_name": "Prescription Drugs",
+                    "short_name": "Drugs",
+                    "abbreviation": null
+                },
+                {
+                    "id": 160,
+                    "full_name": "Drug Rebate",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 439,
+                    "full_name": "Health Equity",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.cms.gov/files/document/cgt-model-ovw-fact-sheet.pdf",
+            "id": 10238,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-01-29",
+            "summary_string": "Improving Maternal Health and Extending Postpartum Coverage in Medicaid and the Children’s Health Insurance Program (CHIP) (SHO #21-007)",
+            "locations": [
+                {
+                    "id": 238,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 119,
+                    "parent": 876
+                },
+                {
+                    "id": 11,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 170,
+                    "parent": 876
+                },
+                {
+                    "id": 53,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 210,
+                    "parent": 1125
+                },
+                {
+                    "id": 56,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 240,
+                    "parent": 1125
+                },
+                {
+                    "id": 10,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 250,
+                    "parent": 1125
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 64,
+                    "full_name": "Maternal Health",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 2,
+                    "full_name": "Alternative Benefit Plan",
+                    "short_name": null,
+                    "abbreviation": "ABP"
+                },
+                {
+                    "id": 36,
+                    "full_name": "Early and Periodic Screening, Diagnostic, and Treatment",
+                    "short_name": null,
+                    "abbreviation": "EPSDT"
+                },
+                {
+                    "id": 101,
+                    "full_name": "Pregnant Women",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 167,
+                    "full_name": "Postpartum Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 10,
+                "name": "Frequently Asked Questions (FAQs)",
+                "description": "",
+                "order": 400,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-01/postpartum-ext-faqs.pdf",
+            "id": 13608,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-01-24",
+            "summary_string": "Departments of Justice and Health and Human Services Issue Letter to State Medicaid Administrators Urging Coverage for Life-Saving Hepatitis C Medications",
+            "locations": [
+                {
+                    "id": 44,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 120,
+                    "parent": 1124
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 155,
+                    "full_name": "Substance Use Disorder",
+                    "short_name": null,
+                    "abbreviation": "SUD"
+                },
+                {
+                    "id": 150,
+                    "full_name": "Prescription Drugs",
+                    "short_name": "Drugs",
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.justice.gov/d9/2024-01/dear_colleague_letter-state_medicaid_coverage_for_people_with_hcv_and_sud.pdf",
+            "id": 10149,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-01-24",
+            "summary_string": "2024 Federal Poverty Level Standards",
+            "locations": [
+                {
+                    "id": 108,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 601,
+                    "parent": 1506
+                },
+                {
+                    "id": 110,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 603,
+                    "parent": 1506
+                },
+                {
+                    "id": 112,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 911,
+                    "parent": 888
+                },
+                {
+                    "id": 310,
+                    "title": 42,
+                    "part": 436,
+                    "type": "section",
+                    "section_id": 601,
+                    "parent": 1091
+                },
+                {
+                    "id": 555,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 315,
+                    "parent": 1376
+                },
+                {
+                    "id": 1579,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 300,
+                    "parent": 3351
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 184,
+                    "full_name": "Medicare Savings Programs",
+                    "short_name": null,
+                    "abbreviation": "MSPs"
+                },
+                {
+                    "id": 389,
+                    "full_name": "Dual Eligibles",
+                    "short_name": "Duals",
+                    "abbreviation": null
+                },
+                {
+                    "id": 358,
+                    "full_name": "Income and Resources",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-01/cib012424_0.pdf",
+            "id": 11687,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Fact Sheet",
+            "file_name_string": null,
+            "date_string": "2024-01-17",
+            "summary_string": "CMS Interoperability and Prior Authorization Final Rule CMS-0057-F",
+            "locations": [
+                {
+                    "id": 177,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": 985
+                },
+                {
+                    "id": 1661,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 61,
+                    "parent": 985
+                },
+                {
+                    "id": 1662,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 80,
+                    "parent": 985
+                },
+                {
+                    "id": 33,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 201,
+                    "parent": 853
+                },
+                {
+                    "id": 125,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 220,
+                    "parent": 853
+                },
+                {
+                    "id": 99,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 917,
+                    "parent": 888
+                },
+                {
+                    "id": 382,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 9,
+                    "parent": 1071
+                },
+                {
+                    "id": 679,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 62,
+                    "parent": 1086
+                },
+                {
+                    "id": 370,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 210,
+                    "parent": 1112
+                },
+                {
+                    "id": 337,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 242,
+                    "parent": 1112
+                },
+                {
+                    "id": 55,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 230,
+                    "parent": 1125
+                },
+                {
+                    "id": 575,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 495,
+                    "parent": 1377
+                },
+                {
+                    "id": 1392,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 700,
+                    "parent": 1391
+                },
+                {
+                    "id": 595,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 730,
+                    "parent": 1391
+                },
+                {
+                    "id": 1663,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 731,
+                    "parent": 1391
+                },
+                {
+                    "id": 1664,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 732,
+                    "parent": 1391
+                },
+                {
+                    "id": 594,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1206,
+                    "parent": 1407
+                },
+                {
+                    "id": 576,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1230,
+                    "parent": 1407
+                },
+                {
+                    "id": 2878,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 221,
+                    "parent": 3831
+                },
+                {
+                    "id": 1666,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 222,
+                    "parent": 3831
+                },
+                {
+                    "id": 1667,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 223,
+                    "parent": 3831
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 414,
+                    "full_name": "Electronic Health Information",
+                    "short_name": null,
+                    "abbreviation": "EHI"
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 102,
+                    "full_name": "Prior Authorization",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.cms.gov/newsroom/fact-sheets/cms-interoperability-and-prior-authorization-final-rule-cms-0057-f",
+            "id": 9466,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Infographic",
+            "file_name_string": null,
+            "date_string": "2024-01",
+            "summary_string": "2024 Home and Community-Based Services Survey Database Results",
+            "locations": [
+                {
+                    "id": 73,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 180,
+                    "parent": 1124
+                },
+                {
+                    "id": 17,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 181,
+                    "parent": 1124
+                },
+                {
+                    "id": 18,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 182,
+                    "parent": 1124
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 19,
+                "name": "Briefs and Reports",
+                "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                "order": 550,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.ahrq.gov/sites/default/files/wysiwyg/cahps/cahps-database/2024-hcbs-infographic.pdf",
+            "id": 10657,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-01",
+            "summary_string": "American Rescue Plan Act of 2021(ARP) Section 9817 State Spending Plan Summaries Federal Fiscal Year 2023 Quarter 1 Update",
+            "locations": [],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 96,
+                    "full_name": "Personal Care Services",
+                    "short_name": null,
+                    "abbreviation": "PCS"
+                },
+                {
+                    "id": 416,
+                    "full_name": "Demonstrations and Waivers",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 356,
+                    "full_name": "Social Determinants of Health",
+                    "short_name": null,
+                    "abbreviation": "SDOH"
+                },
+                {
+                    "id": 402,
+                    "full_name": "Intellectual & Developmental Disabilities",
+                    "short_name": null,
+                    "abbreviation": "I/DD"
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                },
+                {
+                    "id": 408,
+                    "full_name": "Workforce Recruitment and Retention",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 380,
+                    "full_name": "Federal Medical Assistance Percentage",
+                    "short_name": "FMAP",
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 139,
+                "name": "Topic Briefs and Reports",
+                "description": "",
+                "order": 310,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 19,
+                    "name": "Briefs and Reports",
+                    "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                    "order": 550,
+                    "show_if_empty": false,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-01/states-arpa-spending-plan-summaries-ffy2023q1.pdf",
+            "id": 10087,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-01",
+            "summary_string": "Using Managed Care External Quality Review for Quality Improvement in Medicaid and CHIP",
+            "locations": [
+                {
+                    "id": 373,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 1116
+                },
+                {
+                    "id": 376,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 340,
+                    "parent": 1116
+                },
+                {
+                    "id": 352,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 350,
+                    "parent": 1116
+                },
+                {
+                    "id": 642,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 352,
+                    "parent": 1116
+                },
+                {
+                    "id": 638,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 354,
+                    "parent": 1116
+                },
+                {
+                    "id": 641,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 356,
+                    "parent": 1116
+                },
+                {
+                    "id": 639,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 358,
+                    "parent": 1116
+                },
+                {
+                    "id": 659,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 360,
+                    "parent": 1116
+                },
+                {
+                    "id": 644,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 362,
+                    "parent": 1116
+                },
+                {
+                    "id": 640,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 364,
+                    "parent": 1116
+                },
+                {
+                    "id": 377,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 370,
+                    "parent": 1116
+                },
+                {
+                    "id": 598,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1240,
+                    "parent": 1407
+                },
+                {
+                    "id": 599,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1250,
+                    "parent": 1407
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-02/mc-qi-eqr-slides.pdf",
+            "id": 10613,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-01",
+            "summary_string": "Using State Managed Care Quality Strategies for Quality Improvement in Medicaid and CHIP",
+            "locations": [
+                {
+                    "id": 362,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 68,
+                    "parent": 1086
+                },
+                {
+                    "id": 364,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 206,
+                    "parent": 1112
+                },
+                {
+                    "id": 373,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 1116
+                },
+                {
+                    "id": 376,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 340,
+                    "parent": 1116
+                },
+                {
+                    "id": 352,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 350,
+                    "parent": 1116
+                },
+                {
+                    "id": 636,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1218,
+                    "parent": 1407
+                },
+                {
+                    "id": 576,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1230,
+                    "parent": 1407
+                },
+                {
+                    "id": 598,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1240,
+                    "parent": 1407
+                },
+                {
+                    "id": 599,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1250,
+                    "parent": 1407
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 335,
+                    "full_name": "Network Adequacy",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-02/mc-qi-qs-slides.pdf",
+            "id": 10617,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-01",
+            "summary_string": "The CAHPS® Home and Community Based Services (HCBS) Survey Database 2024 Chartbook",
+            "locations": [
+                {
+                    "id": 73,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 180,
+                    "parent": 1124
+                },
+                {
+                    "id": 17,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 181,
+                    "parent": 1124
+                },
+                {
+                    "id": 18,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 182,
+                    "parent": 1124
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 139,
+                "name": "Topic Briefs and Reports",
+                "description": "",
+                "order": 310,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 19,
+                    "name": "Briefs and Reports",
+                    "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                    "order": 550,
+                    "show_if_empty": false,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.ahrq.gov/sites/default/files/wysiwyg/cahps/cahps-database/2024-hcbs-chartbook.pdf",
+            "id": 10656,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024-01",
+            "summary_string": "2024-2025 Medicaid Managed Care Rate Development Guide For Rating Periods Starting between July 1, 2024 and June 30, 2025",
+            "locations": [
+                {
+                    "id": 380,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": 1071
+                },
+                {
+                    "id": 368,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 5,
+                    "parent": 1071
+                },
+                {
+                    "id": 359,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 6,
+                    "parent": 1071
+                },
+                {
+                    "id": 360,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 7,
+                    "parent": 1071
+                },
+                {
+                    "id": 361,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 8,
+                    "parent": 1071
+                },
+                {
+                    "id": 329,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 1071
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 357,
+                    "full_name": "In Lieu of Services and Settings",
+                    "short_name": null,
+                    "abbreviation": "ILOS"
+                },
+                {
+                    "id": 199,
+                    "full_name": "State Directed Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 206,
+                    "full_name": "New Adult Group",
+                    "short_name": "VIII group",
+                    "abbreviation": null
+                },
+                {
+                    "id": 338,
+                    "full_name": "Encounter Data",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 115,
+                    "full_name": "Provider Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 61,
+                    "full_name": "Long-Term Services and Supports",
+                    "short_name": null,
+                    "abbreviation": "LTSS"
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-01/2024-2025-medicaid-rate-guide-01222024.pdf",
+            "id": 11059,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        }
+    ]
+}

--- a/solution/ui/e2e/cypress/fixtures/policy-docs-50-p2.json
+++ b/solution/ui/e2e/cypress/fixtures/policy-docs-50-p2.json
@@ -1,0 +1,7804 @@
+{
+    "count": 2967,
+    "next": "https://bvswm5lqi3.execute-api.us-east-1.amazonaws.com/dev1295/v3/content-search/?category_details=true&location_details=true&page=3&page_size=50&paginate=true&resource-type=external",
+    "previous": "https://bvswm5lqi3.execute-api.us-east-1.amazonaws.com/dev1295/v3/content-search/?category_details=true&location_details=true&page_size=50&paginate=true&resource-type=external",
+    "results": [
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2024",
+            "summary_string": "Managed Care Program Annual Report (MCPAR) Workbook: A requirement of 42 CFR 438.66(e), Version 2024.1",
+            "locations": [
+                {
+                    "id": 334,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 66,
+                    "parent": 1086
+                },
+                {
+                    "id": 362,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 68,
+                    "parent": 1086
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 14,
+                "name": "Templates",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/media/171866",
+            "id": 10658,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-12-18",
+            "summary_string": "Ensuring Eligible Children Maintain Medicaid and Children’s Health Insurance Program Coverage",
+            "locations": [
+                {
+                    "id": 224,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 400,
+                    "parent": 1039
+                },
+                {
+                    "id": 110,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 603,
+                    "parent": 1506
+                },
+                {
+                    "id": 98,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 912,
+                    "parent": 888
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 100,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 926,
+                    "parent": 888
+                },
+                {
+                    "id": 105,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 952,
+                    "parent": 888
+                },
+                {
+                    "id": 601,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 310,
+                    "parent": 1376
+                },
+                {
+                    "id": 577,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 343,
+                    "parent": 1376
+                },
+                {
+                    "id": 602,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 510,
+                    "parent": 1384
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 209,
+                    "full_name": "Procedural Denials",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 241,
+                    "full_name": "Enrollment",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 245,
+                    "full_name": "Coordination with Other Programs",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 246,
+                    "full_name": "Continuous Eligibility",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 216,
+                    "full_name": "Outreach",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 219,
+                    "full_name": "Infants and Children",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-12/cib12182023.pdf",
+            "id": 11391,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-12-14",
+            "summary_string": "Guidance to State Medicaid Agencies on Dually Eligible Beneficiaries Receiving Medicare Part B Marriage and Family Therapist Services, Mental Health Counselor Services, and Intensive Outpatient Services \r\nEffective January 1, 2024",
+            "locations": [
+                {
+                    "id": 77,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 138,
+                    "parent": 901
+                },
+                {
+                    "id": 214,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 139,
+                    "parent": 901
+                },
+                {
+                    "id": 332,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 1071
+                },
+                {
+                    "id": 1121,
+                    "title": 42,
+                    "part": 438,
+                    "type": "subpart",
+                    "subpart_id": "K"
+                },
+                {
+                    "id": 25,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 20,
+                    "parent": 1124
+                },
+                {
+                    "id": 64,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 365,
+                    "parent": 1128
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 133,
+                    "full_name": "Third Party Liability",
+                    "short_name": null,
+                    "abbreviation": "TPL"
+                },
+                {
+                    "id": 389,
+                    "full_name": "Dual Eligibles",
+                    "short_name": "Duals",
+                    "abbreviation": null
+                },
+                {
+                    "id": 40,
+                    "full_name": "Federally Qualified Health Centers",
+                    "short_name": null,
+                    "abbreviation": "FQHC"
+                },
+                {
+                    "id": 297,
+                    "full_name": "Mental Health Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 121,
+                    "full_name": "Rural Health Clinics",
+                    "short_name": null,
+                    "abbreviation": "RHC"
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-12/cib12142023.pdf",
+            "id": 11622,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-12-12",
+            "summary_string": "Development and Maintenance of Direct Support Worker Registries: Benefits of Utilization and Enhanced Federal Funding Availability",
+            "locations": [
+                {
+                    "id": 73,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 180,
+                    "parent": 1124
+                },
+                {
+                    "id": 17,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 181,
+                    "parent": 1124
+                },
+                {
+                    "id": 18,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 182,
+                    "parent": 1124
+                },
+                {
+                    "id": 3287,
+                    "title": 45,
+                    "part": 95,
+                    "type": "subpart",
+                    "subpart_id": "F"
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 96,
+                    "full_name": "Personal Care Services",
+                    "short_name": null,
+                    "abbreviation": "PCS"
+                },
+                {
+                    "id": 393,
+                    "full_name": "Direct Support Workforce",
+                    "short_name": null,
+                    "abbreviation": "DSW"
+                },
+                {
+                    "id": 380,
+                    "full_name": "Federal Medical Assistance Percentage",
+                    "short_name": "FMAP",
+                    "abbreviation": null
+                },
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-12/cib12122023_0.pdf",
+            "id": 10137,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 84713",
+            "file_name_string": null,
+            "date_string": "2023-12-06",
+            "summary_string": "Medicaid; CMS Enforcement of State Compliance With Reporting and Federal Medicaid Renewal Requirements Under Section 1902(tt) of the Social Security Act",
+            "locations": [
+                {
+                    "id": 958,
+                    "title": 42,
+                    "part": 430,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 955
+                },
+                {
+                    "id": 959,
+                    "title": 42,
+                    "part": 430,
+                    "type": "section",
+                    "section_id": 5,
+                    "parent": 955
+                },
+                {
+                    "id": 4863,
+                    "title": 42,
+                    "part": 430,
+                    "type": "section",
+                    "section_id": 49,
+                    "parent": 857
+                },
+                {
+                    "id": 4864,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 927,
+                    "parent": 888
+                },
+                {
+                    "id": 4865,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 928,
+                    "parent": 888
+                },
+                {
+                    "id": 7873,
+                    "title": 45,
+                    "part": 16,
+                    "type": "section",
+                    "section_id": 22,
+                    "parent": null
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 209,
+                    "full_name": "Procedural Denials",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/12/06/2023-26640/medicaid-cms-enforcement-of-state-compliance-with-reporting-and-federal-medicaid-renewal",
+            "id": 13539,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "SHO #23-005",
+            "file_name_string": null,
+            "date_string": "2023-12-01",
+            "summary_string": "RE: Initial Core Set Mandatory Reporting Guidance",
+            "locations": [
+                {
+                    "id": 3049,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 5,
+                    "parent": 5604
+                },
+                {
+                    "id": 3050,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 5604
+                },
+                {
+                    "id": 3051,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": 5604
+                },
+                {
+                    "id": 3052,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 20,
+                    "parent": 5604
+                },
+                {
+                    "id": 3053,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 770,
+                    "parent": 1391
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 162,
+                    "full_name": "SUPPORT Act",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 272,
+                    "full_name": "Children's Health Insurance Program Reauthorization Act",
+                    "short_name": null,
+                    "abbreviation": "CHIPRA"
+                },
+                {
+                    "id": 458,
+                    "full_name": "Reports and Evaluations",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 6,
+                "name": "State Health Official (SHO) Letter",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-12/sho23005_0.pdf",
+            "id": 13324,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-12",
+            "summary_string": "Overview of State Spending under American Rescue Plan Act of 2021 (ARP) Section 9817, as of the \r\nQuarter Ending December 31, 2022",
+            "locations": [
+                {
+                    "id": 73,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 180,
+                    "parent": 1124
+                },
+                {
+                    "id": 17,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 181,
+                    "parent": 1124
+                },
+                {
+                    "id": 18,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 182,
+                    "parent": 1124
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 380,
+                    "full_name": "Federal Medical Assistance Percentage",
+                    "short_name": "FMAP",
+                    "abbreviation": null
+                },
+                {
+                    "id": 325,
+                    "full_name": "Budget and Expenditures",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 139,
+                "name": "Topic Briefs and Reports",
+                "description": "",
+                "order": 310,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 19,
+                    "name": "Briefs and Reports",
+                    "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                    "order": 550,
+                    "show_if_empty": false,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-12/arp-sec9817-overview-infographic_0.pdf",
+            "id": 11625,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 82510",
+            "file_name_string": null,
+            "date_string": "2023-11-24",
+            "summary_string": "Patient Protection and Affordable Care Act, HHS Notice of Benefit and Payment Parameters for 2025; Updating Section 1332 Waiver Public Notice Procedures; Medicaid; Consumer Operated and Oriented Plan (CO-OP) Program; and Basic Health Program",
+            "locations": [
+                {
+                    "id": 108,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 601,
+                    "parent": 1506
+                },
+                {
+                    "id": 3077,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 320,
+                    "parent": 3106
+                },
+                {
+                    "id": 3629,
+                    "title": 45,
+                    "part": 153,
+                    "type": "section",
+                    "section_id": 620,
+                    "parent": null
+                },
+                {
+                    "id": 1573,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 105,
+                    "parent": 3310
+                },
+                {
+                    "id": 3312,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 106,
+                    "parent": 3310
+                },
+                {
+                    "id": 3321,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 170,
+                    "parent": 3310
+                },
+                {
+                    "id": 1575,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 205,
+                    "parent": 3322
+                },
+                {
+                    "id": 1927,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 220,
+                    "parent": 3322
+                },
+                {
+                    "id": 3333,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 221,
+                    "parent": 3322
+                },
+                {
+                    "id": 1580,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": 3351
+                },
+                {
+                    "id": 1581,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 305,
+                    "parent": 3351
+                },
+                {
+                    "id": 1583,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 315,
+                    "parent": 3351
+                },
+                {
+                    "id": 1584,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 320,
+                    "parent": 3351
+                },
+                {
+                    "id": 1585,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 3351
+                },
+                {
+                    "id": 1586,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 335,
+                    "parent": 3351
+                },
+                {
+                    "id": 1590,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 400,
+                    "parent": 3373
+                },
+                {
+                    "id": 3379,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 410,
+                    "parent": 3373
+                },
+                {
+                    "id": 1591,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 420,
+                    "parent": 3373
+                },
+                {
+                    "id": 1592,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 430,
+                    "parent": 3373
+                },
+                {
+                    "id": 3492,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 1050,
+                    "parent": 3473
+                },
+                {
+                    "id": 3528,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 1312,
+                    "parent": 3515
+                },
+                {
+                    "id": 1847,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 1320,
+                    "parent": 3515
+                },
+                {
+                    "id": 3600,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 111,
+                    "parent": 3830
+                },
+                {
+                    "id": 3601,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 115,
+                    "parent": 3830
+                },
+                {
+                    "id": 3662,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 122,
+                    "parent": 3830
+                },
+                {
+                    "id": 3590,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 202,
+                    "parent": 3831
+                },
+                {
+                    "id": 3806,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 520,
+                    "parent": 3834
+                },
+                {
+                    "id": 3642,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 1215,
+                    "parent": 3950
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 193,
+                    "full_name": "Non-MAGI Eligibility",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 365,
+                    "full_name": "Basic Health Program",
+                    "short_name": null,
+                    "abbreviation": "BHP"
+                },
+                {
+                    "id": 367,
+                    "full_name": "State-based Exchange",
+                    "short_name": null,
+                    "abbreviation": "SBE"
+                },
+                {
+                    "id": 20,
+                    "full_name": "Comparability",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 157,
+                    "full_name": "Essential Health Benefit",
+                    "short_name": null,
+                    "abbreviation": "EHB"
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/11/24/2023-25576/patient-protection-and-affordable-care-act-hhs-notice-of-benefit-and-payment-parameters-for-2025",
+            "id": 13090,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-11-22",
+            "summary_string": "Support the Return to Normal Eligibility Operations: Transitional Medical Assistance and Medical Support",
+            "locations": [
+                {
+                    "id": 47,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 211,
+                    "parent": 853
+                },
+                {
+                    "id": 215,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 145,
+                    "parent": 901
+                },
+                {
+                    "id": 216,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 147,
+                    "parent": 901
+                },
+                {
+                    "id": 217,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 148,
+                    "parent": 901
+                },
+                {
+                    "id": 240,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 110,
+                    "parent": 876
+                },
+                {
+                    "id": 237,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 118,
+                    "parent": 876
+                },
+                {
+                    "id": 681,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 610,
+                    "parent": 1506
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 100,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 926,
+                    "parent": 888
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 75,
+                    "full_name": "Notices",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 213,
+                    "full_name": "Change in Circumstances",
+                    "short_name": null,
+                    "abbreviation": "CiC"
+                },
+                {
+                    "id": 214,
+                    "full_name": "Medical Child Support",
+                    "short_name": "Medical Support",
+                    "abbreviation": null
+                },
+                {
+                    "id": 246,
+                    "full_name": "Continuous Eligibility",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 156,
+                    "full_name": "Transitional Medical Assistance",
+                    "short_name": null,
+                    "abbreviation": "TMA"
+                }
+            ],
+            "category": {
+                "id": 10,
+                "name": "Frequently Asked Questions (FAQs)",
+                "description": "",
+                "order": 400,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-12/faq11222023.pdf",
+            "id": 11623,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 80141",
+            "file_name_string": null,
+            "date_string": "2023-11-17",
+            "summary_string": "Medicare and Medicaid Programs; Disclosures of Ownership and Additional Disclosable Parties Information for Skilled Nursing Facilities and Nursing Facilities; Medicare Providers' and Suppliers' Disclosure of Private Equity Companies and Real Estate Investment Trusts",
+            "locations": [
+                {
+                    "id": 1977,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 502,
+                    "parent": null
+                },
+                {
+                    "id": 1796,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 516,
+                    "parent": null
+                },
+                {
+                    "id": 515,
+                    "title": 42,
+                    "part": 455,
+                    "type": "section",
+                    "section_id": 101,
+                    "parent": 1216
+                },
+                {
+                    "id": 518,
+                    "title": 42,
+                    "part": 455,
+                    "type": "section",
+                    "section_id": 104,
+                    "parent": 1216
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 143,
+                    "full_name": "Institutional and Nursing Facility Services",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/11/17/2023-25408/medicare-and-medicaid-programs-disclosures-of-ownership-and-additional-disclosable-parties",
+            "id": 11279,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 78818",
+            "file_name_string": null,
+            "date_string": "2023-11-16",
+            "summary_string": "Medicare and Medicaid Programs; CY 2024 Payment Policies Under the Physician Fee Schedule and Other Changes to Part B Payment and Coverage Policies; Medicare Shared Savings Program Requirements; Medicare Advantage; Medicare and Medicaid Provider and Supplier Enrollment Policies; and Basic Health Program",
+            "locations": [
+                {
+                    "id": 7874,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 400,
+                    "parent": null
+                },
+                {
+                    "id": 2419,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 800,
+                    "parent": null
+                },
+                {
+                    "id": 3905,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2401,
+                    "parent": null
+                },
+                {
+                    "id": 3906,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2411,
+                    "parent": null
+                },
+                {
+                    "id": 2795,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2413,
+                    "parent": null
+                },
+                {
+                    "id": 2796,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2415,
+                    "parent": null
+                },
+                {
+                    "id": 3907,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2446,
+                    "parent": null
+                },
+                {
+                    "id": 3908,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2448,
+                    "parent": null
+                },
+                {
+                    "id": 3909,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2450,
+                    "parent": null
+                },
+                {
+                    "id": 3910,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2452,
+                    "parent": null
+                },
+                {
+                    "id": 2982,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2463,
+                    "parent": null
+                },
+                {
+                    "id": 7875,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2464,
+                    "parent": null
+                },
+                {
+                    "id": 3911,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2468,
+                    "parent": null
+                },
+                {
+                    "id": 2983,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2469,
+                    "parent": null
+                },
+                {
+                    "id": 2984,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": null
+                },
+                {
+                    "id": 2436,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": null
+                },
+                {
+                    "id": 3912,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 18,
+                    "parent": null
+                },
+                {
+                    "id": 2055,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 32,
+                    "parent": null
+                },
+                {
+                    "id": 3913,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 33,
+                    "parent": null
+                },
+                {
+                    "id": 3914,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 47,
+                    "parent": null
+                },
+                {
+                    "id": 3915,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 49,
+                    "parent": null
+                },
+                {
+                    "id": 3916,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 53,
+                    "parent": null
+                },
+                {
+                    "id": 3917,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 54,
+                    "parent": null
+                },
+                {
+                    "id": 1830,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 57,
+                    "parent": null
+                },
+                {
+                    "id": 3918,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 59,
+                    "parent": null
+                },
+                {
+                    "id": 3919,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": null
+                },
+                {
+                    "id": 2056,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 67,
+                    "parent": null
+                },
+                {
+                    "id": 3920,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 72,
+                    "parent": null
+                },
+                {
+                    "id": 2057,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 78,
+                    "parent": null
+                },
+                {
+                    "id": 2088,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 79,
+                    "parent": null
+                },
+                {
+                    "id": 3921,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 130,
+                    "parent": null
+                },
+                {
+                    "id": 3922,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 140,
+                    "parent": null
+                },
+                {
+                    "id": 3923,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 150,
+                    "parent": null
+                },
+                {
+                    "id": 1831,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 152,
+                    "parent": null
+                },
+                {
+                    "id": 1833,
+                    "title": 42,
+                    "part": 411,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": null
+                },
+                {
+                    "id": 3924,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 53,
+                    "parent": null
+                },
+                {
+                    "id": 3925,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 84,
+                    "parent": null
+                },
+                {
+                    "id": 2803,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 94,
+                    "parent": null
+                },
+                {
+                    "id": 2438,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 502,
+                    "parent": null
+                },
+                {
+                    "id": 2439,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 504,
+                    "parent": null
+                },
+                {
+                    "id": 2440,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 507,
+                    "parent": null
+                },
+                {
+                    "id": 3926,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 610,
+                    "parent": null
+                },
+                {
+                    "id": 2990,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 902,
+                    "parent": null
+                },
+                {
+                    "id": 1837,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 904,
+                    "parent": null
+                },
+                {
+                    "id": 2991,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 940,
+                    "parent": null
+                },
+                {
+                    "id": 2441,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1305,
+                    "parent": null
+                },
+                {
+                    "id": 2444,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1320,
+                    "parent": null
+                },
+                {
+                    "id": 2445,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1325,
+                    "parent": null
+                },
+                {
+                    "id": 3927,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1335,
+                    "parent": null
+                },
+                {
+                    "id": 2993,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1340,
+                    "parent": null
+                },
+                {
+                    "id": 2447,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1350,
+                    "parent": null
+                },
+                {
+                    "id": 3928,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1360,
+                    "parent": null
+                },
+                {
+                    "id": 2994,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1365,
+                    "parent": null
+                },
+                {
+                    "id": 3929,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1375,
+                    "parent": null
+                },
+                {
+                    "id": 2089,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1380,
+                    "parent": null
+                },
+                {
+                    "id": 3930,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1385,
+                    "parent": null
+                },
+                {
+                    "id": 2064,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1400,
+                    "parent": null
+                },
+                {
+                    "id": 2995,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1405,
+                    "parent": null
+                },
+                {
+                    "id": 2996,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1415,
+                    "parent": null
+                },
+                {
+                    "id": 2997,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1420,
+                    "parent": null
+                },
+                {
+                    "id": 2998,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1430,
+                    "parent": null
+                },
+                {
+                    "id": 2451,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1450,
+                    "parent": null
+                },
+                {
+                    "id": 3000,
+                    "title": 42,
+                    "part": 415,
+                    "type": "section",
+                    "section_id": 140,
+                    "parent": null
+                },
+                {
+                    "id": 3932,
+                    "title": 42,
+                    "part": 418,
+                    "type": "section",
+                    "section_id": 56,
+                    "parent": null
+                },
+                {
+                    "id": 3933,
+                    "title": 42,
+                    "part": 418,
+                    "type": "section",
+                    "section_id": 114,
+                    "parent": null
+                },
+                {
+                    "id": 1969,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 310,
+                    "parent": null
+                },
+                {
+                    "id": 2453,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 160,
+                    "parent": null
+                },
+                {
+                    "id": 3934,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 205,
+                    "parent": null
+                },
+                {
+                    "id": 3935,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 210,
+                    "parent": null
+                },
+                {
+                    "id": 1977,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 502,
+                    "parent": null
+                },
+                {
+                    "id": 1796,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 516,
+                    "parent": null
+                },
+                {
+                    "id": 1982,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 530,
+                    "parent": null
+                },
+                {
+                    "id": 1797,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 535,
+                    "parent": null
+                },
+                {
+                    "id": 3936,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 541,
+                    "parent": null
+                },
+                {
+                    "id": 3937,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 555,
+                    "parent": null
+                },
+                {
+                    "id": 3001,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 20,
+                    "parent": null
+                },
+                {
+                    "id": 3938,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 106,
+                    "parent": null
+                },
+                {
+                    "id": 2457,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 204,
+                    "parent": null
+                },
+                {
+                    "id": 2459,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": null
+                },
+                {
+                    "id": 3002,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 308,
+                    "parent": null
+                },
+                {
+                    "id": 2460,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 316,
+                    "parent": null
+                },
+                {
+                    "id": 2070,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 400,
+                    "parent": null
+                },
+                {
+                    "id": 2811,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 402,
+                    "parent": null
+                },
+                {
+                    "id": 2813,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 506,
+                    "parent": null
+                },
+                {
+                    "id": 3939,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 507,
+                    "parent": null
+                },
+                {
+                    "id": 2464,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 512,
+                    "parent": null
+                },
+                {
+                    "id": 2071,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 600,
+                    "parent": null
+                },
+                {
+                    "id": 2465,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 601,
+                    "parent": null
+                },
+                {
+                    "id": 2072,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 611,
+                    "parent": null
+                },
+                {
+                    "id": 3006,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 630,
+                    "parent": null
+                },
+                {
+                    "id": 3008,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 650,
+                    "parent": null
+                },
+                {
+                    "id": 3009,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 652,
+                    "parent": null
+                },
+                {
+                    "id": 3010,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 654,
+                    "parent": null
+                },
+                {
+                    "id": 3940,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 655,
+                    "parent": null
+                },
+                {
+                    "id": 3011,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 656,
+                    "parent": null
+                },
+                {
+                    "id": 3012,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 658,
+                    "parent": null
+                },
+                {
+                    "id": 3941,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 659,
+                    "parent": null
+                },
+                {
+                    "id": 3014,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 702,
+                    "parent": null
+                },
+                {
+                    "id": 463,
+                    "title": 42,
+                    "part": 455,
+                    "type": "section",
+                    "section_id": 416,
+                    "parent": 859
+                },
+                {
+                    "id": 3942,
+                    "title": 42,
+                    "part": 455,
+                    "type": "section",
+                    "section_id": 417,
+                    "parent": 859
+                },
+                {
+                    "id": 3943,
+                    "title": 42,
+                    "part": 489,
+                    "type": "section",
+                    "section_id": 30,
+                    "parent": null
+                },
+                {
+                    "id": 2129,
+                    "title": 42,
+                    "part": 491,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": null
+                },
+                {
+                    "id": 2130,
+                    "title": 42,
+                    "part": 491,
+                    "type": "section",
+                    "section_id": 8,
+                    "parent": null
+                },
+                {
+                    "id": 2318,
+                    "title": 42,
+                    "part": 495,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": null
+                },
+                {
+                    "id": 2262,
+                    "title": 42,
+                    "part": 498,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": null
+                },
+                {
+                    "id": 2082,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 125,
+                    "parent": 3104
+                },
+                {
+                    "id": 3063,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 135,
+                    "parent": 3104
+                },
+                {
+                    "id": 3064,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 140,
+                    "parent": 3104
+                },
+                {
+                    "id": 3066,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 145,
+                    "parent": 3104
+                },
+                {
+                    "id": 3071,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 170,
+                    "parent": 3104
+                },
+                {
+                    "id": 3078,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 3106
+                },
+                {
+                    "id": 3079,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 335,
+                    "parent": 3106
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 1,
+                    "full_name": "21st Century Cures Act",
+                    "short_name": "Cures Act",
+                    "abbreviation": null
+                },
+                {
+                    "id": 389,
+                    "full_name": "Dual Eligibles",
+                    "short_name": "Duals",
+                    "abbreviation": null
+                },
+                {
+                    "id": 106,
+                    "full_name": "Provider Screening and Enrollment",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 365,
+                    "full_name": "Basic Health Program",
+                    "short_name": null,
+                    "abbreviation": "BHP"
+                },
+                {
+                    "id": 95,
+                    "full_name": "Peer Support",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/11/16/2023-24184/medicare-and-medicaid-programs-cy-2024-payment-policies-under-the-physician-fee-schedule-and-other",
+            "id": 11312,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-11-16",
+            "summary_string": "Coverage of Services and Supports to Address Health-Related Social Needs in Medicaid and the Children’s Health Insurance Program",
+            "locations": [
+                {
+                    "id": 332,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 1071
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 356,
+                    "full_name": "Social Determinants of Health",
+                    "short_name": null,
+                    "abbreviation": "SDOH"
+                },
+                {
+                    "id": 357,
+                    "full_name": "In Lieu of Services and Settings",
+                    "short_name": null,
+                    "abbreviation": "ILOS"
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-11/cib11162023.pdf",
+            "id": 7592,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 78476",
+            "file_name_string": null,
+            "date_string": "2023-11-15",
+            "summary_string": "Medicare Program; Contract Year 2025 Policy and Technical Changes to the Medicare Advantage Program, Medicare Prescription Drug Benefit Program, Medicare Cost Plan Program, and Programs of All-Inclusive Care for the Elderly; Health Information Technology Standards and Implementation Specifications",
+            "locations": [
+                {
+                    "id": 2091,
+                    "title": 42,
+                    "part": 417,
+                    "type": "section",
+                    "section_id": 472,
+                    "parent": null
+                },
+                {
+                    "id": 1936,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": null
+                },
+                {
+                    "id": 2401,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 52,
+                    "parent": null
+                },
+                {
+                    "id": 1937,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": null
+                },
+                {
+                    "id": 2402,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 62,
+                    "parent": null
+                },
+                {
+                    "id": 2403,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 68,
+                    "parent": null
+                },
+                {
+                    "id": 1938,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 100,
+                    "parent": null
+                },
+                {
+                    "id": 1939,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 102,
+                    "parent": null
+                },
+                {
+                    "id": 1940,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 111,
+                    "parent": null
+                },
+                {
+                    "id": 2406,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 116,
+                    "parent": null
+                },
+                {
+                    "id": 7876,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 125,
+                    "parent": null
+                },
+                {
+                    "id": 3216,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 137,
+                    "parent": null
+                },
+                {
+                    "id": 1944,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 164,
+                    "parent": null
+                },
+                {
+                    "id": 1945,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 166,
+                    "parent": null
+                },
+                {
+                    "id": 2761,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 260,
+                    "parent": null
+                },
+                {
+                    "id": 1969,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 310,
+                    "parent": null
+                },
+                {
+                    "id": 1970,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 311,
+                    "parent": null
+                },
+                {
+                    "id": 2346,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 502,
+                    "parent": null
+                },
+                {
+                    "id": 2347,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 503,
+                    "parent": null
+                },
+                {
+                    "id": 1672,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 504,
+                    "parent": null
+                },
+                {
+                    "id": 2765,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 510,
+                    "parent": null
+                },
+                {
+                    "id": 2410,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 514,
+                    "parent": null
+                },
+                {
+                    "id": 7877,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 516,
+                    "parent": null
+                },
+                {
+                    "id": 2348,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 530,
+                    "parent": null
+                },
+                {
+                    "id": 2352,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 582,
+                    "parent": null
+                },
+                {
+                    "id": 2353,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 584,
+                    "parent": null
+                },
+                {
+                    "id": 7878,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 626,
+                    "parent": null
+                },
+                {
+                    "id": 1934,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 633,
+                    "parent": null
+                },
+                {
+                    "id": 2364,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 2267,
+                    "parent": null
+                },
+                {
+                    "id": 2366,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 2274,
+                    "parent": null
+                },
+                {
+                    "id": 2367,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": null
+                },
+                {
+                    "id": 2522,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 32,
+                    "parent": null
+                },
+                {
+                    "id": 2413,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 38,
+                    "parent": null
+                },
+                {
+                    "id": 2414,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 40,
+                    "parent": null
+                },
+                {
+                    "id": 1958,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 100,
+                    "parent": null
+                },
+                {
+                    "id": 1935,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 120,
+                    "parent": null
+                },
+                {
+                    "id": 7879,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 129,
+                    "parent": null
+                },
+                {
+                    "id": 1959,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 153,
+                    "parent": null
+                },
+                {
+                    "id": 2453,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 160,
+                    "parent": null
+                },
+                {
+                    "id": 1961,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 184,
+                    "parent": null
+                },
+                {
+                    "id": 1962,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 186,
+                    "parent": null
+                },
+                {
+                    "id": 2372,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 503,
+                    "parent": null
+                },
+                {
+                    "id": 2374,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 505,
+                    "parent": null
+                },
+                {
+                    "id": 2569,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 509,
+                    "parent": null
+                },
+                {
+                    "id": 2375,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 514,
+                    "parent": null
+                },
+                {
+                    "id": 2380,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 582,
+                    "parent": null
+                },
+                {
+                    "id": 2381,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 584,
+                    "parent": null
+                },
+                {
+                    "id": 2383,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 600,
+                    "parent": null
+                },
+                {
+                    "id": 2323,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 2267,
+                    "parent": null
+                },
+                {
+                    "id": 2396,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 2274,
+                    "parent": null
+                },
+                {
+                    "id": 7880,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 119,
+                    "parent": 1455
+                },
+                {
+                    "id": 1462,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 121,
+                    "parent": 1455
+                },
+                {
+                    "id": 1489,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 194,
+                    "parent": 1486
+                },
+                {
+                    "id": 7881,
+                    "title": 45,
+                    "part": 170,
+                    "type": "section",
+                    "section_id": 205,
+                    "parent": null
+                },
+                {
+                    "id": 1669,
+                    "title": 45,
+                    "part": 170,
+                    "type": "section",
+                    "section_id": 299,
+                    "parent": null
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 384,
+                    "full_name": "Programs of All-Inclusive Care for the Elderly",
+                    "short_name": null,
+                    "abbreviation": "PACE"
+                },
+                {
+                    "id": 450,
+                    "full_name": "Low-income Subsidy",
+                    "short_name": null,
+                    "abbreviation": "LIS"
+                },
+                {
+                    "id": 389,
+                    "full_name": "Dual Eligibles",
+                    "short_name": "Duals",
+                    "abbreviation": null
+                },
+                {
+                    "id": 361,
+                    "full_name": "Special Enrollment Periods",
+                    "short_name": null,
+                    "abbreviation": "SEPs"
+                },
+                {
+                    "id": 338,
+                    "full_name": "Encounter Data",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/11/15/2023-24118/medicare-program-contract-year-2025-policy-and-technical-changes-to-the-medicare-advantage-program",
+            "id": 11278,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Fact Sheet",
+            "file_name_string": null,
+            "date_string": "2023-11-15",
+            "summary_string": "HHS Notice of Benefit and Payment Parameters for 2025 Proposed Rule",
+            "locations": [
+                {
+                    "id": 108,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 601,
+                    "parent": 1506
+                },
+                {
+                    "id": 3077,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 320,
+                    "parent": 3106
+                },
+                {
+                    "id": 3629,
+                    "title": 45,
+                    "part": 153,
+                    "type": "section",
+                    "section_id": 620,
+                    "parent": null
+                },
+                {
+                    "id": 1573,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 105,
+                    "parent": 3310
+                },
+                {
+                    "id": 3312,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 106,
+                    "parent": 3310
+                },
+                {
+                    "id": 3321,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 170,
+                    "parent": 3310
+                },
+                {
+                    "id": 1575,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 205,
+                    "parent": 3322
+                },
+                {
+                    "id": 1927,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 220,
+                    "parent": 3322
+                },
+                {
+                    "id": 3333,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 221,
+                    "parent": 3322
+                },
+                {
+                    "id": 1580,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": 3351
+                },
+                {
+                    "id": 1581,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 305,
+                    "parent": 3351
+                },
+                {
+                    "id": 1583,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 315,
+                    "parent": 3351
+                },
+                {
+                    "id": 1584,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 320,
+                    "parent": 3351
+                },
+                {
+                    "id": 1585,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 3351
+                },
+                {
+                    "id": 1586,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 335,
+                    "parent": 3351
+                },
+                {
+                    "id": 1590,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 400,
+                    "parent": 3373
+                },
+                {
+                    "id": 3379,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 410,
+                    "parent": 3373
+                },
+                {
+                    "id": 1591,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 420,
+                    "parent": 3373
+                },
+                {
+                    "id": 1592,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 430,
+                    "parent": 3373
+                },
+                {
+                    "id": 3492,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 1050,
+                    "parent": 3473
+                },
+                {
+                    "id": 3528,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 1312,
+                    "parent": 3515
+                },
+                {
+                    "id": 1847,
+                    "title": 45,
+                    "part": 155,
+                    "type": "section",
+                    "section_id": 1320,
+                    "parent": 3515
+                },
+                {
+                    "id": 3600,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 111,
+                    "parent": 3830
+                },
+                {
+                    "id": 3601,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 115,
+                    "parent": 3830
+                },
+                {
+                    "id": 3662,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 122,
+                    "parent": 3830
+                },
+                {
+                    "id": 3590,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 202,
+                    "parent": 3831
+                },
+                {
+                    "id": 3806,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 520,
+                    "parent": 3834
+                },
+                {
+                    "id": 3642,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 1215,
+                    "parent": 3950
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 358,
+                    "full_name": "Income and Resources",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 361,
+                    "full_name": "Special Enrollment Periods",
+                    "short_name": null,
+                    "abbreviation": "SEPs"
+                },
+                {
+                    "id": 364,
+                    "full_name": "Qualified Health Plans",
+                    "short_name": null,
+                    "abbreviation": "QHPs"
+                },
+                {
+                    "id": 365,
+                    "full_name": "Basic Health Program",
+                    "short_name": null,
+                    "abbreviation": "BHP"
+                },
+                {
+                    "id": 367,
+                    "full_name": "State-based Exchange",
+                    "short_name": null,
+                    "abbreviation": "SBE"
+                },
+                {
+                    "id": 335,
+                    "full_name": "Network Adequacy",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 369,
+                    "full_name": "Open Enrollment",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 239,
+                    "full_name": "Eligibility Verification",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 368,
+                    "full_name": "Call Centers",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 150,
+                    "full_name": "Prescription Drugs",
+                    "short_name": "Drugs",
+                    "abbreviation": null
+                },
+                {
+                    "id": 342,
+                    "full_name": "Single Streamlined Application (or Alternative)",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 25,
+                    "full_name": "Dental Services and Oral Health",
+                    "short_name": "Dental",
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 157,
+                    "full_name": "Essential Health Benefit",
+                    "short_name": null,
+                    "abbreviation": "EHB"
+                },
+                {
+                    "id": 158,
+                    "full_name": "Benchmark Coverage",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.cms.gov/newsroom/fact-sheets/hhs-notice-benefit-and-payment-parameters-2025-proposed-rule",
+            "id": 10235,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-11-14",
+            "summary_string": "2024 SSI, Spousal Impoverishment, and Medicare Savings Program Resource",
+            "locations": [
+                {
+                    "id": 259,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 120,
+                    "parent": 876
+                },
+                {
+                    "id": 1657,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 123,
+                    "parent": 876
+                },
+                {
+                    "id": 1658,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 124,
+                    "parent": 876
+                },
+                {
+                    "id": 1659,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 125,
+                    "parent": 876
+                },
+                {
+                    "id": 114,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 217,
+                    "parent": 875
+                },
+                {
+                    "id": 109,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 602,
+                    "parent": 1506
+                },
+                {
+                    "id": 115,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 700,
+                    "parent": 1510
+                },
+                {
+                    "id": 116,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 726,
+                    "parent": 1510
+                },
+                {
+                    "id": 117,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 735,
+                    "parent": 1510
+                },
+                {
+                    "id": 774,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 811,
+                    "parent": 1511
+                },
+                {
+                    "id": 683,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 831,
+                    "parent": 1511
+                },
+                {
+                    "id": 180,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 832,
+                    "parent": 1511
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 358,
+                    "full_name": "Income and Resources",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 429,
+                    "full_name": "Special Income Level",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 173,
+                    "full_name": "Spousal Impoverishment",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 184,
+                    "full_name": "Medicare Savings Programs",
+                    "short_name": null,
+                    "abbreviation": "MSPs"
+                },
+                {
+                    "id": 348,
+                    "full_name": "Supplemental Security Income",
+                    "short_name": null,
+                    "abbreviation": "SSI"
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-11/cib11142024.pdf",
+            "id": 11665,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-11-09",
+            "summary_string": "Guidance on Adding Sexual Orientation and Gender Identity Questions to State Medicaid and CHIP Applications for Health Coverage",
+            "locations": [
+                {
+                    "id": 141,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 300,
+                    "parent": 990
+                },
+                {
+                    "id": 142,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 301,
+                    "parent": 990
+                },
+                {
+                    "id": 143,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": 990
+                },
+                {
+                    "id": 144,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 303,
+                    "parent": 990
+                },
+                {
+                    "id": 146,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 305,
+                    "parent": 990
+                },
+                {
+                    "id": 147,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 306,
+                    "parent": 990
+                },
+                {
+                    "id": 79,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 112,
+                    "parent": 849
+                },
+                {
+                    "id": 111,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 907,
+                    "parent": 888
+                },
+                {
+                    "id": 168,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 1376
+                },
+                {
+                    "id": 643,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1110,
+                    "parent": 954
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 342,
+                    "full_name": "Single Streamlined Application (or Alternative)",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 343,
+                    "full_name": "Transformed Medicaid Statistical Information System",
+                    "short_name": null,
+                    "abbreviation": "T-MSIS"
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-11/cib11092023.pdf",
+            "id": 9585,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-11-07",
+            "summary_string": "Medicaid and CHIP Managed Care Monitoring and Oversight Tools",
+            "locations": [
+                {
+                    "id": 348,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": 1071
+                },
+                {
+                    "id": 332,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 1071
+                },
+                {
+                    "id": 380,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": 1071
+                },
+                {
+                    "id": 359,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 6,
+                    "parent": 1071
+                },
+                {
+                    "id": 360,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 7,
+                    "parent": 1071
+                },
+                {
+                    "id": 334,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 66,
+                    "parent": 1086
+                },
+                {
+                    "id": 658,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 74,
+                    "parent": 1086
+                },
+                {
+                    "id": 365,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 207,
+                    "parent": 1112
+                },
+                {
+                    "id": 719,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 602,
+                    "parent": 858
+                },
+                {
+                    "id": 661,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 608,
+                    "parent": 858
+                },
+                {
+                    "id": 858,
+                    "title": 42,
+                    "part": 438,
+                    "type": "subpart",
+                    "subpart_id": "H"
+                },
+                {
+                    "id": 173,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1201,
+                    "parent": 1407
+                },
+                {
+                    "id": 174,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1203,
+                    "parent": 1407
+                },
+                {
+                    "id": 576,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1230,
+                    "parent": 1407
+                },
+                {
+                    "id": 751,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1285,
+                    "parent": 1407
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 199,
+                    "full_name": "State Directed Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 235,
+                    "full_name": "Program Integrity",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 335,
+                    "full_name": "Network Adequacy",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 338,
+                    "full_name": "Encounter Data",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 159,
+                    "full_name": "Indian/Tribal Health",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-11/cib11072023.pdf",
+            "id": 11052,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-10-27",
+            "summary_string": "Mandatory Continuous Eligibility for Children in Medicaid and CHIP",
+            "locations": [
+                {
+                    "id": 100,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 926,
+                    "parent": 888
+                },
+                {
+                    "id": 493,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 56,
+                    "parent": 1195
+                },
+                {
+                    "id": 167,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 224,
+                    "parent": 1365
+                },
+                {
+                    "id": 556,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 342,
+                    "parent": 1376
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 232,
+                    "full_name": "Premiums and Cost Sharing",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 435,
+                    "full_name": "CHIP Eligibility",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 246,
+                    "full_name": "Continuous Eligibility",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 10,
+                "name": "Frequently Asked Questions (FAQs)",
+                "description": "",
+                "order": 400,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-10/faq102723.pdf",
+            "id": 12990,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-10-19",
+            "summary_string": "Clarification of Medicaid and Children’s Health Insurance Program (CHIP) Grants Closeout Process",
+            "locations": [
+                {
+                    "id": 3,
+                    "title": 42,
+                    "part": 430,
+                    "type": "section",
+                    "section_id": 30,
+                    "parent": 857
+                },
+                {
+                    "id": 632,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 630,
+                    "parent": 1388
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 323,
+                    "full_name": "Grant Administration",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 325,
+                    "full_name": "Budget and Expenditures",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-10/cib10192023.pdf",
+            "id": 10244,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-10",
+            "summary_string": "Scenarios: The Intersection of Continuous Eligibility and Individual Level Renewal Processes",
+            "locations": [
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 100,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 926,
+                    "parent": 888
+                },
+                {
+                    "id": 556,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 342,
+                    "parent": 1376
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 246,
+                    "full_name": "Continuous Eligibility",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-10/int-contin-elig-indiv-lvl-renew-process.pdf",
+            "id": 12050,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "SHO #23-004",
+            "file_name_string": null,
+            "date_string": "2023-09-29",
+            "summary_string": "RE: Section 5112 Requirement for all States to Provide Continuous Eligibility to Children in Medicaid \r\nand CHIP under the Consolidated Appropriations Act, 2023",
+            "locations": [
+                {
+                    "id": 237,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 118,
+                    "parent": 876
+                },
+                {
+                    "id": 234,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 121,
+                    "parent": 876
+                },
+                {
+                    "id": 684,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 225,
+                    "parent": 875
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 100,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 926,
+                    "parent": 888
+                },
+                {
+                    "id": 102,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 945,
+                    "parent": 888
+                },
+                {
+                    "id": 687,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 1009,
+                    "parent": 1518
+                },
+                {
+                    "id": 688,
+                    "title": 42,
+                    "part": 436,
+                    "type": "section",
+                    "section_id": 1005,
+                    "parent": 1107
+                },
+                {
+                    "id": 554,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 1361
+                },
+                {
+                    "id": 601,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 310,
+                    "parent": 1376
+                },
+                {
+                    "id": 556,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 342,
+                    "parent": 1376
+                },
+                {
+                    "id": 577,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 343,
+                    "parent": 1376
+                },
+                {
+                    "id": 171,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 380,
+                    "parent": 1376
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 101,
+                    "full_name": "Pregnant Women",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 167,
+                    "full_name": "Postpartum Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 239,
+                    "full_name": "Eligibility Verification",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 435,
+                    "full_name": "CHIP Eligibility",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 213,
+                    "full_name": "Change in Circumstances",
+                    "short_name": null,
+                    "abbreviation": "CiC"
+                },
+                {
+                    "id": 246,
+                    "full_name": "Continuous Eligibility",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                },
+                {
+                    "id": 248,
+                    "full_name": "Targeted Low-Income Child",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 219,
+                    "full_name": "Infants and Children",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 253,
+                    "full_name": "Incarceration",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 6,
+                "name": "State Health Official (SHO) Letter",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-09/sho23004.pdf",
+            "id": 10153,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "SMD# 23-006",
+            "file_name_string": null,
+            "date_string": "2023-09-28",
+            "summary_string": "RE: Assurance of Transportation: A Medicaid Transportation Coverage Guide",
+            "locations": [
+                {
+                    "id": 850,
+                    "title": 42,
+                    "part": 430,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 960
+                },
+                {
+                    "id": 28,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 53,
+                    "parent": 985
+                },
+                {
+                    "id": 160,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 107,
+                    "parent": 986
+                },
+                {
+                    "id": 221,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 32,
+                    "parent": 1026
+                },
+                {
+                    "id": 806,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 1002,
+                    "parent": 1518
+                },
+                {
+                    "id": 332,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 3,
+                    "parent": 1071
+                },
+                {
+                    "id": 364,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 206,
+                    "parent": 1112
+                },
+                {
+                    "id": 27,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": 1124
+                },
+                {
+                    "id": 48,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 170,
+                    "parent": 1124
+                },
+                {
+                    "id": 70,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 390,
+                    "parent": 1128
+                },
+                {
+                    "id": 453,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 62,
+                    "parent": 889
+                },
+                {
+                    "id": 469,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 52,
+                    "parent": 1195
+                },
+                {
+                    "id": 660,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 201,
+                    "parent": 1198
+                },
+                {
+                    "id": 859,
+                    "title": 42,
+                    "part": 455,
+                    "type": "subpart",
+                    "subpart_id": "E"
+                },
+                {
+                    "id": 593,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 496,
+                    "parent": 1377
+                },
+                {
+                    "id": 3279,
+                    "title": 45,
+                    "part": 95,
+                    "type": "subpart",
+                    "subpart_id": "E"
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 224,
+                    "full_name": "Optional Benefit",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 2,
+                    "full_name": "Alternative Benefit Plan",
+                    "short_name": null,
+                    "abbreviation": "ABP"
+                },
+                {
+                    "id": 3,
+                    "full_name": "Access to Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 36,
+                    "full_name": "Early and Periodic Screening, Diagnostic, and Treatment",
+                    "short_name": null,
+                    "abbreviation": "EPSDT"
+                },
+                {
+                    "id": 226,
+                    "full_name": "Public Assistance Cost Allocation",
+                    "short_name": "Cost Allocation",
+                    "abbreviation": null
+                },
+                {
+                    "id": 223,
+                    "full_name": "Administrative Claiming",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 228,
+                    "full_name": "Rural Health",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 230,
+                    "full_name": "Cost Principles",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 232,
+                    "full_name": "Premiums and Cost Sharing",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 106,
+                    "full_name": "Provider Screening and Enrollment",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 83,
+                    "full_name": "School-based Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 91,
+                    "full_name": "Other Licensed Practitioner",
+                    "short_name": null,
+                    "abbreviation": "OLP"
+                },
+                {
+                    "id": 222,
+                    "full_name": "Transportation",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-09/smd23006.pdf",
+            "id": 10154,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 65230",
+            "file_name_string": null,
+            "date_string": "2023-09-21",
+            "summary_string": "Streamlining Medicaid; Medicare Savings Program Eligibility Determination and Enrollment",
+            "locations": [
+                {
+                    "id": 1635,
+                    "title": 42,
+                    "part": 406,
+                    "type": "section",
+                    "section_id": 21,
+                    "parent": null
+                },
+                {
+                    "id": 241,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": 1046
+                },
+                {
+                    "id": 108,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 601,
+                    "parent": 1506
+                },
+                {
+                    "id": 690,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 909,
+                    "parent": 888
+                },
+                {
+                    "id": 112,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 911,
+                    "parent": 888
+                },
+                {
+                    "id": 105,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 952,
+                    "parent": 888
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 184,
+                    "full_name": "Medicare Savings Programs",
+                    "short_name": null,
+                    "abbreviation": "MSPs"
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/09/21/2023-20382/streamlining-medicaid-medicare-savings-program-eligibility-determination-and-enrollment",
+            "id": 13540,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-09-21",
+            "summary_string": "Preliminary Overview of State Assessments Regarding Compliance with Medicaid and CHIP Automatic Renewal Requirements at the Individual Level, as of September 21, 2023",
+            "locations": [
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 239,
+                    "full_name": "Eligibility Verification",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 139,
+                "name": "Topic Briefs and Reports",
+                "description": "",
+                "order": 310,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 19,
+                    "name": "Briefs and Reports",
+                    "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                    "order": 550,
+                    "show_if_empty": false,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-09/state-asesment-compliance-auto-ren-req.pdf",
+            "id": 11959,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-09-08",
+            "summary_string": "Further Extension of Grace Period Related to the “Four Walls” Requirement under 42 C.F.R. § 440.90 for Indian Health Service and Tribal Facilities to February 11, 2025",
+            "locations": [
+                {
+                    "id": 2,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 90,
+                    "parent": 1124
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                },
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 14,
+                    "full_name": "Clinic Services",
+                    "short_name": "Clinics",
+                    "abbreviation": null
+                },
+                {
+                    "id": 159,
+                    "full_name": "Indian/Tribal Health",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-09/cib090823.pdf",
+            "id": 12311,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 61352",
+            "file_name_string": null,
+            "date_string": "2023-09-06",
+            "summary_string": "Medicare and Medicaid Programs; Minimum Staffing Standards for Long-Term Care Facilities and Medicaid Institutional Payment Transparency Reporting",
+            "locations": [
+                {
+                    "id": 3884,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 72,
+                    "parent": 1086
+                },
+                {
+                    "id": 3951,
+                    "title": 42,
+                    "part": 442,
+                    "type": "section",
+                    "section_id": 43,
+                    "parent": 1180
+                },
+                {
+                    "id": 1703,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 5,
+                    "parent": 7889
+                },
+                {
+                    "id": 1704,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 7889
+                },
+                {
+                    "id": 1705,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": 7889
+                },
+                {
+                    "id": 1730,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 35,
+                    "parent": 7889
+                },
+                {
+                    "id": 1731,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 40,
+                    "parent": 7889
+                },
+                {
+                    "id": 1706,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 45,
+                    "parent": 7889
+                },
+                {
+                    "id": 1732,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 55,
+                    "parent": 7889
+                },
+                {
+                    "id": 1733,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": 7889
+                },
+                {
+                    "id": 1734,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 65,
+                    "parent": 7889
+                },
+                {
+                    "id": 1708,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 70,
+                    "parent": 7889
+                },
+                {
+                    "id": 3952,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 71,
+                    "parent": 7889
+                },
+                {
+                    "id": 1709,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 75,
+                    "parent": 7889
+                },
+                {
+                    "id": 1735,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 80,
+                    "parent": 7889
+                },
+                {
+                    "id": 1736,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 95,
+                    "parent": 7889
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 279,
+                    "full_name": "Supervision",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 143,
+                    "full_name": "Institutional and Nursing Facility Services",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/09/06/2023-18781/medicare-and-medicaid-programs-minimum-staffing-standards-for-long-term-care-facilities-and-medicaid",
+            "id": 6614,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-09",
+            "summary_string": "Medicaid Managed Care Plan Transitions: A Toolkit for States on Promoting Continuity of Care When Plans Enter, Leave, or Merge or are Acquired",
+            "locations": [
+                {
+                    "id": 329,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 1071
+                },
+                {
+                    "id": 330,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 52,
+                    "parent": 1086
+                },
+                {
+                    "id": 331,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 54,
+                    "parent": 1086
+                },
+                {
+                    "id": 350,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 56,
+                    "parent": 1086
+                },
+                {
+                    "id": 679,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 62,
+                    "parent": 1086
+                },
+                {
+                    "id": 335,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 71,
+                    "parent": 1086
+                },
+                {
+                    "id": 369,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 208,
+                    "parent": 1112
+                },
+                {
+                    "id": 358,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 810,
+                    "parent": 1120
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 102,
+                    "full_name": "Prior Authorization",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 75,
+                    "full_name": "Notices",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 368,
+                    "full_name": "Call Centers",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 341,
+                    "full_name": "Continuity of Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 15,
+                "name": "Toolkits",
+                "description": "",
+                "order": 500,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-10/mmcp-transtons-tolkit.pdf",
+            "id": 11070,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 60278",
+            "file_name_string": null,
+            "date_string": "2023-08-31",
+            "summary_string": "Medicaid Program and CHIP; Mandatory Medicaid and Children's Health Insurance Program (CHIP) Core Set Reporting",
+            "locations": [
+                {
+                    "id": 79,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 112,
+                    "parent": 849
+                },
+                {
+                    "id": 3048,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 1,
+                    "parent": 5604
+                },
+                {
+                    "id": 3049,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 5,
+                    "parent": 5604
+                },
+                {
+                    "id": 3050,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 5604
+                },
+                {
+                    "id": 3051,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": 5604
+                },
+                {
+                    "id": 3052,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 20,
+                    "parent": 5604
+                },
+                {
+                    "id": 1392,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 700,
+                    "parent": 1391
+                },
+                {
+                    "id": 3053,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 770,
+                    "parent": 1391
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 49,
+                    "full_name": "Health Homes for Enrollees with Chronic Conditions",
+                    "short_name": "Health Homes",
+                    "abbreviation": null
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/08/31/2023-18669/medicaid-program-and-chip-mandatory-medicaid-and-childrens-health-insurance-program-chip-core-set",
+            "id": 8542,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-08-30",
+            "summary_string": "Ensuring Compliance with Requirements to Conduct Medicaid and CHIP Renewal Requirements at the Individual Level",
+            "locations": [
+                {
+                    "id": 75,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 116,
+                    "parent": 849
+                },
+                {
+                    "id": 112,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 911,
+                    "parent": 888
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 577,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 343,
+                    "parent": 1376
+                },
+                {
+                    "id": 170,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 350,
+                    "parent": 1376
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                },
+                {
+                    "id": 219,
+                    "full_name": "Infants and Children",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-08/state-ltr-ensuring-renewal-compliance.pdf",
+            "id": 7940,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-08-15",
+            "summary_string": "Further extension of the Spousal Impoverishment Rules for Married Applicants and Recipients of Home and Community-Based Services",
+            "locations": [
+                {
+                    "id": 114,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 217,
+                    "parent": 875
+                },
+                {
+                    "id": 109,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 602,
+                    "parent": 1506
+                },
+                {
+                    "id": 115,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 700,
+                    "parent": 1510
+                },
+                {
+                    "id": 116,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 726,
+                    "parent": 1510
+                },
+                {
+                    "id": 117,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 735,
+                    "parent": 1510
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 173,
+                    "full_name": "Spousal Impoverishment",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 9,
+                "name": "CMCS Informational Bulletin (CIB)",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-08/cib08152023.pdf",
+            "id": 12755,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "SMD #23-005",
+            "file_name_string": null,
+            "date_string": "2023-08-11",
+            "summary_string": "RE: State Guidance on Claiming Methodologies for Medicaid Managed Care",
+            "locations": [
+                {
+                    "id": 200,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 1026
+                },
+                {
+                    "id": 203,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": 1026
+                },
+                {
+                    "id": 1032,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 56,
+                    "parent": 1029
+                },
+                {
+                    "id": 755,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 802,
+                    "parent": 1120
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 325,
+                    "full_name": "Budget and Expenditures",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 39,
+                    "full_name": "Family Planning and Sterilizations",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 456,
+                    "full_name": "Breast and Cervical Cancer",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 380,
+                    "full_name": "Federal Medical Assistance Percentage",
+                    "short_name": "FMAP",
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 159,
+                    "full_name": "Indian/Tribal Health",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-08/smd23005.pdf",
+            "id": 13541,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 52262",
+            "file_name_string": null,
+            "date_string": "2023-08-07",
+            "summary_string": "Medicare and Medicaid Programs; CY 2024 Payment Policies Under the Physician Fee Schedule and Other Changes to Part B Payment and Coverage Policies; Medicare Shared Savings Program Requirements; Medicare Advantage; Medicare and Medicaid Provider and Supplier Enrollment Policies; and Basic Health Program",
+            "locations": [
+                {
+                    "id": 2419,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 800,
+                    "parent": null
+                },
+                {
+                    "id": 3905,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2401,
+                    "parent": null
+                },
+                {
+                    "id": 3906,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2411,
+                    "parent": null
+                },
+                {
+                    "id": 2795,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2413,
+                    "parent": null
+                },
+                {
+                    "id": 2796,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2415,
+                    "parent": null
+                },
+                {
+                    "id": 3907,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2446,
+                    "parent": null
+                },
+                {
+                    "id": 3908,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2448,
+                    "parent": null
+                },
+                {
+                    "id": 3909,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2450,
+                    "parent": null
+                },
+                {
+                    "id": 3910,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2452,
+                    "parent": null
+                },
+                {
+                    "id": 2982,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2463,
+                    "parent": null
+                },
+                {
+                    "id": 3911,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2468,
+                    "parent": null
+                },
+                {
+                    "id": 2983,
+                    "title": 42,
+                    "part": 405,
+                    "type": "section",
+                    "section_id": 2469,
+                    "parent": null
+                },
+                {
+                    "id": 2984,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": null
+                },
+                {
+                    "id": 2436,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": null
+                },
+                {
+                    "id": 3912,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 18,
+                    "parent": null
+                },
+                {
+                    "id": 2055,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 32,
+                    "parent": null
+                },
+                {
+                    "id": 3913,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 33,
+                    "parent": null
+                },
+                {
+                    "id": 3914,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 47,
+                    "parent": null
+                },
+                {
+                    "id": 3915,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 49,
+                    "parent": null
+                },
+                {
+                    "id": 3916,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 53,
+                    "parent": null
+                },
+                {
+                    "id": 3917,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 54,
+                    "parent": null
+                },
+                {
+                    "id": 1830,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 57,
+                    "parent": null
+                },
+                {
+                    "id": 3918,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 59,
+                    "parent": null
+                },
+                {
+                    "id": 3919,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": null
+                },
+                {
+                    "id": 2056,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 67,
+                    "parent": null
+                },
+                {
+                    "id": 3920,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 72,
+                    "parent": null
+                },
+                {
+                    "id": 2057,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 78,
+                    "parent": null
+                },
+                {
+                    "id": 2088,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 79,
+                    "parent": null
+                },
+                {
+                    "id": 3921,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 130,
+                    "parent": null
+                },
+                {
+                    "id": 3922,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 140,
+                    "parent": null
+                },
+                {
+                    "id": 3923,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 150,
+                    "parent": null
+                },
+                {
+                    "id": 1831,
+                    "title": 42,
+                    "part": 410,
+                    "type": "section",
+                    "section_id": 152,
+                    "parent": null
+                },
+                {
+                    "id": 1833,
+                    "title": 42,
+                    "part": 411,
+                    "type": "section",
+                    "section_id": 15,
+                    "parent": null
+                },
+                {
+                    "id": 3924,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 53,
+                    "parent": null
+                },
+                {
+                    "id": 3925,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 84,
+                    "parent": null
+                },
+                {
+                    "id": 2803,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 94,
+                    "parent": null
+                },
+                {
+                    "id": 2438,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 502,
+                    "parent": null
+                },
+                {
+                    "id": 2439,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 504,
+                    "parent": null
+                },
+                {
+                    "id": 2440,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 507,
+                    "parent": null
+                },
+                {
+                    "id": 3926,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 610,
+                    "parent": null
+                },
+                {
+                    "id": 2990,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 902,
+                    "parent": null
+                },
+                {
+                    "id": 1837,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 904,
+                    "parent": null
+                },
+                {
+                    "id": 2991,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 940,
+                    "parent": null
+                },
+                {
+                    "id": 2441,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1305,
+                    "parent": null
+                },
+                {
+                    "id": 2444,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1320,
+                    "parent": null
+                },
+                {
+                    "id": 2445,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1325,
+                    "parent": null
+                },
+                {
+                    "id": 3927,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1335,
+                    "parent": null
+                },
+                {
+                    "id": 2993,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1340,
+                    "parent": null
+                },
+                {
+                    "id": 2447,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1350,
+                    "parent": null
+                },
+                {
+                    "id": 3928,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1360,
+                    "parent": null
+                },
+                {
+                    "id": 2994,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1365,
+                    "parent": null
+                },
+                {
+                    "id": 3929,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1375,
+                    "parent": null
+                },
+                {
+                    "id": 2089,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1380,
+                    "parent": null
+                },
+                {
+                    "id": 3930,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1385,
+                    "parent": null
+                },
+                {
+                    "id": 2064,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1400,
+                    "parent": null
+                },
+                {
+                    "id": 2995,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1405,
+                    "parent": null
+                },
+                {
+                    "id": 2996,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1415,
+                    "parent": null
+                },
+                {
+                    "id": 2997,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1420,
+                    "parent": null
+                },
+                {
+                    "id": 3931,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1425,
+                    "parent": null
+                },
+                {
+                    "id": 2998,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1430,
+                    "parent": null
+                },
+                {
+                    "id": 2451,
+                    "title": 42,
+                    "part": 414,
+                    "type": "section",
+                    "section_id": 1450,
+                    "parent": null
+                },
+                {
+                    "id": 3000,
+                    "title": 42,
+                    "part": 415,
+                    "type": "section",
+                    "section_id": 140,
+                    "parent": null
+                },
+                {
+                    "id": 3932,
+                    "title": 42,
+                    "part": 418,
+                    "type": "section",
+                    "section_id": 56,
+                    "parent": null
+                },
+                {
+                    "id": 3933,
+                    "title": 42,
+                    "part": 418,
+                    "type": "section",
+                    "section_id": 114,
+                    "parent": null
+                },
+                {
+                    "id": 1969,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 310,
+                    "parent": null
+                },
+                {
+                    "id": 2453,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 160,
+                    "parent": null
+                },
+                {
+                    "id": 3934,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 205,
+                    "parent": null
+                },
+                {
+                    "id": 3935,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 210,
+                    "parent": null
+                },
+                {
+                    "id": 1977,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 502,
+                    "parent": null
+                },
+                {
+                    "id": 1796,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 516,
+                    "parent": null
+                },
+                {
+                    "id": 1982,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 530,
+                    "parent": null
+                },
+                {
+                    "id": 1797,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 535,
+                    "parent": null
+                },
+                {
+                    "id": 3936,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 541,
+                    "parent": null
+                },
+                {
+                    "id": 3937,
+                    "title": 42,
+                    "part": 424,
+                    "type": "section",
+                    "section_id": 555,
+                    "parent": null
+                },
+                {
+                    "id": 3001,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 20,
+                    "parent": null
+                },
+                {
+                    "id": 3938,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 106,
+                    "parent": null
+                },
+                {
+                    "id": 2457,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 204,
+                    "parent": null
+                },
+                {
+                    "id": 2459,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 302,
+                    "parent": null
+                },
+                {
+                    "id": 3002,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 308,
+                    "parent": null
+                },
+                {
+                    "id": 2460,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 316,
+                    "parent": null
+                },
+                {
+                    "id": 2070,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 400,
+                    "parent": null
+                },
+                {
+                    "id": 2811,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 402,
+                    "parent": null
+                },
+                {
+                    "id": 2813,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 506,
+                    "parent": null
+                },
+                {
+                    "id": 3939,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 507,
+                    "parent": null
+                },
+                {
+                    "id": 2464,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 512,
+                    "parent": null
+                },
+                {
+                    "id": 2071,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 600,
+                    "parent": null
+                },
+                {
+                    "id": 2465,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 601,
+                    "parent": null
+                },
+                {
+                    "id": 2072,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 611,
+                    "parent": null
+                },
+                {
+                    "id": 3006,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 630,
+                    "parent": null
+                },
+                {
+                    "id": 3008,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 650,
+                    "parent": null
+                },
+                {
+                    "id": 3009,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 652,
+                    "parent": null
+                },
+                {
+                    "id": 3010,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 654,
+                    "parent": null
+                },
+                {
+                    "id": 3940,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 655,
+                    "parent": null
+                },
+                {
+                    "id": 3011,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 656,
+                    "parent": null
+                },
+                {
+                    "id": 3012,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 658,
+                    "parent": null
+                },
+                {
+                    "id": 3941,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 659,
+                    "parent": null
+                },
+                {
+                    "id": 3014,
+                    "title": 42,
+                    "part": 425,
+                    "type": "section",
+                    "section_id": 702,
+                    "parent": null
+                },
+                {
+                    "id": 463,
+                    "title": 42,
+                    "part": 455,
+                    "type": "section",
+                    "section_id": 416,
+                    "parent": 859
+                },
+                {
+                    "id": 3942,
+                    "title": 42,
+                    "part": 455,
+                    "type": "section",
+                    "section_id": 417,
+                    "parent": 859
+                },
+                {
+                    "id": 3943,
+                    "title": 42,
+                    "part": 489,
+                    "type": "section",
+                    "section_id": 30,
+                    "parent": null
+                },
+                {
+                    "id": 2129,
+                    "title": 42,
+                    "part": 491,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": null
+                },
+                {
+                    "id": 2130,
+                    "title": 42,
+                    "part": 491,
+                    "type": "section",
+                    "section_id": 8,
+                    "parent": null
+                },
+                {
+                    "id": 2318,
+                    "title": 42,
+                    "part": 495,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": null
+                },
+                {
+                    "id": 2262,
+                    "title": 42,
+                    "part": 498,
+                    "type": "section",
+                    "section_id": 2,
+                    "parent": null
+                },
+                {
+                    "id": 2082,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 125,
+                    "parent": 3104
+                },
+                {
+                    "id": 3063,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 135,
+                    "parent": 3104
+                },
+                {
+                    "id": 3064,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 140,
+                    "parent": 3104
+                },
+                {
+                    "id": 3066,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 145,
+                    "parent": 3104
+                },
+                {
+                    "id": 3071,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 170,
+                    "parent": 3104
+                },
+                {
+                    "id": 3078,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 3106
+                },
+                {
+                    "id": 3079,
+                    "title": 42,
+                    "part": 600,
+                    "type": "section",
+                    "section_id": 335,
+                    "parent": 3106
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 1,
+                    "full_name": "21st Century Cures Act",
+                    "short_name": "Cures Act",
+                    "abbreviation": null
+                },
+                {
+                    "id": 389,
+                    "full_name": "Dual Eligibles",
+                    "short_name": "Duals",
+                    "abbreviation": null
+                },
+                {
+                    "id": 106,
+                    "full_name": "Provider Screening and Enrollment",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 365,
+                    "full_name": "Basic Health Program",
+                    "short_name": null,
+                    "abbreviation": "BHP"
+                },
+                {
+                    "id": 95,
+                    "full_name": "Peer Support",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/08/07/2023-14624/medicare-and-medicaid-programs-cy-2024-payment-policies-under-the-physician-fee-schedule-and-other",
+            "id": 11313,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "SMD# 23-004",
+            "file_name_string": null,
+            "date_string": "2023-08-02",
+            "summary_string": "RE: Extension of 1915(c) Home and Community-Based Services Waiver Appendix K Expiration Dates",
+            "locations": [
+                {
+                    "id": 73,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 180,
+                    "parent": 1124
+                },
+                {
+                    "id": 17,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 181,
+                    "parent": 1124
+                },
+                {
+                    "id": 674,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 304,
+                    "parent": 1149
+                },
+                {
+                    "id": 676,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 355,
+                    "parent": 1150
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 416,
+                    "full_name": "Demonstrations and Waivers",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 7,
+                "name": "State Medicaid Director Letter (SMDL)",
+                "description": "",
+                "order": 100,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-08/smd23004.pdf",
+            "id": 9746,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 50043",
+            "file_name_string": null,
+            "date_string": "2023-08-01",
+            "summary_string": "Medicare Program; Contract Year 2024 Policy and Technical Changes to the Medicare Advantage Program, Medicare Prescription Drug Benefit Program, Medicare Cost Plan Program, and Programs of All-Inclusive Care for the Elderly; Correcting Amendment",
+            "locations": [
+                {
+                    "id": 2402,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 62,
+                    "parent": null
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 384,
+                    "full_name": "Programs of All-Inclusive Care for the Elderly",
+                    "short_name": null,
+                    "abbreviation": "PACE"
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/08/01/2023-16307/medicare-program-contract-year-2024-policy-and-technical-changes-to-the-medicare-advantage-program",
+            "id": 8147,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Infographic",
+            "file_name_string": null,
+            "date_string": "2023-08",
+            "summary_string": "Medicaid Continuous Enrollment Condition, Unwinding: At-A-Glance",
+            "locations": [
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-08/unwinding-cont-enroll-condition-infographic_1.pdf",
+            "id": 12201,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-08",
+            "summary_string": "Mitigation Plan Template for Ex Parte Renewal Compliance Issues",
+            "locations": [
+                {
+                    "id": 79,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 112,
+                    "parent": 849
+                },
+                {
+                    "id": 75,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 116,
+                    "parent": 849
+                },
+                {
+                    "id": 112,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 911,
+                    "parent": 888
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 577,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 343,
+                    "parent": 1376
+                },
+                {
+                    "id": 170,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 350,
+                    "parent": 1376
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                },
+                {
+                    "id": 219,
+                    "full_name": "Infants and Children",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 14,
+                "name": "Templates",
+                "description": "",
+                "order": 300,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-08/ex-parte-renewal-miti-plan-template.pdf",
+            "id": 7946,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-08",
+            "summary_string": "Increasing Access, Quality, and Equity in Postpartum Care in Medicaid and CHIP: A Toolkit for State Medicaid and CHIP Agencies",
+            "locations": [
+                {
+                    "id": 11,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 170,
+                    "parent": 876
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 3,
+                    "full_name": "Access to Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 131,
+                    "full_name": "Telemedicine/Telehealth",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 39,
+                    "full_name": "Family Planning and Sterilizations",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 135,
+                    "full_name": "Tobacco Cessation",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 167,
+                    "full_name": "Postpartum Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 295,
+                    "full_name": "Primary Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 460,
+                    "full_name": "Language Access",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 91,
+                    "full_name": "Other Licensed Practitioner",
+                    "short_name": null,
+                    "abbreviation": "OLP"
+                },
+                {
+                    "id": 60,
+                    "full_name": "Lactation Consultant",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 222,
+                    "full_name": "Transportation",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 31,
+                    "full_name": "Doula Services",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 15,
+                "name": "Toolkits",
+                "description": "",
+                "order": 500,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-08/ppc-for-state-and-medicaid-toolkit.pdf",
+            "id": 11857,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Fact Sheet",
+            "file_name_string": null,
+            "date_string": "2023-07",
+            "summary_string": "Returning to Regular Medicaid Renewals: Monitoring, Oversight, and Requiring States to Meet Federal Requirements",
+            "locations": [
+                {
+                    "id": 75,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 116,
+                    "parent": 849
+                },
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 97,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 1200,
+                    "parent": 1526
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-07/renewals-for-monitoring-state-systems.pdf",
+            "id": 7947,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-07",
+            "summary_string": "Highlights from the Improving Behavioral Health Follow-Up Care Affinity Group",
+            "locations": [
+                {
+                    "id": 51,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 130,
+                    "parent": 1124
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 176,
+                    "full_name": "Behavioral Health",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 442,
+                    "full_name": "Care Coordination",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 356,
+                    "full_name": "Social Determinants of Health",
+                    "short_name": null,
+                    "abbreviation": "SDOH"
+                },
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 19,
+                "name": "Briefs and Reports",
+                "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                "order": 550,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2024-02/bhfua-high-light-reprt.pdf",
+            "id": 10289,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-07",
+            "summary_string": "Using Medicaid and CHIP Managed Care Quality Oversight Activities for Quality Improvement",
+            "locations": [
+                {
+                    "id": 373,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 330,
+                    "parent": 1116
+                },
+                {
+                    "id": 376,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 340,
+                    "parent": 1116
+                },
+                {
+                    "id": 352,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 350,
+                    "parent": 1116
+                },
+                {
+                    "id": 598,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1240,
+                    "parent": 1407
+                },
+                {
+                    "id": 599,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1250,
+                    "parent": 1407
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 63,
+                    "full_name": "Managed Care",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-09/medicaid-chip-managed-care-quality-improvement-slides.pdf",
+            "id": 10611,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-07",
+            "summary_string": "Center for Medicaid & CHIP Services Mental Health and Substance Use Disorder Action Plan Overview",
+            "locations": [],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 297,
+                    "full_name": "Mental Health Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 3,
+                    "full_name": "Access to Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 155,
+                    "full_name": "Substance Use Disorder",
+                    "short_name": null,
+                    "abbreviation": "SUD"
+                }
+            ],
+            "category": {
+                "id": 139,
+                "name": "Topic Briefs and Reports",
+                "description": "",
+                "order": 310,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 19,
+                    "name": "Briefs and Reports",
+                    "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                    "order": 550,
+                    "show_if_empty": false,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/medicaid/benefits/downloads/cmcs-mntl-helth-substnce-disrdr-actn-plan-overview.pdf",
+            "id": 12585,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-07",
+            "summary_string": "Center for Medicaid & CHIP Services Mental Health and Substance Use Disorder Action Plan Guide",
+            "locations": [
+                {
+                    "id": 79,
+                    "title": 42,
+                    "part": 433,
+                    "type": "section",
+                    "section_id": 112,
+                    "parent": 849
+                },
+                {
+                    "id": 3050,
+                    "title": 42,
+                    "part": 437,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 5604
+                },
+                {
+                    "id": 362,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 68,
+                    "parent": 1086
+                },
+                {
+                    "id": 1121,
+                    "title": 42,
+                    "part": 438,
+                    "type": "subpart",
+                    "subpart_id": "K"
+                },
+                {
+                    "id": 73,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 180,
+                    "parent": 1124
+                },
+                {
+                    "id": 17,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 181,
+                    "parent": 1124
+                },
+                {
+                    "id": 18,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 182,
+                    "parent": 1124
+                },
+                {
+                    "id": 405,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 56,
+                    "parent": 889
+                },
+                {
+                    "id": 173,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1201,
+                    "parent": 1407
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 162,
+                    "full_name": "SUPPORT Act",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 3,
+                    "full_name": "Access to Care",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 356,
+                    "full_name": "Social Determinants of Health",
+                    "short_name": null,
+                    "abbreviation": "SDOH"
+                },
+                {
+                    "id": 36,
+                    "full_name": "Early and Periodic Screening, Diagnostic, and Treatment",
+                    "short_name": null,
+                    "abbreviation": "EPSDT"
+                },
+                {
+                    "id": 70,
+                    "full_name": "Mobile Crisis Services",
+                    "short_name": "Mobile Crisis",
+                    "abbreviation": null
+                },
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 165,
+                    "full_name": "Quality Improvement",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 10,
+                    "full_name": "Certified Community Behavioral Health Clinics",
+                    "short_name": null,
+                    "abbreviation": "CCBHCs"
+                },
+                {
+                    "id": 397,
+                    "full_name": "Non-traditional Settings",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 335,
+                    "full_name": "Network Adequacy",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 83,
+                    "full_name": "School-based Services",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 343,
+                    "full_name": "Transformed Medicaid Statistical Information System",
+                    "short_name": null,
+                    "abbreviation": "T-MSIS"
+                },
+                {
+                    "id": 216,
+                    "full_name": "Outreach",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 153,
+                    "full_name": "Home and Community-Based Services",
+                    "short_name": "HCBS",
+                    "abbreviation": null
+                },
+                {
+                    "id": 155,
+                    "full_name": "Substance Use Disorder",
+                    "short_name": null,
+                    "abbreviation": "SUD"
+                },
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 253,
+                    "full_name": "Incarceration",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 95,
+                    "full_name": "Peer Support",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 139,
+                "name": "Topic Briefs and Reports",
+                "description": "",
+                "order": 310,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 19,
+                    "name": "Briefs and Reports",
+                    "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                    "order": 550,
+                    "show_if_empty": false,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/medicaid/benefits/downloads/cmcs-mntl-helth-substnce-disrdr-actn-plan.pdf",
+            "id": 12635,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-06-30",
+            "summary_string": "Consolidated Appropriations Act, 2023: FMAP Reduction for Failure to Meet Reporting Requirements under Section 1902(tt)(1) of the Social Security Act",
+            "locations": [],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 380,
+                    "full_name": "Federal Medical Assistance Percentage",
+                    "short_name": "FMAP",
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 10,
+                "name": "Frequently Asked Questions (FAQs)",
+                "description": "",
+                "order": 400,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/fmap-rdctn-repot-medcid-chip-agncs-06302023.pdf",
+            "id": 8310,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "SHO# 23-003",
+            "file_name_string": null,
+            "date_string": "2023-06-27",
+            "summary_string": "Mandatory Medicaid and Children’s Health Insurance Program Coverage of Adult Vaccinations under the Inflation Reduction Act",
+            "locations": [
+                {
+                    "id": 238,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 119,
+                    "parent": 876
+                },
+                {
+                    "id": 380,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 4,
+                    "parent": 1071
+                },
+                {
+                    "id": 359,
+                    "title": 42,
+                    "part": 438,
+                    "type": "section",
+                    "section_id": 6,
+                    "parent": 1071
+                },
+                {
+                    "id": 24,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 10,
+                    "parent": 1124
+                },
+                {
+                    "id": 25,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 20,
+                    "parent": 1124
+                },
+                {
+                    "id": 26,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 50,
+                    "parent": 1124
+                },
+                {
+                    "id": 27,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": 1124
+                },
+                {
+                    "id": 2,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 90,
+                    "parent": 1124
+                },
+                {
+                    "id": 51,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 130,
+                    "parent": 1124
+                },
+                {
+                    "id": 72,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 345,
+                    "parent": 1128
+                },
+                {
+                    "id": 60,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 347,
+                    "parent": 1128
+                },
+                {
+                    "id": 493,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 56,
+                    "parent": 1195
+                },
+                {
+                    "id": 712,
+                    "title": 42,
+                    "part": 447,
+                    "type": "section",
+                    "section_id": 415,
+                    "parent": 1208
+                },
+                {
+                    "id": 708,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 160,
+                    "parent": 1361
+                },
+                {
+                    "id": 574,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 410,
+                    "parent": 1377
+                },
+                {
+                    "id": 610,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 520,
+                    "parent": 1384
+                },
+                {
+                    "id": 174,
+                    "title": 42,
+                    "part": 457,
+                    "type": "section",
+                    "section_id": 1203,
+                    "parent": 1407
+                },
+                {
+                    "id": 1845,
+                    "title": 45,
+                    "part": 147,
+                    "type": "section",
+                    "section_id": 130,
+                    "parent": null
+                },
+                {
+                    "id": 3709,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 110,
+                    "parent": 3830
+                },
+                {
+                    "id": 3601,
+                    "title": 45,
+                    "part": 156,
+                    "type": "section",
+                    "section_id": 115,
+                    "parent": 3830
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 2,
+                    "full_name": "Alternative Benefit Plan",
+                    "short_name": null,
+                    "abbreviation": "ABP"
+                },
+                {
+                    "id": 36,
+                    "full_name": "Early and Periodic Screening, Diagnostic, and Treatment",
+                    "short_name": null,
+                    "abbreviation": "EPSDT"
+                },
+                {
+                    "id": 101,
+                    "full_name": "Pregnant Women",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 232,
+                    "full_name": "Premiums and Cost Sharing",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 457,
+                    "full_name": "Mandatory Categorically Needy",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 139,
+                    "full_name": "Vaccinations and Immunizations",
+                    "short_name": "Vaccinations",
+                    "abbreviation": null
+                },
+                {
+                    "id": 206,
+                    "full_name": "New Adult Group",
+                    "short_name": "VIII group",
+                    "abbreviation": null
+                },
+                {
+                    "id": 115,
+                    "full_name": "Provider Payments",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 406,
+                    "full_name": "Provider Qualifications",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 157,
+                    "full_name": "Essential Health Benefit",
+                    "short_name": null,
+                    "abbreviation": "EHB"
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                },
+                {
+                    "id": 380,
+                    "full_name": "Federal Medical Assistance Percentage",
+                    "short_name": "FMAP",
+                    "abbreviation": null
+                },
+                {
+                    "id": 445,
+                    "full_name": "Optional Categorically Needy",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 446,
+                    "full_name": "Medically Needy",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 6,
+                "name": "State Health Official (SHO) Letter",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 5,
+                    "name": "Subregulatory Guidance",
+                    "description": "SMDLs, SHOs, CIBs, FAQs, SMM",
+                    "order": 400,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/federal-policy-guidance/downloads/sho23003.pdf",
+            "id": 13579,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-06-20",
+            "summary_string": "Non-Emergency Medical Transportation in Medicaid, 2018–2021",
+            "locations": [
+                {
+                    "id": 28,
+                    "title": 42,
+                    "part": 431,
+                    "type": "section",
+                    "section_id": 53,
+                    "parent": 985
+                },
+                {
+                    "id": 48,
+                    "title": 42,
+                    "part": 440,
+                    "type": "section",
+                    "section_id": 170,
+                    "parent": 1124
+                },
+                {
+                    "id": 453,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 62,
+                    "parent": 889
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 220,
+                    "full_name": "Data and Systems",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 222,
+                    "full_name": "Transportation",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 343,
+                    "full_name": "Transformed Medicaid Statistical Information System",
+                    "short_name": null,
+                    "abbreviation": "T-MSIS"
+                }
+            ],
+            "category": {
+                "id": 135,
+                "name": "HHS and CMS Reports to Congress",
+                "description": "",
+                "order": 210,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 19,
+                    "name": "Briefs and Reports",
+                    "description": "HHS, CMS, ASPE, and MACPAC policy analysis, briefs, summaries, and research reports, as well as HHS and CMS reports to Congress.",
+                    "order": 550,
+                    "show_if_empty": false,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/medicaid/benefits/downloads/nemt-rtc-2018-2021.pdf",
+            "id": 11348,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": null,
+            "file_name_string": null,
+            "date_string": "2023-06-12",
+            "summary_string": "Letter to U.S. Governors from HHS Secretary Xavier Becerra on Medicaid Redeterminations",
+            "locations": [
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 209,
+                    "full_name": "Procedural Denials",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                },
+                {
+                    "id": 216,
+                    "full_name": "Outreach",
+                    "short_name": null,
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.hhs.gov/about/news/2023/06/12/letter-us-governors-from-hhs-secretary-xavier-becerra-medicaid-redeterminations.html",
+            "id": 12202,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 37174",
+            "file_name_string": null,
+            "date_string": "2023-06-07",
+            "summary_string": "Medicare Program; Contract Year 2024 Policy and Technical Changes to the Medicare Advantage Program, Medicare Prescription Drug Benefit Program, Medicare Cost Plan Program, and Programs of All-Inclusive Care for the Elderly; Correction",
+            "locations": [
+                {
+                    "id": 1945,
+                    "title": 42,
+                    "part": 422,
+                    "type": "section",
+                    "section_id": 166,
+                    "parent": null
+                },
+                {
+                    "id": 1962,
+                    "title": 42,
+                    "part": 423,
+                    "type": "section",
+                    "section_id": 186,
+                    "parent": null
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 384,
+                    "full_name": "Programs of All-Inclusive Care for the Elderly",
+                    "short_name": null,
+                    "abbreviation": "PACE"
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/06/07/2023-12098/medicare-program-contract-year-2024-policy-and-technical-changes-to-the-medicare-advantage-program",
+            "id": 8146,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "88 FR 36485",
+            "file_name_string": null,
+            "date_string": "2023-06-05",
+            "summary_string": "Medicare and Medicaid Programs; Policy and Regulatory Changes to the Omnibus COVID-19 Health Care Staff Vaccination Requirements; Additional Policy and Regulatory Changes to the Requirements for Long-Term Care (LTC) Facilities and Intermediate Care Facilities for Individuals With Intellectual Disabilities (ICFs-IID) To Provide COVID-19 Vaccine Education and Offer Vaccinations to Residents, Clients, and Staff; Policy and Regulatory Changes to the Long Term Care Facility COVID-19 Testing Requirements",
+            "locations": [
+                {
+                    "id": 2180,
+                    "title": 42,
+                    "part": 416,
+                    "type": "section",
+                    "section_id": 51,
+                    "parent": null
+                },
+                {
+                    "id": 2181,
+                    "title": 42,
+                    "part": 418,
+                    "type": "section",
+                    "section_id": 60,
+                    "parent": null
+                },
+                {
+                    "id": 403,
+                    "title": 42,
+                    "part": 441,
+                    "type": "section",
+                    "section_id": 151,
+                    "parent": 1134
+                },
+                {
+                    "id": 1440,
+                    "title": 42,
+                    "part": 460,
+                    "type": "section",
+                    "section_id": 74,
+                    "parent": 1432
+                },
+                {
+                    "id": 2182,
+                    "title": 42,
+                    "part": 482,
+                    "type": "section",
+                    "section_id": 42,
+                    "parent": null
+                },
+                {
+                    "id": 1735,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 80,
+                    "parent": 7889
+                },
+                {
+                    "id": 2183,
+                    "title": 42,
+                    "part": 483,
+                    "type": "section",
+                    "section_id": 430,
+                    "parent": 7903
+                },
+                {
+                    "id": 2104,
+                    "title": 42,
+                    "part": 484,
+                    "type": "section",
+                    "section_id": 70,
+                    "parent": null
+                },
+                {
+                    "id": 2185,
+                    "title": 42,
+                    "part": 485,
+                    "type": "section",
+                    "section_id": 58,
+                    "parent": null
+                },
+                {
+                    "id": 2186,
+                    "title": 42,
+                    "part": 485,
+                    "type": "section",
+                    "section_id": 70,
+                    "parent": null
+                },
+                {
+                    "id": 2187,
+                    "title": 42,
+                    "part": 485,
+                    "type": "section",
+                    "section_id": 640,
+                    "parent": null
+                },
+                {
+                    "id": 2188,
+                    "title": 42,
+                    "part": 485,
+                    "type": "section",
+                    "section_id": 725,
+                    "parent": null
+                },
+                {
+                    "id": 2189,
+                    "title": 42,
+                    "part": 485,
+                    "type": "section",
+                    "section_id": 904,
+                    "parent": null
+                },
+                {
+                    "id": 2190,
+                    "title": 42,
+                    "part": 486,
+                    "type": "section",
+                    "section_id": 525,
+                    "parent": null
+                },
+                {
+                    "id": 2130,
+                    "title": 42,
+                    "part": 491,
+                    "type": "section",
+                    "section_id": 8,
+                    "parent": null
+                },
+                {
+                    "id": 2191,
+                    "title": 42,
+                    "part": 494,
+                    "type": "section",
+                    "section_id": 30,
+                    "parent": null
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 166,
+                    "full_name": "Quality Measures",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 139,
+                    "full_name": "Vaccinations and Immunizations",
+                    "short_name": "Vaccinations",
+                    "abbreviation": null
+                },
+                {
+                    "id": 53,
+                    "full_name": "Intermediate Care Facilities for Individuals with Intellectual Disabilities",
+                    "short_name": null,
+                    "abbreviation": "ICF IID"
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                },
+                {
+                    "id": 59,
+                    "full_name": "Laboratory, X-ray Services, and Scans",
+                    "short_name": "Lab, X-Ray, & Scans",
+                    "abbreviation": null
+                },
+                {
+                    "id": 61,
+                    "full_name": "Long-Term Services and Supports",
+                    "short_name": null,
+                    "abbreviation": "LTSS"
+                }
+            ],
+            "category": {
+                "id": 67,
+                "name": "Proposed and Final Rules",
+                "description": "Federal Register documents with agency policy proposals and decisions",
+                "order": 250,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "category"
+            },
+            "url": "https://www.federalregister.gov/documents/2023/06/05/2023-11449/medicare-and-medicaid-programs-policy-and-regulatory-changes-to-the-omnibus-covid-19-health-care",
+            "id": 10076,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Fact Sheet",
+            "file_name_string": null,
+            "date_string": "2023-06",
+            "summary_string": "All Hands-On-Deck: Keeping People Covered as States Restart Routine Medicaid Renewals - What Can You Do?",
+            "locations": [
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 216,
+                    "full_name": "Outreach",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-06/renewals-call-to-action.pdf",
+            "id": 12200,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        },
+        {
+            "doc_name_string": "Fact Sheet",
+            "file_name_string": null,
+            "date_string": "2023-06",
+            "summary_string": "All Hands-On-Deck: Keeping People Covered as States Restart Routine Medicaid Renewals",
+            "locations": [
+                {
+                    "id": 96,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 916,
+                    "parent": 888
+                },
+                {
+                    "id": 97,
+                    "title": 42,
+                    "part": 435,
+                    "type": "section",
+                    "section_id": 1200,
+                    "parent": 1526
+                }
+            ],
+            "resource_type": "external",
+            "subjects": [
+                {
+                    "id": 208,
+                    "full_name": "Unwinding",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 209,
+                    "full_name": "Procedural Denials",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 207,
+                    "full_name": "Renewals",
+                    "short_name": null,
+                    "abbreviation": null
+                },
+                {
+                    "id": 151,
+                    "full_name": "COVID-19",
+                    "short_name": "COVID",
+                    "abbreviation": null
+                }
+            ],
+            "category": {
+                "id": 13,
+                "name": "Technical Assistance for States",
+                "description": "",
+                "order": 200,
+                "show_if_empty": false,
+                "is_fr_doc_category": false,
+                "type": "subcategory",
+                "parent": {
+                    "id": 11,
+                    "name": "Implementation Resources",
+                    "description": "State Technical Assistance, Toolkits, SPA/Waiver Resources",
+                    "order": 500,
+                    "show_if_empty": true,
+                    "is_fr_doc_category": false,
+                    "type": ""
+                }
+            },
+            "url": "https://www.medicaid.gov/sites/default/files/2023-06/renewals-all-hands-on-deck-fact-sheet_0.pdf",
+            "id": 12784,
+            "document_name_headline": null,
+            "summary_headline": null,
+            "division": null
+        }
+    ]
+}

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/DocumentTypeSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/DocumentTypeSelector.vue
@@ -56,7 +56,10 @@ const toggleDocumentType = (clickedType) => {
 
     $router.push({
         name: "subjects",
-        query: queryClone,
+        query: {
+            ...queryClone,
+            page: undefined,
+        },
     });
 };
 

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -5,7 +5,11 @@ import { useRoute } from "vue-router";
 import _isEmpty from "lodash/isEmpty";
 
 import { formatDate } from "utilities/filters";
-import { getFileTypeButton, DOCUMENT_TYPES_MAP } from "utilities/utils";
+import {
+    getCurrentPageResultsRange,
+    getFileTypeButton,
+    DOCUMENT_TYPES_MAP,
+} from "utilities/utils";
 
 import CategoryLabel from "sharedComponents/results-item-parts/CategoryLabel.vue";
 import DivisionLabel from "sharedComponents/results-item-parts/DivisionLabel.vue";
@@ -84,7 +88,7 @@ export default {
 </script>
 
 <script setup>
-defineProps({
+const props = defineProps({
     results: {
         type: Array,
         default: () => [],
@@ -92,6 +96,14 @@ defineProps({
     resultsCount: {
         type: Number,
         default: 0,
+    },
+    page: {
+        type: String,
+        default: "1",
+    },
+    pageSize: {
+        type: Number,
+        default: 10,
     },
     partsLastUpdated: {
         type: Object,
@@ -132,6 +144,12 @@ const resultLinkClasses = (doc) => ({
     external: doc.resource_type === "external",
     "document__link--search": !!$route?.query?.q,
 });
+
+const currentPageResultsRange = getCurrentPageResultsRange({
+    count: props.resultsCount,
+    page: props.page,
+    pageSize: props.pageSize,
+});
 </script>
 
 <template>
@@ -142,8 +160,9 @@ const resultLinkClasses = (doc) => ({
             </h2>
             <div class="search-results-count">
                 <span v-if="results.length > 0"
-                    >1 - {{ results.length }} of</span
-                >
+                    >{{ currentPageResultsRange[0] }} -
+                    {{ currentPageResultsRange[1] }} of
+                </span>
                 {{ resultsCount }} <span v-if="searchQuery">result</span
                 ><span v-else>document</span>
                 <span v-if="results.length != 1">s</span>

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -161,8 +161,8 @@ const currentPageResultsRange = getCurrentPageResultsRange({
             <div class="search-results-count">
                 <span v-if="results.length > 0"
                     >{{ currentPageResultsRange[0] }} -
-                    {{ currentPageResultsRange[1] }} of
-                </span>
+                    {{ currentPageResultsRange[1] }} of</span
+                >
                 {{ resultsCount }} <span v-if="searchQuery">result</span
                 ><span v-else>document</span>
                 <span v-if="results.length != 1">s</span>

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -89,6 +89,10 @@ defineProps({
         type: Array,
         default: () => [],
     },
+    resultsCount: {
+        type: Number,
+        default: 0,
+    },
     partsLastUpdated: {
         type: Object,
         default: () => {},
@@ -140,7 +144,7 @@ const resultLinkClasses = (doc) => ({
                 <span v-if="results.length > 0"
                     >1 - {{ results.length }} of</span
                 >
-                {{ results.length }} <span v-if="searchQuery">result</span
+                {{ resultsCount }} <span v-if="searchQuery">result</span
                 ><span v-else>document</span>
                 <span v-if="results.length != 1">s</span>
                 <span v-if="searchQuery">

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicySelections.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicySelections.vue
@@ -33,6 +33,7 @@ const removeClick = (event) => {
         query: {
             ...routeClone,
             ...paramsToPush,
+            page: undefined,
         },
     });
 };

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
@@ -96,14 +96,11 @@ const subjectClick = (event) => {
 
     if (subjectsArray.includes(subjectToAdd)) return;
 
-    const subject = props.policyDocSubjects.results.find(
-        (s) => s.id === parseInt(subjectToAdd, 10)
-    );
-
     $router.push({
         name: "subjects",
         query: {
             ...$route.query,
+            page: undefined,
             subjects: [subjectToAdd],
         },
     });

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -491,6 +491,8 @@ getDocSubjects();
                                 :base="homeUrl"
                                 :results="policyDocList.results"
                                 :results-count="policyDocList.count"
+                                :page="$route.query.page"
+                                :page-size="pageSize"
                                 :parts-last-updated="partsLastUpdated.results"
                                 :has-editable-job-code="hasEditableJobCode"
                                 :search-query="searchQuery"

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -23,6 +23,7 @@ import HeaderSearch from "@/components/header/HeaderSearch.vue";
 import HeaderUserWidget from "@/components/header/HeaderUserWidget.vue";
 import SignInLink from "@/components/SignInLink.vue";
 import JumpTo from "@/components/JumpTo.vue";
+import PaginationController from "@/components/pagination/PaginationController.vue";
 import PolicyResults from "@/components/subjects/PolicyResults.vue";
 import PolicySelections from "@/components/subjects/PolicySelections.vue";
 import PolicySidebar from "@/components/subjects/PolicySidebar.vue";
@@ -162,6 +163,7 @@ const getPartsLastUpdated = async () => {
 
 // policyDocList fetch for policy document list
 const policyDocList = ref({
+    count: 0,
     results: [],
     loading: true,
     error: false,
@@ -178,9 +180,11 @@ const getDocList = async (requestParams = "") => {
             requestParams,
         });
         policyDocList.value.results = contentList.results;
+        policyDocList.value.count = contentList.count;
     } catch (error) {
         console.error(error);
         policyDocList.value.results = [];
+        policyDocList.value.count = 0;
         policyDocList.value.error = true;
     } finally {
         policyDocList.value.loading = false;
@@ -309,6 +313,9 @@ const setSelectedSubjectParts = () => {
         selectedSubjectParts.value = [];
     }
 };
+
+// pagination
+const pageSize = 50;
 
 watch(
     () => policyDocSubjects.value.loading,
@@ -478,11 +485,23 @@ getDocSubjects();
                             <PolicyResults
                                 :base="homeUrl"
                                 :results="policyDocList.results"
+                                :results-count="policyDocList.count"
                                 :parts-last-updated="partsLastUpdated.results"
                                 :has-editable-job-code="hasEditableJobCode"
                                 :search-query="searchQuery"
                                 :selected-subject-parts="selectedSubjectParts"
                             />
+                            <div class="pagination-expand-row">
+                                <div class="pagination-expand-container">
+                                    <PaginationController
+                                        v-if="policyDocList.count > 0"
+                                        :count="policyDocList.count"
+                                        :page="1"
+                                        :page-size="50"
+                                        view="subjects"
+                                    />
+                                </div>
+                            </div>
                         </template>
                     </template>
                 </div>

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -169,9 +169,11 @@ const policyDocList = ref({
     error: false,
 });
 
-const getDocList = async (requestParams = "") => {
+const getDocList = async (requestParamsString = "") => {
     policyDocList.value.loading = true;
     policyDocList.value.error = false;
+
+    const requestParams = requestParamsString + "&page_size=50";
 
     try {
         const contentList = await getCombinedContent({

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -227,6 +227,10 @@ provide("selectedParams", selectedParams);
 const setSelectedParams = (subjectsListRef) => (param) => {
     const [paramType, paramValue] = param;
 
+    if (paramType === "page") {
+        return;
+    }
+
     if (paramType === "q") {
         searchQuery.value = paramValue;
         return;

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -90,6 +90,8 @@ const FilterTypesDict = {
     q: "query",
 };
 
+const pageSize = 50;
+
 // provide Django template variables
 provide("apiUrl", props.apiUrl);
 provide("base", props.homeUrl);
@@ -173,7 +175,7 @@ const getDocList = async (requestParamsString = "") => {
     policyDocList.value.loading = true;
     policyDocList.value.error = false;
 
-    const requestParams = requestParamsString + "&page_size=50";
+    const requestParams = `${requestParamsString}&page_size=${pageSize}&paginate=true`;
 
     try {
         const contentList = await getCombinedContent({
@@ -315,9 +317,6 @@ const setSelectedSubjectParts = () => {
         selectedSubjectParts.value = [];
     }
 };
-
-// pagination
-const pageSize = 50;
 
 watch(
     () => policyDocSubjects.value.loading,
@@ -498,8 +497,8 @@ getDocSubjects();
                                     <PaginationController
                                         v-if="policyDocList.count > 0"
                                         :count="policyDocList.count"
-                                        :page="1"
-                                        :page-size="50"
+                                        :page="$route.query.page"
+                                        :page-size="pageSize"
                                         view="subjects"
                                     />
                                 </div>

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -491,7 +491,7 @@ getDocSubjects();
                                 :base="homeUrl"
                                 :results="policyDocList.results"
                                 :results-count="policyDocList.count"
-                                :page="$route.query.page"
+                                :page="parseInt($route.query.page, 10) || 1"
                                 :page-size="pageSize"
                                 :parts-last-updated="partsLastUpdated.results"
                                 :has-editable-job-code="hasEditableJobCode"
@@ -503,7 +503,7 @@ getDocSubjects();
                                     <PaginationController
                                         v-if="policyDocList.count > 0"
                                         :count="policyDocList.count"
-                                        :page="$route.query.page"
+                                        :page="parseInt($route.query.page, 10) || 1"
                                         :page-size="pageSize"
                                         view="subjects"
                                     />

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -124,10 +124,11 @@ const clearSearchQuery = () => {
 };
 
 const executeSearch = (payload) => {
+    const { q, page, ...rest } = $route.query;
     $router.push({
         name: "subjects",
         query: {
-            ...$route.query,
+            ...rest,
             q: payload.query,
         },
     });

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -34,6 +34,7 @@ const PARAM_MAP = {
     subjects: "subjects",
     q: "q",
     type: "resource-type",
+    page: "page",
 };
 
 /**
@@ -56,13 +57,15 @@ const PARAM_MAP = {
  * @type {Object}
  * @property {function} subjects - Validates that the subject is a number
  * @property {function} q - Validates that the query is a string or undefined.  We need to allow undefined because Vue Router can return undefined if the query param is not present.
- *
+ * @property {function} type - Validates that the type is either "external", "internal", or "all"
+ * @property {function} page - Validates that the page is a number
  */
 const PARAM_VALIDATION_DICT = {
     subjects: (subject) =>
         !Number.isNaN(parseInt(subject, 10)) && !Number.isNaN(Number(subject)),
     q: (query) => query === undefined || query.length > 0,
     type: (type) => DOCUMENT_TYPES.includes(type) || type === "all",
+    page: (page) => !Number.isNaN(parseInt(page, 10)),
 };
 
 /**

--- a/solution/ui/regulations/utilities/utils.test.js
+++ b/solution/ui/regulations/utilities/utils.test.js
@@ -202,7 +202,7 @@ describe("Utilities.js", () => {
             page: 1,
         };
 
-        expect(getRequestParams(query8)).toBe("q=test");
+        expect(getRequestParams(query8)).toBe("q=test&page=1");
 
         const query9 = {
             q: "test",


### PR DESCRIPTION
Resolves [EREGCSC-2403](https://jiraent.cms.gov/browse/EREGCSC-2403)

**Description**

Add Pagination Controls to Subjects page with a default `page_size` of `50`.

**This pull request changes:**

- Hooks `PaginationController` up into Subjects page
- Adds `page` query parameter to Subjects page to control which page of results to display
- Adds Cypress tests and fixtures of paginated data

**Steps to manually verify this change:**

1. Green check marks
2. Visit [experimental deployment](https://bvswm5lqi3.execute-api.us-east-1.amazonaws.com/dev1295/) and poke around the subjects page
   - Pagination controls should exist at the bottom of search results
   - Searches with > 50 results should have multiple pages of results
   - Results pages should be accessible via clicking "Previous/Next" buttons or clicking a page number
   - If a page number is in the URL, that page of results should be fetched and displayed on page load
      - Ex: https://bvswm5lqi3.execute-api.us-east-1.amazonaws.com/dev1295/subjects?subjects=2&page=2

