### PR TITLE
[Hotfix] Ruff Github action

### DIFF
--- a/.github/workflows/ruff-action.yml
+++ b/.github/workflows/ruff-action.yml
@@ -8,4 +8,4 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           src: "./solution"
-          args: --preview
+          args: "check --preview"


### PR DESCRIPTION
Resolves deployment blocker

**Description**

The Ruff Github action began failing last week.  This PR fixes the issue.

**This pull request changes:**

- Adds `check` argument to Ruff Github action config to fix failing action
   - This `check` argument requirement was enforced in [Ruff 0.5.0](https://github.com/astral-sh/ruff/releases/tag/0.5.0), which was released Thursday 27 June. Our Ruff Github actions have been failing since then.

**Steps to manually verify this change:**

1. Green check marks

