### PR TITLE
EREGCSC-2478 Add license + remove old dependencies for serverless-cloudfront-invalidate

### DIFF
--- a/solution/backend/package.json
+++ b/solution/backend/package.json
@@ -8,8 +8,5 @@
     "serverless-go-plugin": "^2.0.1",
     "serverless-python-requirements": "^5.1.1",
     "serverless-wsgi": "^1.7.8"
-  },
-  "dependencies": {
-    "serverless-cloudfront-invalidate": "^1.12.2"
   }
 }

--- a/solution/serverless-test-files/package.json
+++ b/solution/serverless-test-files/package.json
@@ -7,8 +7,5 @@
     "serverless-go-plugin": "^2.0.1",
     "serverless-python-requirements": "^5.1.1",
     "serverless-wsgi": "^1.7.8"
-  },
-  "dependencies": {
-    "serverless-cloudfront-invalidate": "^1.12.2"
   }
 }

--- a/solution/static-assets/custom-cf-invalidate-plugin/LICENSE
+++ b/solution/static-assets/custom-cf-invalidate-plugin/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Amir
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/solution/static-assets/custom-cf-invalidate-plugin/index.js
+++ b/solution/static-assets/custom-cf-invalidate-plugin/index.js
@@ -1,4 +1,3 @@
-=======
 /**
  * This file is a modified version of https://github.com/aghadiry/serverless-cloudfront-invalidate,
  * which is licensed under the MIT license.

--- a/solution/static-assets/custom-cf-invalidate-plugin/index.js
+++ b/solution/static-assets/custom-cf-invalidate-plugin/index.js
@@ -1,3 +1,31 @@
+=======
+/**
+ * This file is a modified version of https://github.com/aghadiry/serverless-cloudfront-invalidate,
+ * which is licensed under the MIT license.
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017 aghadiry
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 'use strict';
 
 const randomstring = require('randomstring');

--- a/solution/static-assets/package.json
+++ b/solution/static-assets/package.json
@@ -4,7 +4,6 @@
     "description": "Serverless config for eRegs core",
     "private": true,
     "dependencies": {
-        "serverless-cloudfront-invalidate": "^1.12.2",
         "serverless-python-requirements": "^5.4.0",
         "serverless-s3-sync": "^1.17.3"
     }

--- a/solution/static-assets/package.json
+++ b/solution/static-assets/package.json
@@ -5,9 +5,7 @@
     "private": true,
     "dependencies": {
         "serverless-python-requirements": "^5.4.0",
-        "serverless-s3-sync": "^1.17.3"
-    },
-    "devDependencies": {
+        "serverless-s3-sync": "^1.17.3",
         "aws-sdk": "^2.224.1",
         "chalk": "^2.3.1",
         "proxy-agent": "^5.0.0",

--- a/solution/static-assets/package.json
+++ b/solution/static-assets/package.json
@@ -6,5 +6,11 @@
     "dependencies": {
         "serverless-python-requirements": "^5.4.0",
         "serverless-s3-sync": "^1.17.3"
+    },
+    "devDependencies": {
+        "aws-sdk": "^2.224.1",
+        "chalk": "^2.3.1",
+        "proxy-agent": "^5.0.0",
+        "randomstring": "^1.1.5"
     }
 }


### PR DESCRIPTION
Resolves #EREGCSC-2478

**Description-**
We integrated the serverless-cloudfront-invalidate plugin into our project in the previous update (#1326). This pull request adds the MIT license from the original repository and removes references to the old package.

**This pull request changes...**

Adds license text

Removes references to old package

**Steps to manually verify this change...**
Ensure tests pass
Ensure license is there