### PR TITLE
EREGCSC-2460 -- Remove flaky Cypress test

### DIFF
--- a/solution/ui/e2e/cypress/e2e/part.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/part.spec.cy.js
@@ -188,38 +188,6 @@ describe("Part View", () => {
                 "contain.text",
                 "Cost Allocations for Surveys of Home Health Agencies (HHAs)"
             );
-
-        // Assert that internal documents can also mix with subcategories
-        // Find and expand Internal Documents category
-        cy.get("button[data-test='Internal Documents and Correspondence']")
-            .scrollIntoView()
-            .click({ force: true });
-
-        // Assert that subcategory is visible
-        cy.get("button[data-test='Policy Context/Interpretation']").should(
-            "be.visible"
-        );
-
-        // Assert that supplemental content list is visible alongside subcategories
-        cy.get(
-            "div[data-test='Internal Documents and Correspondence'] > .supplemental-content-list"
-        ).should("exist");
-
-        // Assert that supplemental content that is not in a subcategory is visible
-        // and contains expected text
-        cy.get(
-            "div[data-test='Internal Documents and Correspondence'] > .supplemental-content-list a .supplemental-content-description"
-        )
-            .first()
-            .should("exist");
-
-        cy.get(
-            "div[data-test='Internal Documents and Correspondence'] > .supplemental-content-list a .supplemental-content-description"
-        )
-            .first()
-            .find("span")
-            .first()
-            .should("contain.text", "[Mock] TXT testDownload TXT");
     });
 
     it("loads a subpart view in a mobile width", () => {


### PR DESCRIPTION
Resolves [EREGCSC-2460](https://jiraent.cms.gov/browse/EREGCSC-2460)

**Description**

The original PR for EREGCSC-2460 included Cypress end to end tests to validate that individual items were displayed alongside item subcategories under a single category.  

Tests were written to validate public AND internal documents.

However, internal document tests are flaky and are preventing deployment to `prod`.  Since the functionality of this PR has been manually validated for both public and internal documents, and because the code changes are already being validated in Cypress using public documents, the flaky internal document tests are being removed as unnecessary.

**This pull request changes:**

- Remove internal document test logic

**Steps to manually verify this change:**

1. Green check marks
2. PR is merged into `main` and deploy successfully to `dev`/`val`/`prod`

