### PR TITLE
EREGCSC-2796 Fix extract_url behavior

### DIFF
--- a/solution/backend/resources/admin/actions.py
+++ b/solution/backend/resources/admin/actions.py
@@ -4,7 +4,7 @@ from django.contrib import admin, messages
 from django.urls import reverse
 from django.utils.html import format_html
 
-from resources.utils import call_text_extractor
+from resources.utils import call_text_extractor, get_support_link
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +39,7 @@ def extract_text(modeladmin, request, queryset):
             if len(failures) > 1 else
             "this item has a valid URL or attached file"
         )
-        message += ", then <a href=\"https://docs.google.com/forms/d/e/1FAIpQLSdcG9mfTz6Kebdni8YSacl27rIwpGy2a7GsMGO0kb_T7FSNxg"\
-                   "/viewform?embedded=true\" target=\"_blank\">contact support</a> for assistance if needed"
+        message += f", then {get_support_link('contact support')} for assistance if needed"
     message += "."
 
     modeladmin.message_user(request, format_html(message), messages.ERROR if failures else messages.SUCCESS)

--- a/solution/backend/resources/admin/public_resources.py
+++ b/solution/backend/resources/admin/public_resources.py
@@ -1,17 +1,25 @@
+import json
+import logging
+
+import requests
 from django import forms
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.db.models import Prefetch
+from django.utils.html import format_html
 
 from resources.models import (
     FederalRegisterLink,
     PublicLink,
     ResourceGroup,
 )
+from resources.utils import field_changed, get_support_link
 
 from .resources import (
     AbstractPublicResourceAdmin,
     AbstractPublicResourceForm,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class PublicLinkForm(AbstractPublicResourceForm):
@@ -107,10 +115,28 @@ class FederalRegisterLinkAdmin(AbstractPublicResourceAdmin):
         )
 
     def save_model(self, request, obj, form, change):
-        if change and form.initial.get("url") != form.cleaned_data.get("url"):
-            # Attempt to use the Federal Register API to retrieve the document's extract_url parameter
-            pass
-        super().save_model(request, obj, form, change)
+        force_extract = False
+        if not change or field_changed(form, "document_number") or field_changed(form, "url"):
+            # Attempt to use the Federal Register's API to retrieve the document's raw text URL
+            try:
+                document_number = form.cleaned_data.get("document_number")
+                response = requests.get(
+                    f"https://www.federalregister.gov/api/v1/documents/{document_number}.json",
+                    timeout=10,
+                )
+                response.raise_for_status()
+                content = json.loads(response.content)
+                obj.extract_url = content["raw_text_url"]
+                force_extract = True
+            except Exception as e:
+                # This can be due to a bad document_number, a network error, or a JSON parse error due to an invalid response.
+                # We handle all cases in the same way: show a warning to the user, log the error, then finally save the model.
+                logger.warning("Failed to retrieve the raw text URL for Federal Register Link \"%s\": %s", document_number, e)
+                message = "Failed to retrieve the URL used for extracting raw text from the Federal Register. "\
+                          f"Please check the document number and try again, or {get_support_link('contact support')} "\
+                          "for assistance."
+                self.message_user(request, format_html(message), level=messages.WARNING)
+        super().save_model(request, obj, form, change, force_extract=force_extract)
 
     # Override document_id's default help_text to show specific FR link information
     def get_form(self, request, obj=None, **kwargs):

--- a/solution/backend/resources/admin/resources.py
+++ b/solution/backend/resources/admin/resources.py
@@ -18,6 +18,7 @@ from resources.models import (
     AbstractCitation,
     AbstractInternalCategory,
     AbstractPublicCategory,
+    ResourcesConfiguration,
 )
 from resources.utils import (
     call_text_extractor,
@@ -60,7 +61,8 @@ class AbstractResourceAdmin(CustomAdminMixin, admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change, *args, **kwargs):
         super().save_model(request, obj, form, change)
-        if not change or field_changed(form, "url") or kwargs.pop("force_extract", False):
+        auto_extract = ResourcesConfiguration.get_solo().auto_extract
+        if auto_extract and (not change or field_changed(form, "url") or kwargs.pop("force_extract", False)):
             _, fail = call_text_extractor(request, [obj])
             url = f"<a target=\"_blank\" href=\"{reverse('edit', args=[obj.pk])}\">{str(obj)}</a>"
             if fail:

--- a/solution/backend/resources/migrations/0005_reset_extract_url.py
+++ b/solution/backend/resources/migrations/0005_reset_extract_url.py
@@ -1,0 +1,21 @@
+# Created by Caleb Godwin on 2024-08-12
+# Blanks the extract_url field for all non-FR-link resources
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def blank_extract_url(apps, schema_editor):
+    AbstractResource = apps.get_model("resources", "AbstractResource")
+    AbstractResource.objects.filter(abstractpublicresource__federalregisterlink__isnull=True).update(extract_url="")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('resources', '0004_resourcesconfiguration_auto_extract_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(blank_extract_url, reverse_code=migrations.RunPython.noop),
+    ]

--- a/solution/backend/resources/tests/test_admin_actions.py
+++ b/solution/backend/resources/tests/test_admin_actions.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from resources.admin import PublicLinkAdmin
 from resources.admin.actions import mark_approved, mark_not_approved
 from resources.models import PublicLink
+from resources.utils import get_support_link
 
 
 class AdminActionsTestCase(TestCase):
@@ -53,8 +54,7 @@ class AdminActionsTestCase(TestCase):
             "Text extraction successfully started on 1 resource, but extraction failed for the following resource: "
             f"<a target=\"_blank\" href=\"{edit_url}\">{self.resource2.pk}</a>. "
             "Please be sure this item has a valid URL or attached file, then "
-            "<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSdcG9mfTz6Kebdni8YSacl27rIwpGy2a7GsMGO0kb_T7FSNxg"
-            "/viewform?embedded=true\" target=\"_blank\">contact support</a> for assistance if needed."
+            f"{get_support_link('contact support')} for assistance if needed."
         )
 
         self.assertEqual(len(messages), 1)
@@ -77,8 +77,7 @@ class AdminActionsTestCase(TestCase):
             "Text extraction successfully started on 2 resources, but extraction failed for the following resource: "
             f"<a target=\"_blank\" href=\"{edit_url}\">{self.resource2.pk}</a>. "
             "Please be sure this item has a valid URL or attached file, then "
-            "<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSdcG9mfTz6Kebdni8YSacl27rIwpGy2a7GsMGO0kb_T7FSNxg"
-            "/viewform?embedded=true\" target=\"_blank\">contact support</a> for assistance if needed."
+            f"{get_support_link('contact support')} for assistance if needed."
         )
 
         self.assertEqual(len(messages), 1)
@@ -106,8 +105,7 @@ class AdminActionsTestCase(TestCase):
             f"<a target=\"_blank\" href=\"{edit_url1}\">{self.resource2.pk}</a>, "
             f"<a target=\"_blank\" href=\"{edit_url2}\">{self.resource3.pk}</a>. "
             "Please be sure these items have valid URLs or attached files, then "
-            "<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSdcG9mfTz6Kebdni8YSacl27rIwpGy2a7GsMGO0kb_T7FSNxg"
-            "/viewform?embedded=true\" target=\"_blank\">contact support</a> for assistance if needed."
+            f"{get_support_link('contact support')} for assistance if needed."
         )
 
         self.assertEqual(len(messages), 1)
@@ -135,8 +133,7 @@ class AdminActionsTestCase(TestCase):
             f"<a target=\"_blank\" href=\"{edit_url1}\">{self.resource2.pk}</a>, "
             f"<a target=\"_blank\" href=\"{edit_url2}\">{self.resource3.pk}</a>. "
             "Please be sure these items have valid URLs or attached files, then "
-            "<a href=\"https://docs.google.com/forms/d/e/1FAIpQLSdcG9mfTz6Kebdni8YSacl27rIwpGy2a7GsMGO0kb_T7FSNxg"
-            "/viewform?embedded=true\" target=\"_blank\">contact support</a> for assistance if needed."
+            f"{get_support_link('contact support')} for assistance if needed."
         )
 
         self.assertEqual(len(messages), 1)

--- a/solution/backend/resources/tests/test_fr_link_admin.py
+++ b/solution/backend/resources/tests/test_fr_link_admin.py
@@ -1,0 +1,138 @@
+import json
+from unittest.mock import patch
+
+from django.contrib import messages
+from django.contrib.admin import AdminSite
+from django.contrib.auth.models import User
+from django.contrib.messages import get_messages
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
+from resources.admin import FederalRegisterLinkAdmin
+from resources.models import FederalRegisterLink
+
+
+class FederalRegisterLinkExtractUrlTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.admin = FederalRegisterLinkAdmin(FederalRegisterLink, AdminSite())
+        self.user = User.objects.create_superuser(username='admin', password='admin', email='admin@example.com')  # noqa
+        self.link = FederalRegisterLink.objects.create(title='Test Link')
+
+    @patch('resources.admin.requests.get')
+    @patch('resources.admin.resources.call_text_extractor')
+    def test_save_model_new_link(self, mock_call_text_extractor, mock_get):
+        mock_get.return_value = MockResponse(
+            content=json.dumps({"raw_text_url": "https://example.com/raw_text"}),
+            status_code=200
+        )
+        mock_call_text_extractor.return_value = (1, [])
+
+        request = self.factory.post(reverse('admin:resources_federalregisterlink_add'))
+        session_middleware = SessionMiddleware(request)
+        session_middleware.process_request(request)
+        message_middleware = MessageMiddleware(request)
+        message_middleware.process_request(request)
+        request.user = self.user
+
+        form_data = {
+            "url": "https://example.com",
+            "title": "Test Link 2",
+            "document_number": "12345",
+            "action_type": "Action",
+            "approved": True,
+        }
+
+        form = self.admin.get_form(request)(data=form_data)
+        form.is_valid()
+
+        self.admin.save_model(request, form.instance, form, True)
+
+        link = FederalRegisterLink.objects.get(title='Test Link 2')
+        self.assertEqual(link.extract_url, "https://example.com/raw_text")
+
+        response_messages = list(get_messages(request))
+        self.assertEqual(len(response_messages), 1)
+        self.assertEqual(response_messages[0].level, messages.SUCCESS)
+
+    @patch('resources.admin.requests.get')
+    @patch('resources.admin.resources.call_text_extractor')
+    def test_save_model_existing_link(self, mock_call_text_extractor, mock_get):
+        mock_get.return_value = MockResponse(
+            content=json.dumps({"raw_text_url": "https://example.com/raw_text"}),
+            status_code=200
+        )
+        mock_call_text_extractor.return_value = (1, [])
+
+        request = self.factory.post(reverse('admin:resources_federalregisterlink_change', args=[self.link.id]))
+        session_middleware = SessionMiddleware(request)
+        session_middleware.process_request(request)
+        message_middleware = MessageMiddleware(request)
+        message_middleware.process_request(request)
+        request.user = self.user
+
+        form_data = {
+            "url": "https://example.com",
+            "title": "Test Link",
+            "document_number": "12345",
+            "action_type": "Action",
+            "approved": True,
+        }
+
+        form = self.admin.get_form(request)(data=form_data, instance=self.link)
+        form.is_valid()
+
+        self.admin.save_model(request, form.instance, form, False)
+
+        link = FederalRegisterLink.objects.get(title='Test Link')
+        self.assertEqual(link.extract_url, "https://example.com/raw_text")
+
+        response_messages = list(get_messages(request))
+        self.assertEqual(len(response_messages), 1)
+        self.assertEqual(response_messages[0].level, messages.SUCCESS)
+
+    @patch('resources.admin.requests.get')
+    @patch('resources.admin.resources.call_text_extractor')
+    def test_save_model_failed_request(self, mock_call_text_extractor, mock_get):
+        mock_get.return_value = MockResponse(status_code=500)
+        mock_call_text_extractor.return_value = (1, [])
+
+        request = self.factory.post(reverse('admin:resources_federalregisterlink_add'))
+        session_middleware = SessionMiddleware(request)
+        session_middleware.process_request(request)
+        message_middleware = MessageMiddleware(request)
+        message_middleware.process_request(request)
+        request.user = self.user
+
+        form_data = {
+            "url": "https://example.com",
+            "title": "Test Link 2",
+            "document_number": "12345",
+            "action_type": "Action",
+            "approved": True,
+        }
+
+        form = self.admin.get_form(request)(data=form_data)
+        form.is_valid()
+
+        self.admin.save_model(request, form.instance, form, True)
+
+        link = FederalRegisterLink.objects.get(title='Test Link 2')
+        self.assertEqual(link.extract_url, "")
+
+        response_messages = list(get_messages(request))
+        self.assertEqual(len(response_messages), 2)
+        self.assertEqual(response_messages[0].level, messages.WARNING)
+        self.assertIn("Failed to retrieve the URL used for extracting raw text", response_messages[0].message)
+
+
+class MockResponse:
+    def __init__(self, content=None, status_code=200):
+        self.content = content
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("Error")

--- a/solution/backend/resources/tests/test_fr_link_admin.py
+++ b/solution/backend/resources/tests/test_fr_link_admin.py
@@ -54,8 +54,7 @@ class FederalRegisterLinkExtractUrlTestCase(TestCase):
         self.assertEqual(link.extract_url, "https://example.com/raw_text")
 
         response_messages = list(get_messages(request))
-        self.assertEqual(len(response_messages), 1)
-        self.assertEqual(response_messages[0].level, messages.SUCCESS)
+        self.assertEqual(len(response_messages), 0)
 
     @patch('resources.admin.requests.get')
     @patch('resources.admin.resources.call_text_extractor')
@@ -90,8 +89,7 @@ class FederalRegisterLinkExtractUrlTestCase(TestCase):
         self.assertEqual(link.extract_url, "https://example.com/raw_text")
 
         response_messages = list(get_messages(request))
-        self.assertEqual(len(response_messages), 1)
-        self.assertEqual(response_messages[0].level, messages.SUCCESS)
+        self.assertEqual(len(response_messages), 0)
 
     @patch('resources.admin.requests.get')
     @patch('resources.admin.resources.call_text_extractor')
@@ -123,7 +121,7 @@ class FederalRegisterLinkExtractUrlTestCase(TestCase):
         self.assertEqual(link.extract_url, "")
 
         response_messages = list(get_messages(request))
-        self.assertEqual(len(response_messages), 2)
+        self.assertEqual(len(response_messages), 1)
         self.assertEqual(response_messages[0].level, messages.WARNING)
         self.assertIn("Failed to retrieve the URL used for extracting raw text", response_messages[0].message)
 

--- a/solution/backend/resources/utils/general_purpose.py
+++ b/solution/backend/resources/utils/general_purpose.py
@@ -1,6 +1,7 @@
 # Functions and mixins that are exportable to other apps may go here
 
 
+from django.conf import settings
 from django.core.exceptions import BadRequest
 from django.db.models import Q
 
@@ -12,6 +13,18 @@ def is_int(x):
         return True
     except ValueError:
         return False
+
+
+# Returns a support link if it exists with custom link text if provided.
+def get_support_link(link_text):
+    if hasattr(settings, "SURVEY_URL") and settings.SURVEY_URL:
+        return f"<a href=\"{settings.SURVEY_URL}\" target=\"_blank\">{link_text}</a>"
+    return link_text
+
+
+# Returne True if the given field has changed in the form, False otherwise.
+def field_changed(form, field):
+    return form.initial.get(field) != form.cleaned_data.get(field)
 
 
 # Generates an OR'd together Q query of all citations passed in via the "citations" argument.

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -5,12 +5,11 @@ from django.db.models import F, Prefetch, Q
 from django.http import JsonResponse
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
-from rest_framework.authentication import BasicAuthentication, SessionAuthentication
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 
-from common.mixins import ViewSetPagination
 from common.auth import SettingsAuthentication
-
+from common.mixins import ViewSetPagination
 from resources.models import (
     AbstractCategory,
     AbstractCitation,
@@ -21,8 +20,8 @@ from resources.models import (
     InternalFile,
     InternalLink,
     PublicLink,
-    Subject,
     ResourcesConfiguration,
+    Subject,
 )
 from resources.serializers import (
     AbstractResourceSerializer,
@@ -34,9 +33,9 @@ from resources.serializers import (
     StringListSerializer,
 )
 from resources.utils import (
+    call_text_extractor,
     get_citation_filter,
     string_to_bool,
-    call_text_extractor,
 )
 
 logger = logging.getLogger(__name__)
@@ -141,7 +140,7 @@ class FederalRegisterLinkViewSet(PublicResourceViewSet):
         if ResourcesConfiguration.get_solo().auto_extract:
             _, fail = call_text_extractor(request, FederalRegisterLink.objects.filter(pk=link.pk))
             if fail:
-                logger.warning(f"Failed to extract text for Federal Register Link {link.pk}: {fail[0]['reason']}")
+                logger.warning("Failed to extract text for Federal Register Link %i: %s", link.pk, fail[0]["reason"])
         return JsonResponse(sc.validated_data)
 
 


### PR DESCRIPTION
Resolves #2796

**Description-**

We have a special field, `extract_url`, on AbstractResource that enables us to feed the raw text versions of FR links to our text extractor. We get this URL from the FR API. But we currently have somewhat inconsistent/unexpected behavior around this field, so let's fix that.

**This pull request changes...**

- For all non-FR resources, the `extract_url` field is blanked out for now.
- Admin panel save_model will try to retrieve `extract_url` from the FR API if `url` or `document_number` has changed.
    - If it fails, a warning message is shown to the user and the event is logged, but saving continues unhindered.
- If `extract_url` is updated and `auto_extract` is true, the text extractor will be invoked even if `url` hasn't changed.
- Implemented `auto_extract` checking anywhere the text extractor is automatically called.
- Two new utility methods: `get_support_link` and `field_changed` in general purpose utils.
- Updated FR parser endpoint to utilize `transaction.atomic` that was already present (i.e. no need to check exceptions and delete the newly-created FR link).

**Steps to manually verify this change...**

1. Green check marks indicate new unit tests pass.
2. Go to the Django Admin panel on the experimental deploy and select a recent FR Link (one with an html page in the URL).
3. Modify the document number, for example by adding random numbers/letters at the end. (Keep the original document number handy in your clipboard.) Click Save.
4. You should see a message indicating that retrieving the extraction URL failed, and a second message indicating that saving succeeded. Both are true so this is expected.
5. Go back and reset the document number to the original value, and save again.
6. You should see a message indicating the text extraction started, and another indicating successful saving.
7. Repeat steps 2-6, but first go to "Resources Configuration" and uncheck "Auto Extract" and save. You will see that on step 6, you will only see a message indicating that saving succeeded. Text extraction will not start with "Auto Extract" unchecked.

