### PR TITLE
[Hotfix] Remove `resources/search` endpoint from Cypress API test suite

### DIFF
--- a/solution/ui/e2e/cypress/e2e/api.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/api.spec.cy.js
@@ -35,7 +35,6 @@ const API_ENDPOINTS_V3 = [
     `/v3/resources/locations`,
     `/v3/resources/locations/sections`,
     `/v3/resources/locations/subparts`,
-    `/v3/resources/search?q=${SEARCH_TERM}`,
     `/v3/resources/supplemental_content`,
     `/v3/search?q=${SEARCH_TERM}`,
     `/v3/statutes`,


### PR DESCRIPTION
Resolves issue where our deployments depend on Search.gov having 100% uptime

**Description**

In order to return a successful response, one of our unused and soon-to-be-deleted endpoints, `v3/resources/search`, needs a valid response from Search.gov.

Unfortunately, right now Search.gov is having some issues and requests are timing out. Our `v3/resources/search` endpoint is not equipped to gracefully handle a Search.gov timeout, and as a result this endpoint is returning a 500 error that is causing a Cypress test to fail.  This failing test is preventing us from deploying anything.

**This pull request changes:**

- Removes test for `v3/resources/search` endpoint

**Steps to manually verify this change:**

1. Green check marks
2. Successful deployments all the way to `prod`

