### PR TITLE
EREGCSC-2713 -- Encode hash marks and other characters in `content-search` endpoint

### DIFF
--- a/solution/ui/e2e/cypress/e2e/search.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/search.spec.cy.js
@@ -55,7 +55,7 @@ describe("Search flow", () => {
         cy.get('[data-testid="search-form-submit"]').click({
             force: true,
         });
-        cy.url().should("include", "/search?q=test+search");
+        cy.url().should("include", "/search?q=test%2520search");
         cy.get(".search-form .form-helper-text .search-suggestion").should(
             "not.exist"
         );

--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -427,7 +427,7 @@ describe("Find by Subjects", () => {
         });
         cy.url().should(
             "include",
-            "/subjects?type=internal&subjects=3&q=test+search"
+            "/subjects?type=internal&subjects=3&q=test%2520search"
         );
         cy.get(".search-form .form-helper-text .search-suggestion").should(
             "not.exist"

--- a/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchEmptyState.vue
@@ -4,14 +4,21 @@
         <div class="options-list">
             <div class="query-prompt">
                 See results for
-                <span class="query-emphasis">{{ query }}</span> on:
+                <span class="query-emphasis">{{
+                    decodeURIComponent(query)
+                }}</span>
+                on:
             </div>
             <ul class="external-resource-links">
                 <li v-if="showInternalLink">
                     <a :href="eregsLink">{{ eregs_url_label }}</a>
                 </li>
                 <li>
-                    <a :href="ecfrLink" class="external" target="_blank" rel="noopener noreferrer"
+                    <a
+                        :href="ecfrLink"
+                        class="external"
+                        target="_blank"
+                        rel="noopener noreferrer"
                         >eCFR</a
                     >
                 </li>
@@ -25,7 +32,11 @@
                     >
                 </li>
                 <li>
-                    <a :href="medicaidGovLink" class="external" target="_blank" rel="noopener noreferrer"
+                    <a
+                        :href="medicaidGovLink"
+                        class="external"
+                        target="_blank"
+                        rel="noopener noreferrer"
                         >Medicaid.gov</a
                     >
                 </li>

--- a/solution/ui/regulations/eregs-vite/src/components/SearchInput.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchInput.vue
@@ -164,7 +164,7 @@ export default {
     watch: {
         searchQuery: {
             async handler(newQuery) {
-                this.searchInputValue = decodeURIComponent(newQuery);
+                this.updateSearchValue(newQuery);
             },
         },
     },

--- a/solution/ui/regulations/eregs-vite/src/components/SearchInput.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchInput.vue
@@ -93,7 +93,7 @@ export default {
         },
         searchQuery: {
             type: String,
-            default: undefined,
+            default: "",
         },
         synonyms: {
             type: Array,
@@ -106,17 +106,17 @@ export default {
     },
 
     created() {
-        this.searchInputValue = this.searchQuery;
+        this.searchInputValue = decodeURIComponent(this.searchQuery);
     },
     data() {
         return {
-            searchInputValue: undefined,
+            searchInputValue: "",
         };
     },
 
     computed: {
         multiWordQuery() {
-            if (this.searchQuery === undefined) return false;
+            if (this.searchQuery === "") return false;
 
             return (
                 this.searchQuery.split(" ").length > 1 &&
@@ -128,14 +128,16 @@ export default {
 
     methods: {
         submitForm() {
-            this.$emit("execute-search", { query: this.searchInputValue });
+            this.$emit("execute-search", {
+                query: encodeURIComponent(this.searchInputValue),
+            });
         },
         clearForm() {
-            this.searchInputValue = undefined;
+            this.searchInputValue = "";
             this.$emit("clear-form");
         },
         updateSearchValue(value) {
-            this.searchInputValue = value;
+            this.searchInputValue = decodeURIComponent(value);
         },
         synonymLink(synonym) {
             this.$router.push({
@@ -162,7 +164,7 @@ export default {
     watch: {
         searchQuery: {
             async handler(newQuery) {
-                this.searchInputValue = newQuery;
+                this.searchInputValue = decodeURIComponent(newQuery);
             },
         },
     },

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -169,7 +169,7 @@ const currentPageResultsRange = getCurrentPageResultsRange({
                 <span v-if="searchQuery">
                     for
                     <span class="search-query__span">{{
-                        searchQuery
+                        decodeURIComponent(searchQuery)
                     }}</span></span
                 >
                 <span v-if="searchQuery && selectedSubjectParts[0]">

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -424,7 +424,7 @@ export default {
         },
         async retrieveResourcesResults({ query, page, pageSize }) {
             this.resourcesError = false;
-            const requestParams = `q=${query}&page=${
+            const requestParams = `q=${encodeURIComponent(query)}&page=${
                 page ?? 1
             }&page_size=${pageSize}&paginate=true`;
             let response = "";

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -310,7 +310,7 @@ export default {
             );
             this.retrieveSynonyms(this.searchQuery);
             this.retrieveAllResults({
-                query: this.searchQuery,
+                query: encodeURIComponent(this.searchQuery),
                 page: this.page,
                 pageSize: this.pageSize,
             });
@@ -424,7 +424,7 @@ export default {
         },
         async retrieveResourcesResults({ query, page, pageSize }) {
             this.resourcesError = false;
-            const requestParams = `q=${encodeURIComponent(query)}&page=${
+            const requestParams = `q=${query}&page=${
                 page ?? 1
             }&page_size=${pageSize}&paginate=true`;
             let response = "";

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -310,7 +310,7 @@ export default {
             );
             this.retrieveSynonyms(this.searchQuery);
             this.retrieveAllResults({
-                query: encodeURIComponent(this.searchQuery),
+                query: this.searchQuery,
                 page: this.page,
                 pageSize: this.pageSize,
             });

--- a/solution/ui/regulations/utilities/api.js
+++ b/solution/ui/regulations/utilities/api.js
@@ -386,9 +386,7 @@ const getRegSearchResults = async ({
     page_size = 100,
 }) => {
     const response = await httpApiGet(
-        `search?q=${encodeURIComponent(
-            q
-        )}&paginate=${paginate}&page_size=${page_size}&page=${page}`
+        `search?q=${q}&paginate=${paginate}&page_size=${page_size}&page=${page}`
     );
 
     return response;

--- a/solution/ui/regulations/utilities/api.js
+++ b/solution/ui/regulations/utilities/api.js
@@ -630,7 +630,7 @@ const getCombinedContent = async ({
 }) =>
     httpApiGetLegacy(
         `${apiUrl}content-search/${
-            requestParams ? `?${requestParams}&` : "?"
+            requestParams ? `?${encodeURIComponent(requestParams)}&` : "?"
         }location_details=true&category_details=true`,
         {},
         cacheResponse

--- a/solution/ui/regulations/utilities/api.js
+++ b/solution/ui/regulations/utilities/api.js
@@ -630,7 +630,7 @@ const getCombinedContent = async ({
 }) =>
     httpApiGetLegacy(
         `${apiUrl}content-search/${
-            requestParams ? `?${encodeURIComponent(requestParams)}&` : "?"
+            requestParams ? `?${requestParams}&` : "?"
         }location_details=true&category_details=true`,
         {},
         cacheResponse

--- a/solution/ui/regulations/utilities/api.js
+++ b/solution/ui/regulations/utilities/api.js
@@ -190,7 +190,11 @@ function fetchJson({
 
 // ---------- helper functions ---------------
 
-function httpApiGet(urlPath, { params } = {}, cacheResponse = DEFAULT_CACHE_RESPONSE) {
+function httpApiGet(
+    urlPath,
+    { params } = {},
+    cacheResponse = DEFAULT_CACHE_RESPONSE
+) {
     return fetchJson({
         url: `${config.apiPath}/${urlPath}`,
         options: {
@@ -202,7 +206,11 @@ function httpApiGet(urlPath, { params } = {}, cacheResponse = DEFAULT_CACHE_RESP
 }
 
 // use when components used directly in Django templates
-function httpApiGetLegacy(urlPath, { params } = {}, cacheResponse = DEFAULT_CACHE_RESPONSE) {
+function httpApiGetLegacy(
+    urlPath,
+    { params } = {},
+    cacheResponse = DEFAULT_CACHE_RESPONSE
+) {
     return fetchJson({
         url: `${urlPath}`,
         options: {
@@ -254,7 +262,10 @@ const setCacheItem = async (key, data) => {
  * @param {boolean} [options.cacheResponse=DEFAULT_CACHE_RESPONSE] - A boolean flag indicating whether to cache the API response. Defaults to the value of `DEFAULT_CACHE_RESPONSE`.
  * @returns {Promise<Array<object>>} - Promise that contains array of categories when fulfilled
  */
-const getExternalCategories = async ({apiUrl, cacheResponse = DEFAULT_CACHE_RESPONSE}) => {
+const getExternalCategories = async ({
+    apiUrl,
+    cacheResponse = DEFAULT_CACHE_RESPONSE,
+}) => {
     if (apiUrl) {
         return httpApiGetLegacy(
             `${apiUrl}resources/categories`,
@@ -276,7 +287,10 @@ const getExternalCategories = async ({apiUrl, cacheResponse = DEFAULT_CACHE_RESP
  * @param {boolean} [options.cacheResponse=DEFAULT_CACHE_RESPONSE] - A boolean flag indicating whether to cache the API response. Defaults to the value of `DEFAULT_CACHE_RESPONSE`.
  * @returns {Promise<Array<object>>} - Promise that contains array of categories when fulfilled
  */
-const getExternalCategoriesTree = async ({apiUrl, cacheResponse = DEFAULT_CACHE_RESPONSE}) => {
+const getExternalCategoriesTree = async ({
+    apiUrl,
+    cacheResponse = DEFAULT_CACHE_RESPONSE,
+}) => {
     if (apiUrl) {
         return httpApiGetLegacy(
             `${apiUrl}resources/categories/tree`,
@@ -532,7 +546,10 @@ const getStatutes = async ({
  * @param {boolean} [cacheResponse=DEFAULT_CACHE_RESPONSE] - Whether to cache the response. Defaults to the value of `DEFAULT_CACHE_RESPONSE`.
  * @returns {Promise<Array<{id: number, full_name: string, short_name: string, abbreviation: string}>>} - Promise that contains array of subjects when fulfilled
  */
-const getInternalSubjects = async ({ apiUrl, cacheResponse = DEFAULT_CACHE_RESPONSE }) => {
+const getInternalSubjects = async ({
+    apiUrl,
+    cacheResponse = DEFAULT_CACHE_RESPONSE,
+}) => {
     if (apiUrl) {
         return httpApiGetLegacy(
             `${apiUrl}file-manager/subjects`,
@@ -563,7 +580,10 @@ const getInternalSubjects = async ({ apiUrl, cacheResponse = DEFAULT_CACHE_RESPO
  * @param {boolean} [cacheResponse=DEFAULTS_CACHE_RESPONSE] - Whether to cache the response. Defaults to the value of `DEFAULT_CACHE_RESPONSE`.
  * @returns {Promise<Array<InternalCategory>>} - Promise that contains array of categories when fulfilled
  */
-const getInternalCategories = async ({ apiUrl, cacheResponse = DEFAULT_CACHE_RESPONSE }) => {
+const getInternalCategories = async ({
+    apiUrl,
+    cacheResponse = DEFAULT_CACHE_RESPONSE,
+}) => {
     if (apiUrl) {
         return httpApiGetLegacy(
             `${apiUrl}file-manager/categories`,
@@ -582,7 +602,10 @@ const getInternalCategories = async ({ apiUrl, cacheResponse = DEFAULT_CACHE_RES
  * @param {boolean} [cacheResponse=DEFAULT_CACHE_RESPONSE] - Whether to cache the response. Defaults to the value of `DEFAULT_CACHE_RESPONSE`.
  * @returns {Promise<Array<InternalCategory>>} - Promise that contains array of categories when fulfilled
  */
-const getInternalCategoriesTree = async ({ apiUrl, cacheResponse = DEFAULT_CACHE_RESPONSE }) => {
+const getInternalCategoriesTree = async ({
+    apiUrl,
+    cacheResponse = DEFAULT_CACHE_RESPONSE,
+}) => {
     if (apiUrl) {
         return httpApiGetLegacy(
             `${apiUrl}file-manager/categories/tree`,

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -74,6 +74,17 @@ const PARAM_VALIDATION_DICT = {
     intcategories: (category) => !Number.isNaN(parseInt(category, 10)),
 };
 
+/**
+ * Dictionary of query parameters to encode before sending to the API.
+ *
+ * * @type {Object}
+ * @property {function} q - Encodes the q search string query parameter
+ *
+ * @example
+ * const query = "SMDL #12-002";
+ * const encodedQuery = PARAM_ENCODE_DICT.q(query);
+ * console.log(encodedQuery); // "SMDL%20%2312-002"
+ */
 const PARAM_ENCODE_DICT = {
     q: (query) => encodeURIComponent(query),
 };

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -74,6 +74,10 @@ const PARAM_VALIDATION_DICT = {
     intcategories: (category) => !Number.isNaN(parseInt(category, 10)),
 };
 
+const PARAM_ENCODE_DICT = {
+    q: (query) => encodeURIComponent(query),
+};
+
 /**
  * @param {string} fileName - name of the file
  * @returns {string | null} - returns null if the file name is not a string or does not pass validation;
@@ -146,7 +150,12 @@ const getRequestParams = (query) => {
             );
 
             return filteredValues
-                .map((v) => `${PARAM_MAP[key]}=${v}`)
+                .map(
+                    (v) =>
+                        `${PARAM_MAP[key]}=${
+                            PARAM_ENCODE_DICT[key] ? encodeURIComponent(v) : v
+                        }`
+                )
                 .join("&");
         })
         .filter(([key, value]) => !_isEmpty(value))

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -75,21 +75,6 @@ const PARAM_VALIDATION_DICT = {
 };
 
 /**
- * Dictionary of query parameters to encode before sending to the API.
- *
- * * @type {Object}
- * @property {function} q - Encodes the q search string query parameter
- *
- * @example
- * const query = "SMDL #12-002";
- * const encodedQuery = PARAM_ENCODE_DICT.q(query);
- * console.log(encodedQuery); // "SMDL%20%2312-002"
- */
-const PARAM_ENCODE_DICT = {
-    q: (query) => encodeURIComponent(query),
-};
-
-/**
  * @param {string} fileName - name of the file
  * @returns {string | null} - returns null if the file name is not a string or does not pass validation;
  * otherwise returns the suffix of the file name
@@ -163,9 +148,7 @@ const getRequestParams = (query) => {
             return filteredValues
                 .map(
                     (v) =>
-                        `${PARAM_MAP[key]}=${
-                            PARAM_ENCODE_DICT[key] ? encodeURIComponent(v) : v
-                        }`
+                        `${PARAM_MAP[key]}=${v}`
                 )
                 .join("&");
         })


### PR DESCRIPTION
Resolves [EREGCSC-2713](https://jiraent.cms.gov/browse/EREGCSC-2713)

**Description**

If you search for something with a # in the query (from the combined search page or from the subjects page), you get a few unexpected effects:

- In the results, the “related regulation citations” show as “none”
- In the results, the category and subcategory labels are missing ("Subregulatory Guidance" etc)
- Anything after # in the query seems to be ignored
- If you're on the subjects page and run this kind of query, the filters don't work as expected. For example, if I uncheck "public", public items are still displayed. 

**This pull request changes:**

- TBD

**Steps to manually verify this change:**

1. Green check marks
2. Search for "`SMDL #12-002`" on Subjects page and Combined Search page on [experimental deployment](https://2sgg65154h.execute-api.us-east-1.amazonaws.com/dev1337)
   - On the Subjects page, ensure you can further filter by category and subject.  [Example](https://2sgg65154h.execute-api.us-east-1.amazonaws.com/dev1337/subjects?q=SMDL+%2312-002&subjects=63&categories=5)


