### PR TITLE
EREGCSC-2772 Fix for "Can't delete internal files"

### DIFF
--- a/solution/backend/resources/admin/internal_resources.py
+++ b/solution/backend/resources/admin/internal_resources.py
@@ -110,12 +110,7 @@ class InternalFileAdmin(AbstractInternalResourceAdmin):
 
     def del_file(self, obj):
         s3_client = establish_client("s3")
-        key = obj.get_key()
-
-        try:
-            s3_client.delete_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=key)
-        except Exception:
-            raise Exception("Unable to delete")
+        s3_client.delete_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=obj.key)
 
     def delete_model(self, request, obj):
         try:


### PR DESCRIPTION
Resolves #2772

**Description-**

On prod, internal files are failing to delete. This is because the old code used `get_key()` and the new code uses `key` as a computed property. Note that this code, along with all upload/download code, will be refactored in a near-future ticket, so even though this isn't the most elegant or resilient code it will change soon. This PR only fixes the immediate issue.

**This pull request changes...**

- Fix this naming error.
- Remove redundant exception.

**Steps to manually verify this change...**

1. Go to the admin panel of the experimental deploy.
2. Go to internal files, and upload a _new_ file (don't use an existing file for this test, since they don't actually exist in the S3 bucket for this deploy).
3. Save the new file, then go back to it and hit Delete and confirm deletion.
4. Make sure the file is deleted, and no 500 error occurs.

