### PR TITLE
EREGCSC-2223 -- Style internal links on frontend

### DIFF
--- a/solution/ui/e2e/cypress/e2e/part.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/part.spec.cy.js
@@ -127,6 +127,13 @@ describe("Part View", () => {
                 .first()
                 .find(".supplemental-content-description")
                 .contains("[Mock] Internal PDF");
+            cy.get(
+                ".internal-docs__container div[data-test=TestSubCat] .supplemental-content"
+            )
+                .eq(1)
+                .find(".supplemental-content-description")
+                .should("have.class", "supplemental-content-external-link")
+                .and("include.text", "[Mock] Test 1 -- internal link");
             cy.get(".internal-docs__container div[data-test=TestSubCat]")
                 .find(".show-more-button")
                 .contains("+ Show More (6)")
@@ -141,12 +148,9 @@ describe("Part View", () => {
         cy.intercept("**/v3/resources/public?&citations=42.433.A**", {
             fixture: "42.433.A.resources.json",
         }).as("resources433A");
-        cy.intercept(
-            "**/v3/resources/internal&citations=42.433.A**",
-            {
-                fixture: "42.433.A.internal.json",
-            }
-        ).as("internal433A");
+        cy.intercept("**/v3/resources/internal&citations=42.433.A**", {
+            fixture: "42.433.A.internal.json",
+        }).as("internal433A");
 
         cy.viewport("macbook-15");
         cy.eregsLogin({ username, password });
@@ -179,10 +183,7 @@ describe("Part View", () => {
             "div[data-test='Subregulatory Guidance'] > .supplemental-content-list a .supplemental-content-description"
         )
             .and("be.visible")
-            .and(
-                "contain.text",
-                "Mock title"
-            );
+            .and("contain.text", "Mock title");
     });
 
     it("loads a subpart view in a mobile width", () => {

--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -230,14 +230,14 @@ describe("Find by Subjects", () => {
             .and("have.text", " Search Results ");
         cy.get(".search-results-count").should(
             "have.text",
-            "1 - 2 of 2 results for mock within Access to Services"
+            "1 - 3 of 3 results for mock within Access to Services"
         );
         cy.get(`button[data-testid=remove-subject-3]`).click({
             force: true,
         });
         cy.get(".search-results-count").should(
             "have.text",
-            "1 - 2 of 2 results for mock"
+            "1 - 3 of 3 results for mock"
         );
     });
 
@@ -320,7 +320,7 @@ describe("Find by Subjects", () => {
             .should("have.attr", "href")
             .and("not.include", "undefined")
             .and("include", "/42/430/Subpart-A/");
-        cy.get(".result__link")
+        cy.get(".result__link") // internal_file
             .eq(0)
             .should("include.text", "Download")
             .find("a")
@@ -329,8 +329,13 @@ describe("Find by Subjects", () => {
                 "span[data-testid=download-chip-1149e520-6691-4f00-9094-d741b0b114a5]"
             )
             .should("include.text", "Download MSG");
-        cy.get(".result__link")
+        cy.get(".result__link") // public_link
             .eq(1)
+            .find("a")
+            .should("not.include.text", "Download")
+            .and("have.class", "external");
+        cy.get(".result__link") // internal_link
+            .eq(2)
             .find("a")
             .should("not.include.text", "Download")
             .and("have.class", "external");

--- a/solution/ui/e2e/cypress/fixtures/42.431.internal.json
+++ b/solution/ui/e2e/cypress/fixtures/42.431.internal.json
@@ -130,7 +130,7 @@
             "uid": "34299796-e8ed-4f3e-87ab-64f852ae7a7c"
         },
         {
-            "type": "internal_file",
+            "type": "internal_link",
             "id": 2010,
             "created_at": "2024-06-27 14:01:03.218783",
             "updated_at": "2024-06-27 14:01:24.805811",
@@ -155,13 +155,10 @@
             ],
             "subjects": [],
             "document_id": "",
-            "title": "[Mock] Test file 1",
+            "title": "[Mock] Test 1 -- internal link",
             "date": "2024-01-01",
-            "url": "",
-            "summary": "",
-            "file_name": "",
-            "file_type": "",
-            "uid": "263565ff-2758-41b6-9fcb-3c82d59cb989"
+            "url": "http://www.sharepoint.com",
+            "summary": ""
         },
         {
             "type": "internal_file",

--- a/solution/ui/e2e/cypress/fixtures/policy-docs-search.json
+++ b/solution/ui/e2e/cypress/fixtures/policy-docs-search.json
@@ -1,5 +1,5 @@
 {
-    "count": 2,
+    "count": 3,
     "next": null,
     "previous": null,
     "results": [
@@ -120,6 +120,53 @@
             "date": "2017-06-29",
             "url": "https://www.medicaid.gov/sites/default/files/medicaid-chip-program-information/by-topics/prescription-drugs/downloads/rx-releases/mfr-releases/mfr-rel-105.pdf",
             "related_resources": []
+        },
+        {
+            "type": "internal_link",
+            "id": 20077,
+            "created_at": "2024-07-09 15:19:36.129789",
+            "updated_at": "2024-07-10 10:38:27.931896",
+            "approved": true,
+            "category": {
+                "id": 26,
+                "name": "Mock Category",
+                "description": "This is a mock category",
+                "order": 0,
+                "show_if_empty": false,
+                "is_fr_link_category": false,
+                "type": "internal_category"
+            },
+            "cfr_citations": [
+                {
+                    "id": 18,
+                    "title": 42,
+                    "part": 430,
+                    "type": "subpart",
+                    "subpart_id": "A"
+                },
+                {
+                    "id": 25,
+                    "title": 42,
+                    "part": 430,
+                    "type": "section",
+                    "section_id": 10
+                }
+            ],
+            "subjects": [
+                {
+                    "id": 3,
+                    "full_name": "Access to Services",
+                    "short_name": "",
+                    "abbreviation": "",
+                    "description": ""
+                }
+            ],
+            "document_id": "internal document id field",
+            "title": "mock internal link",
+            "date": "2024-09-09",
+            "url": "http://www.sharepoint.com",
+            "related_resources": [],
+            "summary": "This is the summary to the mock internal link"
         }
     ]
 }

--- a/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
+++ b/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
@@ -150,10 +150,6 @@
         color: $primary_link_color;
         text-decoration: none;
         font-size: $font-size-sm;
-
-        &.supplemental-content-external-link {
-            display: flex;
-        }
     }
 
     .supplemental-content-external-link {
@@ -164,7 +160,7 @@
 }
 
 .internal-docs__container {
-    .supplemental-content-description > span {
+    .supplemental-content-description > span:has(.result__link--file-type) {
         display: flex;
         align-items: center;
         flex-wrap: wrap;

--- a/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
+++ b/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
@@ -150,6 +150,10 @@
         color: $primary_link_color;
         text-decoration: none;
         font-size: $font-size-sm;
+
+        &.supplemental-content-external-link {
+            display: flex;
+        }
     }
 
     .supplemental-content-external-link {

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentObject.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentObject.vue
@@ -128,7 +128,8 @@ export default {
         getLinkClasses(docType, description) {
             return {
                 "supplemental-content-external-link":
-                    DOCUMENT_TYPES_MAP[docType] !== "Internal" &&
+                    (DOCUMENT_TYPES_MAP[docType] === "Public" ||
+                        docType === "internal_link") &&
                     this.isBlank(description),
             };
         },

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -190,7 +190,7 @@ const needsBar = (item) =>
 const resultLinkClasses = (doc) => ({
     external:
         DOCUMENT_TYPES_MAP[getFieldVal({ item: doc, fieldName: "type" })] ===
-        "Public",
+        "Public" || getFieldVal({ item: doc, fieldName: "type" }) === "internal_link",
     "document__link--search": !!$route?.query?.q,
 });
 


### PR DESCRIPTION
Resolves [EREGCSC-2223](https://jiraent.cms.gov/browse/EREGCSC-2223)

**Description**

Internal links are a new type of document: they go to Sharepoint URLs that are external to eRegs.  As such, we would like to indicate that these links will open a new tab and go to an external site.  We already do that with other external links by adding an External Link icon at the end of the styled link.

**This pull request changes:**

- Updates logic needed to add `external` class to internal links
- Updates CSS style rules where needed to properly position external link icon at the end of Internal Links
- Adds tests

**Steps to manually verify this change:**

1. Green check marks
2. Visit experimental deployment
3. Create an internal link and upload a file
4. Visit the Search page, the Subjects page, and the Reader view to validate that the newly created internal link includes the external link icon

