### PR TITLE
EREGCSC-2771 -- Updating front end field/display mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ solution/static-assets/regulations/*
 solution/ui/regulations/dist
 solution/Dockerfile
 solution/ui/regulations/coverage/
+db_backup

--- a/solution/backend/content_search/models.py
+++ b/solution/backend/content_search/models.py
@@ -124,8 +124,7 @@ def get_or_create_index(instance, created):
 
 @receiver(post_save, sender=PublicLink)
 @receiver(post_save, sender=FederalRegisterLink)
-@receiver(post_save, sender=InternalLink)
-def update_indexed_resource(sender, instance, created, **kwargs):
+def update_indexed_public_resource(sender, instance, created, **kwargs):
     index = get_or_create_index(instance, created)
     index.name = instance.document_id
     index.summary = instance.title
@@ -140,7 +139,7 @@ def update_indexed_resource(sender, instance, created, **kwargs):
 
 
 @receiver(post_save, sender=InternalFile)
-def update_indexed_file(sender, instance, created, **kwargs):
+def update_indexed_internal_file(sender, instance, created, **kwargs):
     index = get_or_create_index(instance, created)
     index.name = instance.title
     index.summary = instance.summary
@@ -150,6 +149,18 @@ def update_indexed_file(sender, instance, created, **kwargs):
         instance.date,
         instance.file_name,
     )
+    index.rank_d_string = " ".join([str(i) for i in instance.subjects.all()])
+    index.save()
+
+
+@receiver(post_save, sender=InternalLink)
+def update_indexed_internal_link(sender, instance, created, **kwargs):
+    index = get_or_create_index(instance, created)
+    index.name = instance.title
+    index.summary = instance.summary
+    index.rank_a_string = instance.title
+    index.rank_b_string = instance.summary
+    index.rank_c_string = instance.date
     index.rank_d_string = " ".join([str(i) for i in instance.subjects.all()])
     index.save()
 

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -183,7 +183,6 @@ const getUrl = ({ type: resourceType, url, uid }) =>
         : url;
 
 const needsBar = (item) =>
-    DOCUMENT_TYPES_MAP[getFieldVal({ item, fieldName: "type" })] === "Public" &&
     getFieldVal({ item, fieldName: "date" }) &&
     getFieldVal({ item, fieldName: "document_id" });
 
@@ -358,12 +357,7 @@ const currentPageResultsRange = getCurrentPageResultsRange({
                     :division="doc.division"
                 /-->
                 <span
-                    v-if="
-                        DOCUMENT_TYPES_MAP[
-                            getFieldVal({ item: doc, fieldName: 'type' })
-                        ] === 'Public' &&
-                        getFieldVal({ item: doc, fieldName: 'document_id' })
-                    "
+                    v-if="getFieldVal({ item: doc, fieldName: 'document_id' })"
                     >{{
                         getFieldVal({ item: doc, fieldName: "document_id" })
                     }}</span

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -71,7 +71,10 @@ const showResultSnippet = (item) => {
     if (
         DOCUMENT_TYPES_MAP[getFieldVal({ item, fieldName: "type" })] ===
             "Internal" &&
-        (item.content_headline || item.summary_headline || item.summary_string)
+        (item.content_headline ||
+            item.summary_headline ||
+            item.summary_string ||
+            item.summary)
     )
         return true;
 
@@ -101,6 +104,8 @@ const getResultSnippet = (item) => {
             snippet = addSurroundingEllipses(item.summary_headline);
         } else if (item.summary_string) {
             snippet = item.summary_string;
+        } else if (item.summary) {
+            snippet = item.summary;
         }
 
         return snippet;


### PR DESCRIPTION
Resolves [EREGCSC-2771](https://jiraent.cms.gov/browse/EREGCSC-2771)

**Description**

When displaying internal links and internal files on the Search and Subjects pages, we need to map the item field of the API response item to the proper display field on the front end of the application.

**This pull request changes:**

- Adds post-save hook that is specific to `internal_link`s to properly map DB fields to API response item fields
- Updates display logic on the front end to ensure fields are being displayed in their proper places

**Steps to manually verify this change...**

1. Green check marks
2. Log in to the [experimental deployment](https://nzfrr0fz11.execute-api.us-east-1.amazonaws.com/dev1378)
3. Visit the Subjects and Search pages and search for various internal documents.  Searching for "Mock" or "Summary" should give you several good examples to test
4. Ensure everything looks like it's in the right place based on the examples in the JIRA ticket
5. Feel free to add your own internal files and links for further validation

