### PR TITLE
[hotfix] Add missing order by date for related_resources prefetch

### DIFF
--- a/solution/backend/resources/tests/test_resources_endpoints.py
+++ b/solution/backend/resources/tests/test_resources_endpoints.py
@@ -67,6 +67,14 @@ class TestResourcesEndpoint(TestCase):
             for j in i["related_resources"]:
                 self.assertEqual(j["approved"], True)
 
+    def test_group_ordering_by_date(self):
+        FederalRegisterLink.objects.filter(id=3).update(approved=True)
+        response = self.client.get("/v3/resources/?cfr_citations=1.1.1&cfr_citations=1.1.2")
+        data = get_paginated_data(response)["results"]
+        self.assertEqual(data[0]["id"], 1)
+        self.assertEqual(data[0]["related_resources"][0]["id"], 3)
+        self.assertEqual(data[0]["related_resources"][1]["id"], 2)
+
     def test_unapproved_resources_showing(self):
         response = self.client.get("/v3/resources/?cfr_citations=1.1.1&cfr_citations=1.1.2&group_resources=false")
         data = get_paginated_data(response)["results"]

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -70,7 +70,7 @@ class ResourceViewSet(viewsets.ModelViewSet):
                     Prefetch("category", category_prefetch),
                     Prefetch("cfr_citations", citation_prefetch),
                     Prefetch("subjects", subject_prefetch),
-                ).select_subclasses()),
+                ).order_by(F("date").desc(nulls_last=True)).select_subclasses()),
             ).filter(Q(group_parent=True) | Q(related_resources__isnull=True))
             citation_prefix = "related_citations__"
             category_prefix = "related_categories__"


### PR DESCRIPTION
Resolves #n/a

**Description-**

Forgot to include order_by("date") for the related_resources prefetch during the v4 refactor. This results in grouped documents appearing out of order.

**This pull request changes...**

- Added order_by statement to the related_resources prefetch.
- Add test for related_resources being in the correct order.

**Steps to manually verify this change...**

1. Go to /42/431/Subpart-A/2024-07-09/
2. Check the right sidebar under Proposed and Final Rules for an FR link with grouped documents.
3. Verify the grouped documents are in the correct order, with latest first.

