### PR TITLE
EREGCSC-2713 -- Encode hash marks and other characters so `content-search` endpoint returns successfully

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -455,16 +455,24 @@ export default {
                 return;
             }
 
+            const encodedQuery = encodeURIComponent(query);
+
             this.regsLoading = true;
             this.resourcesLoading = true;
 
-            this.retrieveResourcesResults({ query, page, pageSize }).then(
-                () => {
-                    this.resourcesLoading = false;
-                }
-            );
+            this.retrieveResourcesResults({
+                query: encodedQuery,
+                page,
+                pageSize,
+            }).then(() => {
+                this.resourcesLoading = false;
+            });
 
-            this.retrieveRegResults({ query, page, pageSize }).then(() => {
+            this.retrieveRegResults({
+                query,
+                page,
+                pageSize,
+            }).then(() => {
                 this.regsLoading = false;
             });
         },

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -1065,6 +1065,7 @@ export {
     isFloat,
     mapToArray,
     niceDate,
+    PARAM_ENCODE_DICT,
     PARAM_VALIDATION_DICT,
     parseError,
     removeFragmentParams,

--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -75,6 +75,21 @@ const PARAM_VALIDATION_DICT = {
 };
 
 /**
+ * Dictionary of query parameters to encode before sending to the API.
+ *
+ * * @type {Object}
+ * @property {function} q - Encodes the q search string query parameter
+ *
+ * @example
+ * const query = "SMDL #12-002";
+ * const encodedQuery = PARAM_ENCODE_DICT.q(query);
+ * console.log(encodedQuery); // "SMDL%20%2312-002"
+ */
+const PARAM_ENCODE_DICT = {
+    q: (query) => encodeURIComponent(query),
+};
+
+/**
  * @param {string} fileName - name of the file
  * @returns {string | null} - returns null if the file name is not a string or does not pass validation;
  * otherwise returns the suffix of the file name
@@ -146,7 +161,12 @@ const getRequestParams = (query) => {
             );
 
             return filteredValues
-                .map((v) => `${PARAM_MAP[key]}=${v}`)
+                .map(
+                    (v) =>
+                        `${PARAM_MAP[key]}=${
+                            PARAM_ENCODE_DICT[key] ? encodeURIComponent(v) : v
+                        }`
+                )
                 .join("&");
         })
         .filter(([key, value]) => !_isEmpty(value))

--- a/solution/ui/regulations/utilities/utils.test.js
+++ b/solution/ui/regulations/utilities/utils.test.js
@@ -9,6 +9,7 @@ import {
     getFileTypeButton,
     getRequestParams,
     getSectionsRecursive,
+    PARAM_ENCODE_DICT,
     romanize,
     shapeTitlesResponse,
 } from "utilities/utils.js";
@@ -114,6 +115,34 @@ describe("Utilities.js", () => {
             457: "2023-08-31",
             460: "2023-08-04",
         });
+    });
+
+    it("PARAM_ENCODE_DICT.q properly encodes special characters", async () => {
+        expect(PARAM_ENCODE_DICT.q(" ")).toBe("%20");
+        expect(PARAM_ENCODE_DICT.q("&")).toBe("%26");
+        expect(PARAM_ENCODE_DICT.q("%")).toBe("%25");
+        expect(PARAM_ENCODE_DICT.q("?")).toBe("%3F");
+        expect(PARAM_ENCODE_DICT.q("=")).toBe("%3D");
+        expect(PARAM_ENCODE_DICT.q("/")).toBe("%2F");
+        expect(PARAM_ENCODE_DICT.q("\\")).toBe("%5C");
+        expect(PARAM_ENCODE_DICT.q("#")).toBe("%23");
+        expect(PARAM_ENCODE_DICT.q(";")).toBe("%3B");
+        expect(PARAM_ENCODE_DICT.q(":")).toBe("%3A");
+        expect(PARAM_ENCODE_DICT.q('"')).toBe("%22");
+        expect(PARAM_ENCODE_DICT.q("<")).toBe("%3C");
+        expect(PARAM_ENCODE_DICT.q(">")).toBe("%3E");
+        expect(PARAM_ENCODE_DICT.q("{")).toBe("%7B");
+        expect(PARAM_ENCODE_DICT.q("}")).toBe("%7D");
+        expect(PARAM_ENCODE_DICT.q("[")).toBe("%5B");
+        expect(PARAM_ENCODE_DICT.q("]")).toBe("%5D");
+        expect(PARAM_ENCODE_DICT.q("|")).toBe("%7C");
+        expect(PARAM_ENCODE_DICT.q("^")).toBe("%5E");
+        expect(PARAM_ENCODE_DICT.q("`")).toBe("%60");
+        expect(PARAM_ENCODE_DICT.q("@")).toBe("%40");
+        expect(PARAM_ENCODE_DICT.q("$")).toBe("%24");
+        expect(PARAM_ENCODE_DICT.q("+")).toBe("%2B");
+        expect(PARAM_ENCODE_DICT.q(",")).toBe("%2C");
+        expect(PARAM_ENCODE_DICT.q("SMDL #12-002")).toBe("SMDL%20%2312-002");
     });
 
     it("getActAbbr returns expected act abbreviation", async () => {


### PR DESCRIPTION
Resolves [EREGCSC-2713](https://jiraent.cms.gov/browse/EREGCSC-2713)

**Description**

If you search for something with a # in the query (from the combined search page or from the subjects page), you get a few unexpected effects:

- In the results, the “related regulation citations” show as “none”
- In the results, the category and subcategory labels are missing ("Subregulatory Guidance" etc)
- Anything after # in the query seems to be ignored
- If you're on the subjects page and run this kind of query, the filters don't work as expected. For example, if I uncheck "public", public items are still displayed. 

**This pull request changes:**

- Encodes `q` query parameter before it is included `content-search` API call
   - We're creating the `content-search` query string two different wants in Search and Subjects pages, so we are encoding `q` in two different places
   - This will be addressed in a future story (2657) -- Search page will be refactored to share most of Subjects page logic, which will reduce the number of times we need to encode `q` to one.
- Adds unit test

**Steps to manually verify this change:**

1. Green check marks
2. Visit [experimental deployment](https://g065mi4m29.execute-api.us-east-1.amazonaws.com/dev1340/) and start adding special characters to search page and subjects page queries
   - Special characters shouldn't break site and they should be encoded in the query string parameters of the API call
   - Example: [SMDL #12-002](https://g065mi4m29.execute-api.us-east-1.amazonaws.com/dev1340/search/?q=SMDL+%2312-002) (Search)
   - Example: [SMDL #12-002](https://g065mi4m29.execute-api.us-east-1.amazonaws.com/dev1340/subjects?q=SMDL+%2312-002) (Subjects)