### PR TITLE
EREGCSC-2678-remove-zappa-django-utils

### DIFF
--- a/solution/static-assets/requirements.txt
+++ b/solution/static-assets/requirements.txt
@@ -1,6 +1,5 @@
 Cryptography==3.4.8
 Werkzeug==0.15.5
-zappa-django-utils
 boto3
 django-debug-toolbar
 django>=5,<6


### PR DESCRIPTION
Resolves #EREGCSC-2678-remove-zappa-django-utils

**Description-**
Snyk [reports](https://app.snyk.io/org/eregs-x7s/project/95496066-f240-4403-b97d-ae11557a04ce) that our [requirements file](https://github.com/Enterprise-CMCS/cmcs-eregulations/blob/main/solution/static-assets/requirements.txt) includes a transitive dependency on Django version 1, apparently through [zappa-django-utils](https://github.com/Miserlou/zappa-django-utils/blob/master/requirements.txt).

Therefore, we should remove this dependency. If we still require its functionality, we should replace it with an alternative solution.
So we should remove it. If we still need something it did, let's replace it with something else.

**This pull request changes...**

- expected change 1
updated requirements.txt to remove this plugin

update the requirements.txt to remove zappa-django-utils

**Steps to manually verify this change...**

Ensure website still functions properly after removal of zapa-ddjango-utils
Make sure test pass.
