### PR TITLE
EREGCSC-2711 -- Update Vue Router navigation guard to ensure query params are not an array (except `type`)

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/components/dropdowns/Categories.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/dropdowns/Categories.vue
@@ -152,7 +152,7 @@ onMounted(() => {
     window.addEventListener("popstate", onPopState);
 });
 
-onUnmounted(() => window.removeEventListener("resize", onPopState));
+onUnmounted(() => window.removeEventListener("popstate", onPopState));
 </script>
 
 <template>

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicySelections.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicySelections.vue
@@ -4,8 +4,6 @@ import { useRouter, useRoute } from "vue-router";
 
 import useRemoveList from "composables/removeList";
 
-import _isArray from "lodash/isArray";
-
 const $router = useRouter();
 const $route = useRoute();
 

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectChip.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectChip.vue
@@ -38,7 +38,7 @@ defineProps({
         :to="{
             name: 'subjects',
             query: {
-                subjects: [subjectId.toString()],
+                subjects: subjectId.toString(),
                 type: ['all'],
             },
             params: { subjectName },

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectSelector.vue
@@ -110,7 +110,7 @@ const subjectClick = (event) => {
         name: "subjects",
         query: {
             ...cleanedRoute,
-            subjects: [subjectToAdd],
+            subjects: subjectToAdd,
         },
     });
 };

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectTOC.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectTOC.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, inject } from "vue";
 
-import { getSubjectName, getSubjectNameParts } from "utilities/filters";
+import { getSubjectNameParts } from "utilities/filters";
 
 const isAuthenticated = inject("isAuthenticated");
 

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectTOC.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SubjectTOC.vue
@@ -35,7 +35,7 @@ const subjectsLength = computed(() => props.policyDocSubjects.results.length);
                         :to="{
                             name: 'subjects',
                             query: {
-                                subjects: [subject.id.toString()],
+                                subjects: subject.id.toString(),
                             },
                         }"
                     >

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -6,6 +6,8 @@ import vuetify from "./plugins/vuetify";
 import App from "./App.vue";
 import vueRouter from "./router";
 
+import _isArray from "lodash/isArray";
+
 const mountEl = document.querySelector("#vite-app");
 const { customUrl, host } = mountEl.dataset;
 
@@ -21,6 +23,15 @@ const router = vueRouter({ customUrl, host });
 
 router.beforeEach((to) => {
     const pageTitle = "Find by Subject | Medicaid & CHIP eRegulations";
+
+    // If you pass multiple query params in the URL, Vue Router will parse them as arrays.
+    // This is a workaround to convert them back to strings -- we only need the first value.
+    // `type` is the only query param that should be an array.
+    Object.entries(to.query).forEach(([key, value]) => {
+        if (_isArray(value) && key != "type") {
+            to.query[key] = value[0];
+        }
+    });
 
     if (to.name === "subjects") {
         if (!to.query?.subject) {

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -24,22 +24,14 @@ const router = vueRouter({ customUrl, host });
 router.beforeEach((to) => {
     const pageTitle = "Find by Subject | Medicaid & CHIP eRegulations";
 
-    const queryClone = { ...to.query };
-
-    Object.entries(queryClone).forEach(([key, value]) => {
-        if (!_isArray(value)) {
-            queryClone[key] = [value];
-        }
-    });
-
     if (to.name === "subjects") {
-        if (!queryClone?.subject) {
+        if (!to.query?.subject) {
             document.title = pageTitle;
         }
 
-        if (!isAuthenticated && queryClone?.type) {
-            const { type, ...typelessQuery } = queryClone;
-            return { name: "subjects", typelessQuery };
+        if (!isAuthenticated && to.query?.type) {
+            const { type, ...typelessQuery } = to.query;
+            return { name: "subjects", query: typelessQuery };
         }
     }
 

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -6,8 +6,6 @@ import vuetify from "./plugins/vuetify";
 import App from "./App.vue";
 import vueRouter from "./router";
 
-import _isArray from "lodash/isArray";
-
 const mountEl = document.querySelector("#vite-app");
 const { customUrl, host } = mountEl.dataset;
 

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -6,6 +6,8 @@ import vuetify from "./plugins/vuetify";
 import App from "./App.vue";
 import vueRouter from "./router";
 
+import _isArray from "lodash/isArray";
+
 const mountEl = document.querySelector("#vite-app");
 const { customUrl, host } = mountEl.dataset;
 
@@ -22,14 +24,22 @@ const router = vueRouter({ customUrl, host });
 router.beforeEach((to) => {
     const pageTitle = "Find by Subject | Medicaid & CHIP eRegulations";
 
+    const queryClone = { ...to.query };
+
+    Object.entries(queryClone).forEach(([key, value]) => {
+        if (!_isArray(value)) {
+            queryClone[key] = [value];
+        }
+    });
+
     if (to.name === "subjects") {
-        if (!to.query?.subject) {
+        if (!queryClone?.subject) {
             document.title = pageTitle;
         }
 
-        if (!isAuthenticated && to.query?.type) {
-            const { type, ...query } = to.query;
-            return { name: "subjects", query };
+        if (!isAuthenticated && queryClone?.type) {
+            const { type, ...typelessQuery } = queryClone;
+            return { name: "subjects", typelessQuery };
         }
     }
 

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from "vue-router";
 
 import useRemoveList from "composables/removeList";
 
+import _isArray from "lodash/isArray";
 import _isEmpty from "lodash/isEmpty";
 
 import {
@@ -264,7 +265,8 @@ const setSelectedParams = (subjectsListRef) => (param) => {
         return;
     }
 
-    paramValue.forEach((paramId) => {
+    const paramList = !_isArray(paramValue) ? [paramValue] : paramValue;
+    paramList.forEach((paramId) => {
         const subject = subjectsListRef.value.results.filter(
             (subjectObj) => paramId === subjectObj.id.toString()
         )[0];
@@ -371,7 +373,9 @@ watch(
         // set title on subject selection
         const { subjects } = newQueryParams;
         if (subjects) {
-            const subjectTitleToSet = subjects[0];
+            const subjectTitleToSet = _isArray(subjects)
+                ? subjects[0]
+                : subjects;
             setDocumentTitle(
                 subjectTitleToSet,
                 policyDocSubjects.value.results

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -4,7 +4,6 @@ import { useRoute, useRouter } from "vue-router";
 
 import useRemoveList from "composables/removeList";
 
-import _isArray from "lodash/isArray";
 import _isEmpty from "lodash/isEmpty";
 
 import {
@@ -265,8 +264,7 @@ const setSelectedParams = (subjectsListRef) => (param) => {
         return;
     }
 
-    const paramList = !_isArray(paramValue) ? [paramValue] : paramValue;
-    paramList.forEach((paramId) => {
+    paramValue.forEach((paramId) => {
         const subject = subjectsListRef.value.results.filter(
             (subjectObj) => paramId === subjectObj.id.toString()
         )[0];
@@ -373,9 +371,7 @@ watch(
         // set title on subject selection
         const { subjects } = newQueryParams;
         if (subjects) {
-            const subjectTitleToSet = _isArray(subjects)
-                ? subjects[0]
-                : subjects;
+            const subjectTitleToSet = subjects[0];
             setDocumentTitle(
                 subjectTitleToSet,
                 policyDocSubjects.value.results


### PR DESCRIPTION
Resolves [EREGCSC-2711](https://jiraent.cms.gov/browse/EREGCSC-2711)

**Description**

We've had some issues where some query parameters from the Vue Router `route` are arrays sometimes and strings other times.  Specifically, this has been happening to `subjects`.

The reason for this issue turns out to be: we are explicitly setting `subjects` as an array when we programmatically set it via `router-link` or `$router.push`.  Whoops!

This was likely left over from the initial implementation of the Subjects page, where we briefly allows users to select more than one subject to view results from all subjects.  This was quickly changed to the current implementation, which only allows one subject to be selected at a time.

As such, we've removed the instances where we are programmatically setting `subjects` as an array -- it is now set as a string once again.

However.

If you have more than one query parameter in the URL -- `?subjects=1&subjects=2`, for example -- then Vue Router will still return `subjects` as an array (`subjects: ["1", "2"]`).  So we still need to handle the possibility that a user may somehow edit the URL and add another query parameter to one that already exists, if only to make sure the site doesn't keep breaking.

In this case, we're just going to return the first item in the resulting array -- so `subjects: ["1", "2"]` will be changed to to `subjects: "1"`.  The URL will still contain the multiple `subjects` query params but the site will load assuming that only the first one matters.  This is an extreme edge case that would be the result of the user mucking around in the URL, but it's a low lift to guard against this unlikely scenario.

So, now `subjects` and all query params that are not `type` (which is used in the Document Type Selector to filter by Internal or External documents) can safely be assumed to be a string.  (`type` will probably get refactors a tiny bit in a coming story so it may also join the other query params in being consistent.)

**This pull request changes:**

- When programmatically setting the `subjects` query param via `router-link` or `$router.push`, do not wrap the value in an array
- In the `router.beforeEach` navigation guard, loop through query params and ensure they are not arrays.  If they are arrays, only return the first item in that array.
   - except `type`, as noted above
- Clean up unused imports
- Fix `removeEventListener` to remove the correct event listener

**Steps to manually verify this change:**

1. Green check marks
2. Site works as expected on [experimental deployment](https://dd3cd7n5ue.execute-api.us-east-1.amazonaws.com/dev1329)
3. Visit a complex filter state and make sure it loads properly ([example](https://dd3cd7n5ue.execute-api.us-east-1.amazonaws.com/dev1329/subjects/?categories=11&page=2&q=long-term))
4. No errors in the console

