### PR TITLE
[Onboarding] Updates to config files and documentation based on recent setup experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ See "Quick Start" in [SECRETSCANNING.md](SECRETSCANNING.md#quick-start) to ensur
 git clone https://github.com/Enterprise-CMCS/cmcs-eregulations
 ```
 
+Or if using SSH keys:
+
+```
+git clone git@github.com:Enterprise-CMCS/cmcs-eregulations.git
+```
+
 ## Create your Dockerfile
 
 - Create the Dockerfile

--- a/solution/Dockerfile.template
+++ b/solution/Dockerfile.template
@@ -3,6 +3,8 @@ FROM python:3.12-alpine
 COPY ["static-assets/requirements.txt", "/app/src/"]
 WORKDIR /app/src/
 
+RUN apk add libffi-dev
+
 RUN apk --update add ca-certificates build-base postgresql-dev \
     && update-ca-certificates \
     && rm -rf /var/cache/apk/*


### PR DESCRIPTION
Resolves error when pulling down, installing, and running project for the first time on a new machine.  Also adds link to clone project with SSH in addition to HTTPS.

**Description**

Running through the project's installation process on a new machine, it was discovered that our Dockerfile template does not contain reference to a needed library.  As such, an error was being thrown and the Docker containers were unable to be created.

The error:

```
158.1       src/c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
158.1          15 | #include <ffi.h>
158.1             |          ^~~~~~~
158.1       compilation terminated.
158.1       error: command '/usr/bin/gcc' failed with exit code 1
158.1       [end of output]
158.1
158.1   note: This error originates from a subprocess, and is likely not a problem with pip.
158.1   ERROR: Failed building wheel for cffi
```

Some research led me to [this StackOverflow conversation](https://stackoverflow.com/questions/71372066/docker-fails-to-install-cffi-with-python3-9-alpine-in-dockerfile), which concludes that the `libffi` package is missing.  Adding the following like to the Dockerfile fixes the issue:

`RUN apk add libffi-dev` 

**This pull request changes:**

- Updates Dockerfile.template to include `libffi` installation command per StackOverflow discussion listed above
   - `RUN apk add libffi-dev`
- Updates `README` to include mention of cloning the project with SSH

**Steps to manually verify this change:**

1. Next contributor to pull down and install this project does not have the same Docker error

