### PR TITLE
EREGCSC-2674 Fix for bug "Resource search results seem to be sorted by ID"

### DIFF
--- a/solution/backend/content_search/tests/test_search.py
+++ b/solution/backend/content_search/tests/test_search.py
@@ -206,3 +206,14 @@ class SearchTest(TestCase):
         response = self.client.get("/v3/content-search/?q=reference")
         data = get_paginated_data(response)
         self.assertEqual(data["results"][0]["content_headline"], None)
+
+    # If sorted by 'id', a search for 'fire' from fixture data will return two results with pk's 92 then 98.
+    # We want the results sorted by rank, which if working properly will return the reverse: 98 then 92.
+    def test_rank_sorting(self):
+        self.login()
+        response = self.client.get("/v3/content-search/?q=fire")
+        data = get_paginated_data(response)
+        results = data["results"]
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["id"], 98)
+        self.assertEqual(results[1]["id"], 92)


### PR DESCRIPTION
Resolves #2674

**Description-**

Due to the recent change (https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1231) that made it so that search headlines were only generated for the current page instead of the entire queryset, we were losing the `sort_by("-rank")` from the search query.

Upon feeding the rank-sorted, paginated results back into a second `ContentIndex` `pk__in` filter, the default sort by `pk` was occurring instead. Since the rank is lost by the time the second query occurs, there is no way to simply include a second `sort_by`.

Instead we have to use the ranked-sorted list of pk's to sort the output of the second query immediately before serialization.

**This pull request changes...**

- Store `ranked_results` list (renamed from `results`) at the function level for use later in the function.
- Later in the function, use Python's built-in `sorted` method to sort the final queryset by the initial queryset's outut.
- Added a test to verify that sort by rank is working as expected.

**Steps to manually verify this change...**

1. In the experimental deploy, search for `medicaid` (e.g. `/v3/content-search/?q=medicaid`).
2. By observing the `id` field in each result, verify that they are _not_ sorted by `id` ascending.
    - Simply verifying that _at least one_ id is less than the next in the list is proof enough for this test.

