### PR TITLE
EREGCSC-2756 - Update swagger

### DIFF
--- a/solution/Makefile
+++ b/solution/Makefile
@@ -79,8 +79,8 @@ ruff:
 	docker-compose exec regulations ruff check --preview .
 	docker-compose exec text-extractor ruff check --preview .
 ruff-fix:
-	docker-compose exec regulations ruff --preview --fix .
-	docker-compose exec text-extractor ruff --preview --fix .
+	docker-compose exec regulations ruff check --preview --fix .
+	docker-compose exec text-extractor ruff check --preview --fix .
 local: ## Start a local environment with parts 400 and 433 loaded.
 local: regulations local.docker data.local
 	@echo Local environment started. Visit http://localhost:8000

--- a/solution/Makefile
+++ b/solution/Makefile
@@ -95,6 +95,8 @@ local.regulations: ## Run migrations and restart the regulations-core
 	docker-compose exec regulations python manage.py migrate; \
 		docker-compose restart regulations; \
 		sleep 5;
+local.spectacular: ## Run swagger locally 
+	docker-compose exec regulations python manage.py spectacular --file schema.yaml
 
 tools/ecfr-parser/build/ecfr-parser: tools/ecfr-parser/*.go tools/ecfr-parser/**/*.go
 	cd tools/ecfr-parser; go build -o build/ecfr-parser .

--- a/solution/backend/common/auth.py
+++ b/solution/backend/common/auth.py
@@ -1,6 +1,16 @@
 from django.conf import settings
 from rest_framework import authentication, exceptions
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
+class SettingsAuthenticationScheme(OpenApiAuthenticationExtension):
+    target_class = 'common.auth.SettingsAuthentication'
+    name = 'SettingsAuth'
+
+    def get_security_definition(self, auto_schema):
+        return {
+            'type': 'http',
+            'scheme': 'bearer'
+        }
 
 class SettingsUser:
     is_authenticated = False

--- a/solution/backend/common/auth.py
+++ b/solution/backend/common/auth.py
@@ -1,6 +1,7 @@
 from django.conf import settings
-from rest_framework import authentication, exceptions
 from drf_spectacular.extensions import OpenApiAuthenticationExtension
+from rest_framework import authentication, exceptions
+
 
 class SettingsAuthenticationScheme(OpenApiAuthenticationExtension):
     target_class = 'common.auth.SettingsAuthentication'
@@ -11,6 +12,7 @@ class SettingsAuthenticationScheme(OpenApiAuthenticationExtension):
             'type': 'http',
             'scheme': 'bearer'
         }
+
 
 class SettingsUser:
     is_authenticated = False

--- a/solution/backend/content_search/serializers.py
+++ b/solution/backend/content_search/serializers.py
@@ -18,6 +18,7 @@ class ContentSearchSerializer(serializers.Serializer):
 
     reg_text = serializers.SerializerMethodField()
 
+
 class ContentUpdateSerializer(serializers.Serializer):
     id = serializers.CharField()
     text = serializers.CharField()

--- a/solution/backend/content_search/serializers.py
+++ b/solution/backend/content_search/serializers.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from common.fields import HeadlineField
@@ -10,4 +11,13 @@ class ContentSearchSerializer(serializers.Serializer):
     content_headline = HeadlineField(blank_when_no_highlight=True)
 
     resource = AbstractResourceSerializer()
-    reg_text = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    @extend_schema_field(serializers.IntegerField())
+    def get_reg_text(self, obj):
+        return obj.reg_text.id if obj.reg_text else None
+
+    reg_text = serializers.SerializerMethodField()
+
+class ContentUpdateSerializer(serializers.Serializer):
+    id = serializers.CharField()
+    text = serializers.CharField()

--- a/solution/backend/content_search/serializers.py
+++ b/solution/backend/content_search/serializers.py
@@ -17,8 +17,3 @@ class ContentSearchSerializer(serializers.Serializer):
         return obj.reg_text.id if obj.reg_text else None
 
     reg_text = serializers.SerializerMethodField()
-
-
-class ContentUpdateSerializer(serializers.Serializer):
-    id = serializers.CharField()
-    text = serializers.CharField()

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -72,7 +72,7 @@ from .serializers import ContentSearchSerializer
             name="citations",
             required=False,
             type=int,
-            description= "Limit results to only resources linked to these citations. Use \"&citations=X&citations=Y\" "
+            description="Limit results to only resources linked to these citations. Use \"&citations=X&citations=Y\" "
                          "for multiple. Examples: 42, 42.433, 42.433.15, 42.433.D., str, False",
             location=OpenApiParameter.QUERY,
         ),

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -68,6 +68,14 @@ from .serializers import ContentSearchSerializer
                         "Default is true.",
             location=OpenApiParameter.QUERY,
         ),
+        OpenApiParameter(
+            name="citations",
+            required=False,
+            type=int,
+            description= "Limit results to only resources linked to these citations. Use \"&citations=X&citations=Y\" "
+                         "for multiple. Examples: 42, 42.433, 42.433.15, 42.433.D., str, False",
+            location=OpenApiParameter.QUERY,
+        ),
     ]  # + LocationFiltererMixin.PARAMETERS + PAGINATION_PARAMS
 )
 class ContentSearchViewSet(viewsets.ReadOnlyModelViewSet):

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -73,7 +73,7 @@ from .serializers import ContentSearchSerializer
             required=False,
             type=int,
             description="Limit results to only resources linked to these citations. Use \"&citations=X&citations=Y\" "
-                         "for multiple. Examples: 42, 42.433, 42.433.15, 42.433.D., str, False",
+                        "for multiple. Examples: 42, 42.433, 42.433.15, 42.433.D., str, False",
             location=OpenApiParameter.QUERY,
         ),
     ]  # + LocationFiltererMixin.PARAMETERS + PAGINATION_PARAMS

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -18,7 +18,9 @@ from .serializers import ContentSearchSerializer
 
 
 @extend_schema(
-    description="Retrieve list of uploaded files",
+    description="Search and retrieve content with highlighted matching terms. "
+                "This endpoint allows you to search through both resources and regulation texts, "
+                "returning relevant content with highlighted matches in the name, summary, and content fields.",
     parameters=[
         OpenApiParameter(
             name="subjects",
@@ -78,6 +80,7 @@ from .serializers import ContentSearchSerializer
         ),
     ]  # + LocationFiltererMixin.PARAMETERS + PAGINATION_PARAMS
 )
+
 class ContentSearchViewSet(viewsets.ReadOnlyModelViewSet):
     model = ContentIndex
     serializer_class = ContentSearchSerializer

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -80,7 +80,6 @@ from .serializers import ContentSearchSerializer
         ),
     ]  # + LocationFiltererMixin.PARAMETERS + PAGINATION_PARAMS
 )
-
 class ContentSearchViewSet(viewsets.ReadOnlyModelViewSet):
     model = ContentIndex
     serializer_class = ContentSearchSerializer

--- a/solution/backend/regcore/views/parser.py
+++ b/solution/backend/regcore/views/parser.py
@@ -15,6 +15,7 @@ from regcore.serializers.parser import (
 
 from .utils import OpenApiPathParameter
 
+
 @extend_schema(description="Retrieve configuration for the eCFR and Federal Register parsers.")
 class ParserConfigurationViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ParserConfigurationSerializer

--- a/solution/backend/regcore/views/parser.py
+++ b/solution/backend/regcore/views/parser.py
@@ -18,8 +18,8 @@ from .utils import OpenApiPathParameter
 
 
 class SettingsAuthenticationScheme(OpenApiAuthenticationExtension):
-    target_class = 'common.auth.SettingsAuthentication'  # Full import path to your authentication class
-    name = 'SettingsAuth'  # Name used in the OpenAPI schema
+    target_class = 'common.auth.SettingsAuthentication'
+    name = 'SettingsAuth'
 
     def get_security_definition(self, auto_schema):
         return {

--- a/solution/backend/regcore/views/parser.py
+++ b/solution/backend/regcore/views/parser.py
@@ -1,10 +1,10 @@
 from django.db import transaction
 from django.http import Http404, JsonResponse
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
-from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
 from common.auth import SettingsAuthentication
 from regcore.models import ECFRParserResult, ParserConfiguration, Part
@@ -26,6 +26,7 @@ class SettingsAuthenticationScheme(OpenApiAuthenticationExtension):
             'type': 'http',
             'scheme': 'bearer'
         }
+
 
 @extend_schema(description="Retrieve configuration for the eCFR and Federal Register parsers.")
 class ParserConfigurationViewSet(viewsets.ReadOnlyModelViewSet):

--- a/solution/backend/regcore/views/parser.py
+++ b/solution/backend/regcore/views/parser.py
@@ -1,6 +1,5 @@
 from django.db import transaction
 from django.http import Http404, JsonResponse
-from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
@@ -15,18 +14,6 @@ from regcore.serializers.parser import (
 )
 
 from .utils import OpenApiPathParameter
-
-
-class SettingsAuthenticationScheme(OpenApiAuthenticationExtension):
-    target_class = 'common.auth.SettingsAuthentication'
-    name = 'SettingsAuth'
-
-    def get_security_definition(self, auto_schema):
-        return {
-            'type': 'http',
-            'scheme': 'bearer'
-        }
-
 
 @extend_schema(description="Retrieve configuration for the eCFR and Federal Register parsers.")
 class ParserConfigurationViewSet(viewsets.ReadOnlyModelViewSet):

--- a/solution/backend/regcore/views/parser.py
+++ b/solution/backend/regcore/views/parser.py
@@ -4,6 +4,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
 
 from common.auth import SettingsAuthentication
 from regcore.models import ECFRParserResult, ParserConfiguration, Part
@@ -15,6 +16,16 @@ from regcore.serializers.parser import (
 
 from .utils import OpenApiPathParameter
 
+
+class SettingsAuthenticationScheme(OpenApiAuthenticationExtension):
+    target_class = 'common.auth.SettingsAuthentication'  # Full import path to your authentication class
+    name = 'SettingsAuth'  # Name used in the OpenAPI schema
+
+    def get_security_definition(self, auto_schema):
+        return {
+            'type': 'http',
+            'scheme': 'bearer'
+        }
 
 @extend_schema(description="Retrieve configuration for the eCFR and Federal Register parsers.")
 class ParserConfigurationViewSet(viewsets.ReadOnlyModelViewSet):

--- a/solution/backend/resources/serializers/categories.py
+++ b/solution/backend/resources/serializers/categories.py
@@ -42,6 +42,7 @@ class PublicSubCategorySerializer(CategorySerializer):
 
     parent = serializers.SerializerMethodField()
 
+
 class PublicCategoryWithSubCategoriesSerializer(CategorySerializer):
     subcategories = PublicSubCategorySerializer(many=True)
 

--- a/solution/backend/resources/serializers/categories.py
+++ b/solution/backend/resources/serializers/categories.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from resources.models import (
@@ -35,8 +36,11 @@ class CategorySerializer(serializers.Serializer):
 
 
 class PublicSubCategorySerializer(CategorySerializer):
-    parent = serializers.PrimaryKeyRelatedField(read_only=True)
+    @extend_schema_field(serializers.IntegerField())
+    def get_parent(self, obj):
+        return obj.parent.id if obj.parent else None
 
+    parent = serializers.SerializerMethodField()
 
 class PublicCategoryWithSubCategoriesSerializer(CategorySerializer):
     subcategories = PublicSubCategorySerializer(many=True)
@@ -47,7 +51,11 @@ class PublicCategorySerializer(CategorySerializer):
 
 
 class InternalSubCategorySerializer(CategorySerializer):
-    parent = serializers.PrimaryKeyRelatedField(read_only=True)
+    @extend_schema_field(serializers.IntegerField())
+    def get_parent(self, obj):
+        return obj.parent.id if obj.parent else None
+
+    parent = serializers.SerializerMethodField()
 
 
 class InternalCategoryWithSubCategoriesSerializer(CategorySerializer):

--- a/solution/backend/resources/serializers/groups.py
+++ b/solution/backend/resources/serializers/groups.py
@@ -17,4 +17,3 @@ class ResourceGroupSerializer(serializers.Serializer):
         return [resource.id for resource in obj.resources.all()]
 
     resources = serializers.SerializerMethodField()
-

--- a/solution/backend/resources/serializers/groups.py
+++ b/solution/backend/resources/serializers/groups.py
@@ -18,13 +18,3 @@ class ResourceGroupSerializer(serializers.Serializer):
 
     resources = serializers.SerializerMethodField()
 
-    def to_representation(self, instance):
-        representation = super().to_representation(instance)
-        request = self.context.get('request', None)
-
-        # Serialize resources by full representation if requested
-        if request and request.query_params.get('serialize_by') == 'full':
-            resource_serializer = ResourceSerializer(instance.resources.all(), many=True)
-            representation['resources'] = resource_serializer.data
-
-        return representation

--- a/solution/backend/resources/serializers/groups.py
+++ b/solution/backend/resources/serializers/groups.py
@@ -1,5 +1,5 @@
-from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
 
 
 class ResourceSerializer(serializers.Serializer):

--- a/solution/backend/resources/serializers/groups.py
+++ b/solution/backend/resources/serializers/groups.py
@@ -1,7 +1,30 @@
 from rest_framework import serializers
+from drf_spectacular.utils import extend_schema_field
+
+
+class ResourceSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
 
 
 class ResourceGroupSerializer(serializers.Serializer):
     name = serializers.CharField()
     common_identifiers = serializers.ListField(child=serializers.CharField())
-    resources = serializers.PrimaryKeyRelatedField(many=True, read_only=True)  # TODO: serialize the whole resource
+
+    @extend_schema_field(serializers.ListField(child=serializers.IntegerField()))
+    def get_resources(self, obj):
+        # Default behavior: return primary keys
+        return [resource.id for resource in obj.resources.all()]
+
+    resources = serializers.SerializerMethodField()
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        request = self.context.get('request', None)
+
+        # Serialize resources by full representation if requested
+        if request and request.query_params.get('serialize_by') == 'full':
+            resource_serializer = ResourceSerializer(instance.resources.all(), many=True)
+            representation['resources'] = resource_serializer.data
+
+        return representation

--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -1,8 +1,8 @@
 import re
+from typing import List, Optional
 
 from django.db.models import Q
 from rest_framework import serializers
-from typing import Optional, List
 
 from resources.models import (
     AbstractCitation,

--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -1,5 +1,4 @@
 import re
-from typing import List, Optional
 
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema_field

--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -2,6 +2,7 @@ import re
 
 from django.db.models import Q
 from rest_framework import serializers
+from typing import Optional, List
 
 from resources.models import (
     AbstractCitation,
@@ -192,7 +193,7 @@ class ResourceSerializer(serializers.Serializer):
     url = serializers.CharField()
     related_resources = serializers.SerializerMethodField()
 
-    def get_related_resources(self, obj):
+    def get_related_resources(self, obj) -> Optional[List[dict]]:
         if self.context.get("show_related", False):
             return AbstractResourceSerializer(instance=obj.related_resources, many=True).data
         return None

--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -2,6 +2,7 @@ import re
 from typing import List, Optional
 
 from django.db.models import Q
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from resources.models import (
@@ -193,7 +194,8 @@ class ResourceSerializer(serializers.Serializer):
     url = serializers.CharField()
     related_resources = serializers.SerializerMethodField()
 
-    def get_related_resources(self, obj) -> Optional[List[dict]]:
+    @extend_schema_field(serializers.ListField(child=serializers.DictField()))
+    def get_related_resources(self, obj):
         if self.context.get("show_related", False):
             return AbstractResourceSerializer(instance=obj.related_resources, many=True).data
         return None

--- a/solution/backend/resources/views/categories.py
+++ b/solution/backend/resources/views/categories.py
@@ -16,6 +16,7 @@ from resources.serializers import (
     PublicCategoryWithSubCategoriesSerializer,
 )
 
+
 @extend_schema(
     description="Retrieve a list of public categories along with their subcategories. "
                 "This endpoint provides access to categories that are publicly available. "
@@ -28,6 +29,7 @@ class PublicCategoryViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = PublicCategory.objects.all().prefetch_related(
         Prefetch("subcategories", PublicSubCategory.objects.order_by("order")),
     ).order_by("order")
+
 
 @extend_schema(
     description="Retrieve a list of internal categories along with their subcategories. "

--- a/solution/backend/resources/views/categories.py
+++ b/solution/backend/resources/views/categories.py
@@ -1,4 +1,5 @@
 from django.db.models import Prefetch
+from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
@@ -15,7 +16,12 @@ from resources.serializers import (
     PublicCategoryWithSubCategoriesSerializer,
 )
 
-
+@extend_schema(
+    description="Retrieve a list of public categories along with their subcategories. "
+                "This endpoint provides access to categories that are publicly available. "
+                "Categories and their respective subcategories are ordered based on their "
+                "defined order field."
+)
 class PublicCategoryViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = ViewSetPagination
     serializer_class = PublicCategoryWithSubCategoriesSerializer
@@ -23,7 +29,13 @@ class PublicCategoryViewSet(viewsets.ReadOnlyModelViewSet):
         Prefetch("subcategories", PublicSubCategory.objects.order_by("order")),
     ).order_by("order")
 
-
+@extend_schema(
+    description="Retrieve a list of internal categories along with their subcategories. "
+                "This endpoint is accessible only to authenticated users and provides access "
+                "to internal categories that may include restricted or confidential information. "
+                "Categories and their respective subcategories are ordered based on their "
+                "defined order field."
+)
 class InternalCategoryViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = ViewSetPagination
     authentication_classes = [SessionAuthentication]

--- a/solution/backend/resources/views/citations.py
+++ b/solution/backend/resources/views/citations.py
@@ -1,4 +1,5 @@
 from django.db.models import Prefetch
+from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 
 from common.mixins import ViewSetPagination
@@ -13,13 +14,21 @@ from resources.serializers import (
     SubpartWithChildrenSerializer,
 )
 
-
+@extend_schema(
+    description="Retrieve a list of legal citations, which may include references to sections, subparts, and other "
+                "regulatory text. This endpoint supports access to different types of citations, and the results are "
+                "ordered based on the specific citation subclass. "
+)
 class CitationViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = ViewSetPagination
     serializer_class = AbstractCitationSerializer
     queryset = AbstractCitation.objects.select_subclasses()
 
-
+@extend_schema(
+    description="Retrieve a list of sections within regulatory text, including their parent subparts. "
+                "This endpoint provides access to sections and their associated subparts, with the data "
+                "prefetched and ordered according to their hierarchy."
+)
 class SectionViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = ViewSetPagination
     serializer_class = SectionWithParentSerializer
@@ -27,7 +36,11 @@ class SectionViewSet(viewsets.ReadOnlyModelViewSet):
         Prefetch("parent", Subpart.objects.all()),
     )
 
-
+@extend_schema(
+    description="Retrieve a list of subparts within regulatory text, including their child sections. "
+                "This endpoint allows access to subparts and their associated sections, with data "
+                "prefetched to include child sections and ordered by their hierarchical structure."
+)
 class SubpartViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = ViewSetPagination
     serializer_class = SubpartWithChildrenSerializer

--- a/solution/backend/resources/views/citations.py
+++ b/solution/backend/resources/views/citations.py
@@ -14,6 +14,7 @@ from resources.serializers import (
     SubpartWithChildrenSerializer,
 )
 
+
 @extend_schema(
     description="Retrieve a list of legal citations, which may include references to sections, subparts, and other "
                 "regulatory text. This endpoint supports access to different types of citations, and the results are "
@@ -23,6 +24,7 @@ class CitationViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = ViewSetPagination
     serializer_class = AbstractCitationSerializer
     queryset = AbstractCitation.objects.select_subclasses()
+
 
 @extend_schema(
     description="Retrieve a list of sections within regulatory text, including their parent subparts. "
@@ -35,6 +37,7 @@ class SectionViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Section.objects.prefetch_related(
         Prefetch("parent", Subpart.objects.all()),
     )
+
 
 @extend_schema(
     description="Retrieve a list of subparts within regulatory text, including their child sections. "

--- a/solution/backend/resources/views/groups.py
+++ b/solution/backend/resources/views/groups.py
@@ -1,4 +1,5 @@
 from django.db.models import Prefetch
+from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 
 from common.mixins import ViewSetPagination
@@ -9,7 +10,13 @@ from resources.models import (
 )
 from resources.serializers import ResourceGroupSerializer
 
-
+@extend_schema(
+    description="Retrieve a list of resource groups, which are collections of related resources. "
+                "This endpoint supports both authenticated and unauthenticated users, with different "
+                "resource filters applied based on the user's authentication status. Authenticated users "
+                "can access all resources, while unauthenticated users are limited to public resources only. "
+                "The results include prefetched resources belonging to each group."
+)
 class ResourceGroupViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ResourceGroupSerializer
     pagination_class = ViewSetPagination

--- a/solution/backend/resources/views/groups.py
+++ b/solution/backend/resources/views/groups.py
@@ -10,6 +10,7 @@ from resources.models import (
 )
 from resources.serializers import ResourceGroupSerializer
 
+
 @extend_schema(
     description="Retrieve a list of resource groups, which are collections of related resources. "
                 "This endpoint supports both authenticated and unauthenticated users, with different "

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -148,13 +148,11 @@ class PublicResourceViewSet(ResourceViewSet):
     model = AbstractPublicResource
 
 
-@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class PublicLinkViewSet(PublicResourceViewSet):
     model = PublicLink
     serializer_class = PublicLinkSerializer
 
 
-@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class FederalRegisterLinkViewSet(PublicResourceViewSet):
     model = FederalRegisterLink
     authentication_classes = [SettingsAuthentication]

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -83,7 +83,7 @@ COMMON_QUERY_PARAMETERS = [
 ]
 
 
-@extend_schema( parameters=COMMON_QUERY_PARAMETERS )
+@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class ResourceViewSet(viewsets.ModelViewSet):
     pagination_class = ViewSetPagination
     serializer_class = AbstractResourceSerializer
@@ -98,6 +98,7 @@ class ResourceViewSet(viewsets.ModelViewSet):
     )
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
+
     def get_serializer_context(self):
         return {"show_related": string_to_bool(self.request.GET.get("group_resources"), True)}
 
@@ -156,10 +157,12 @@ class ResourceViewSet(viewsets.ModelViewSet):
 
         return query.distinct().select_subclasses()
 
+
 @extend_schema(description="Retrieve a list of public resources with optional filtering by "
-                           "citations, categories, subjects, and resource grouping." )
+                           "citations, categories, subjects, and resource grouping.")
 class PublicResourceViewSet(ResourceViewSet):
     model = AbstractPublicResource
+
 
 @extend_schema(description="Retrieve a list of public links, including options to filter by citations, "
                            "categories, subjects, and grouping criteria. This endpoint is available to "
@@ -209,14 +212,13 @@ class InternalResourceViewSet(ResourceViewSet):
     @extend_schema(description="Retrieve a list of internal resources, which are only "
                                "accessible to authenticated users. This endpoint supports "
                                "filtering by citations, categories, subjects, and grouping criteria")
-
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
 
 @extend_schema(description="Retrieve a list of internal files, accessible only to authenticated users. "
                            "This endpoint supports filtering by citations, categories, subjects, and "
-                           "grouping criteria." )
+                           "grouping criteria.")
 class InternalFileViewSet(InternalResourceViewSet):
     model = InternalFile
     serializer_class = InternalFileSerializer

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -82,6 +82,7 @@ COMMON_QUERY_PARAMETERS = [
     ),
 ]
 
+
 @extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class ResourceViewSet(viewsets.ModelViewSet):
     pagination_class = ViewSetPagination
@@ -183,7 +184,6 @@ class FederalRegisterLinkViewSet(PublicResourceViewSet):
         return JsonResponse(sc.validated_data)
 
 
-@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class InternalResourceViewSet(ResourceViewSet):
     model = AbstractInternalResource
     authentication_classes = [SessionAuthentication]

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -51,7 +51,8 @@ COMMON_QUERY_PARAMETERS = [
         name="citations",
         type=OpenApiTypes.STR,  # Assuming citations are strings, use OpenApiTypes.INT if they're integers
         location=OpenApiParameter.QUERY,
-        description="List of citation IDs to filter by",
+        description="Limit results to only resources linked to these citations. Use \"&citations=X&citations=Y\" "
+                    "for multiple. Examples: 42, 42.433, 42.433.15, 42.433.D., str, False",
         required=False,
         explode=False,  # Treat as an array, not a CSV string
     ),

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -189,13 +189,11 @@ class InternalResourceViewSet(ResourceViewSet):
     permission_classes = [IsAuthenticated]
 
 
-@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class InternalFileViewSet(InternalResourceViewSet):
     model = InternalFile
     serializer_class = InternalFileSerializer
 
 
-@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class InternalLinkViewSet(InternalResourceViewSet):
     model = InternalLink
     serializer_class = InternalLinkSerializer

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -41,7 +41,6 @@ from resources.utils import (
 
 logger = logging.getLogger(__name__)
 
-
 # OpenApiQueryParameter("citations",
 #                       "Limit results to only resources linked to these CFR Citations. Use \"&citations=X&citations=Y\" "
 #                       "for multiple. Examples: 42, 42.433, 42.433.15, 42.433.D.", str, False),
@@ -92,7 +91,7 @@ class ResourceViewSet(viewsets.ModelViewSet):
     @extend_schema(
         description="Retrieve, filter, and group various resources based on citations, "
                     "categories, subjects, and other criteria. This endpoint allows "
-                    "authenticated and unauthenticated users to search through approved "
+                    "authenticated and unauthenticated users to view approved "
                     "resources, with options to group resources and filter by related fields "
                     "such as categories, subjects, and citations.",
     )
@@ -173,10 +172,10 @@ class PublicLinkViewSet(PublicResourceViewSet):
 
 
 @extend_schema(description="Retrieve and update Federal Register links. "
-                            "This endpoint allows filtering by citations, "
-                            "categories, subjects, and grouping criteria. "
-                            "Only authenticated users can update existing Federal i"
-                            "Register links.")
+                           "This endpoint allows filtering by citations, "
+                           "categories, subjects, and grouping criteria. "
+                           "Only authenticated users can update existing Federal "
+                           "Register links.")
 class FederalRegisterLinkViewSet(PublicResourceViewSet):
     model = FederalRegisterLink
     authentication_classes = [SettingsAuthentication]

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -45,6 +45,41 @@ logger = logging.getLogger(__name__)
 # OpenApiQueryParameter("citations",
 #                       "Limit results to only resources linked to these CFR Citations. Use \"&citations=X&citations=Y\" "
 #                       "for multiple. Examples: 42, 42.433, 42.433.15, 42.433.D.", str, False),
+
+COMMON_QUERY_PARAMETERS = [
+    OpenApiParameter(
+        name="citations",
+        type=OpenApiTypes.STR,  # Assuming citations are strings, use OpenApiTypes.INT if they're integers
+        location=OpenApiParameter.QUERY,
+        description="List of citation IDs to filter by",
+        required=False,
+        explode=False,  # Treat as an array, not a CSV string
+    ),
+    OpenApiParameter(
+        name="categories",
+        type=OpenApiTypes.STR,  # Assuming categories are strings, use OpenApiTypes.INT if they're integers
+        location=OpenApiParameter.QUERY,
+        description="List of category IDs to filter by, including subcategories",
+        required=False,
+        explode=False,
+    ),
+    OpenApiParameter(
+        name="subjects",
+        type=OpenApiTypes.STR,  # Assuming subjects are strings, use OpenApiTypes.INT if they're integers
+        location=OpenApiParameter.QUERY,
+        description="List of subject IDs to filter by",
+        required=False,
+        explode=False,
+    ),
+    OpenApiParameter(
+        name="group_resources",
+        type=OpenApiTypes.BOOL,
+        location=OpenApiParameter.QUERY,
+        description="Boolean flag to control resource grouping",
+        required=False,
+        default=True,
+    ),
+]
 class ResourceViewSet(viewsets.ModelViewSet):
     pagination_class = ViewSetPagination
     serializer_class = AbstractResourceSerializer
@@ -113,47 +148,13 @@ class PublicResourceViewSet(ResourceViewSet):
     model = AbstractPublicResource
 
 
-@extend_schema(
-    parameters=[
-        OpenApiParameter(
-            name="citations",
-            type=OpenApiTypes.STR,  # Assuming citations are strings, use OpenApiTypes.INT if they're integers
-            location=OpenApiParameter.QUERY,
-            description="List of citation IDs to filter by",
-            required=False,
-            explode=False,  # Treat as an array, not a CSV string
-        ),
-        OpenApiParameter(
-            name="categories",
-            type=OpenApiTypes.STR,  # Assuming categories are strings, use OpenApiTypes.INT if they're integers
-            location=OpenApiParameter.QUERY,
-            description="List of category IDs to filter by, including subcategories",
-            required=False,
-            explode=False,
-        ),
-        OpenApiParameter(
-            name="subjects",
-            type=OpenApiTypes.STR,  # Assuming subjects are strings, use OpenApiTypes.INT if they're integers
-            location=OpenApiParameter.QUERY,
-            description="List of subject IDs to filter by",
-            required=False,
-            explode=False,
-        ),
-        OpenApiParameter(
-            name="group_resources",
-            type=OpenApiTypes.BOOL,
-            location=OpenApiParameter.QUERY,
-            description="Boolean flag to control resource grouping",
-            required=False,
-            default=True,
-        ),
-    ]
-)
+@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class PublicLinkViewSet(PublicResourceViewSet):
     model = PublicLink
     serializer_class = PublicLinkSerializer
 
 
+@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class FederalRegisterLinkViewSet(PublicResourceViewSet):
     model = FederalRegisterLink
     authentication_classes = [SettingsAuthentication]
@@ -180,18 +181,20 @@ class FederalRegisterLinkViewSet(PublicResourceViewSet):
                 logger.warning("Failed to extract text for Federal Register Link %i: %s", link.pk, fail[0]["reason"])
         return JsonResponse(sc.validated_data)
 
-
+@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class InternalResourceViewSet(ResourceViewSet):
     model = AbstractInternalResource
     authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
 
+@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class InternalFileViewSet(InternalResourceViewSet):
     model = InternalFile
     serializer_class = InternalFileSerializer
 
 
+@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class InternalLinkViewSet(InternalResourceViewSet):
     model = InternalLink
     serializer_class = InternalLinkSerializer

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from django.db.models import F, Prefetch, Q
 from django.http import JsonResponse
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema, OpenApiParameter
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
@@ -80,6 +80,8 @@ COMMON_QUERY_PARAMETERS = [
         default=True,
     ),
 ]
+
+
 class ResourceViewSet(viewsets.ModelViewSet):
     pagination_class = ViewSetPagination
     serializer_class = AbstractResourceSerializer
@@ -178,6 +180,7 @@ class FederalRegisterLinkViewSet(PublicResourceViewSet):
             if fail:
                 logger.warning("Failed to extract text for Federal Register Link %i: %s", link.pk, fail[0]["reason"])
         return JsonResponse(sc.validated_data)
+
 
 @extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class InternalResourceViewSet(ResourceViewSet):

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -82,7 +82,7 @@ COMMON_QUERY_PARAMETERS = [
     ),
 ]
 
-
+@extend_schema(parameters=COMMON_QUERY_PARAMETERS)
 class ResourceViewSet(viewsets.ModelViewSet):
     pagination_class = ViewSetPagination
     serializer_class = AbstractResourceSerializer

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -3,7 +3,8 @@ import logging
 from django.db import transaction
 from django.db.models import F, Prefetch, Q
 from django.http import JsonResponse
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework import viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
@@ -112,6 +113,42 @@ class PublicResourceViewSet(ResourceViewSet):
     model = AbstractPublicResource
 
 
+@extend_schema(
+    parameters=[
+        OpenApiParameter(
+            name="citations",
+            type=OpenApiTypes.STR,  # Assuming citations are strings, use OpenApiTypes.INT if they're integers
+            location=OpenApiParameter.QUERY,
+            description="List of citation IDs to filter by",
+            required=False,
+            explode=False,  # Treat as an array, not a CSV string
+        ),
+        OpenApiParameter(
+            name="categories",
+            type=OpenApiTypes.STR,  # Assuming categories are strings, use OpenApiTypes.INT if they're integers
+            location=OpenApiParameter.QUERY,
+            description="List of category IDs to filter by, including subcategories",
+            required=False,
+            explode=False,
+        ),
+        OpenApiParameter(
+            name="subjects",
+            type=OpenApiTypes.STR,  # Assuming subjects are strings, use OpenApiTypes.INT if they're integers
+            location=OpenApiParameter.QUERY,
+            description="List of subject IDs to filter by",
+            required=False,
+            explode=False,
+        ),
+        OpenApiParameter(
+            name="group_resources",
+            type=OpenApiTypes.BOOL,
+            location=OpenApiParameter.QUERY,
+            description="Boolean flag to control resource grouping",
+            required=False,
+            default=True,
+        ),
+    ]
+)
 class PublicLinkViewSet(PublicResourceViewSet):
     model = PublicLink
     serializer_class = PublicLinkSerializer

--- a/solution/backend/resources/views/subjects.py
+++ b/solution/backend/resources/views/subjects.py
@@ -6,6 +6,7 @@ from common.mixins import ViewSetPagination
 from resources.models import Subject
 from resources.serializers import SubjectWithCountsSerializer
 
+
 @extend_schema(
     description="Retrieve a list of subjects, each annotated with the count of associated public and internal resources. "
                 "Authenticated users can see the count of both public and internal resources, while unauthenticated users "

--- a/solution/backend/resources/views/subjects.py
+++ b/solution/backend/resources/views/subjects.py
@@ -1,11 +1,16 @@
 from django.db.models import Count, Q, Value
+from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 
 from common.mixins import ViewSetPagination
 from resources.models import Subject
 from resources.serializers import SubjectWithCountsSerializer
 
-
+@extend_schema(
+    description="Retrieve a list of subjects, each annotated with the count of associated public and internal resources. "
+                "Authenticated users can see the count of both public and internal resources, while unauthenticated users "
+                "only see the count of public resources. The subjects are ordered by a predefined sort order."
+)
 class SubjectViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = SubjectWithCountsSerializer
     pagination_class = ViewSetPagination


### PR DESCRIPTION
Resolves # EREGCSC-2756

**Description-**
Update swagger so that it does not return an error anymore. The issue was that ResourceGroupSerializer needed to be updated to serialize the entire resource not just using the primary keys. 

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change

visit : [swagger](https://fdc0l1ak6c.execute-api.us-east-1.amazonaws.com/dev1407/api/swagger)
notice error is no longer there. 
2. on your local go to this pull request branch.
3. on your local, run django app `make local`
4. run `run make local.spectacular`
5. check to see that there are no errors. 