### PR TITLE
[Hotfix] Ensure CMS Design System npm package version is 2.5.0

### DIFF
--- a/solution/ui/regulations/package-lock.json
+++ b/solution/ui/regulations/package-lock.json
@@ -7,7 +7,7 @@
       "name": "regulations",
       "license": "CC",
       "dependencies": {
-        "@cmsgov/design-system": "^2.5.0",
+        "@cmsgov/design-system": "2.5.0",
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@vitejs/plugin-vue": "^4.6.2",
         "@vue/test-utils": "^2.4.6",
@@ -318,22 +318,20 @@
       "dev": true
     },
     "node_modules/@cmsgov/design-system": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@cmsgov/design-system/-/design-system-2.13.0.tgz",
-      "integrity": "sha512-5/rNspXZvMXOov3PqTgksZPOKV5dnh0WpyuFtSOW6ulNXa9eWNIa1Tq26eL1fD5uJsf7Lz8LqKrsZi1Mr8NbMw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cmsgov/design-system/-/design-system-2.5.0.tgz",
+      "integrity": "sha512-jcqfS39xl/m7m+iPG/FiNAloQE/xAgeex8gB3DsXZhRY0+JWRpMsmRh+vR+k0RkzZtTQMUC9fgX7ThsjTScj9w==",
       "dependencies": {
         "@popperjs/core": "^2.4.4",
-        "@types/react": "^17.0.10",
-        "@types/react-dom": "^17.0.10",
         "classnames": "^2.2.5",
         "core-js": "^3.6.5",
         "downshift": "^3.2.10",
         "ev-emitter": "^1.1.1",
         "focus-trap-react": "^6.0.0",
-        "lodash": "^4.17.21",
+        "lodash.uniqueid": "^4.0.1",
         "prop-types": "^15.7.2",
         "react-aria-modal": "^2.11.1",
-        "react-transition-group": "^4.4.2"
+        "react-transition-group": "^2.9.0"
       },
       "peerDependencies": {
         "react": ">=16.0.0",
@@ -1479,34 +1477,6 @@
       "dependencies": {
         "undici-types": "~6.13.0"
       }
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.12",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
-      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
-    },
-    "node_modules/@types/react": {
-      "version": "17.0.80",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.80.tgz",
-      "integrity": "sha512-LrgHIu2lEtIo8M7d1FcI3BdwXWoRQwMoXOZ7+dPTW0lYREjmlHl3P0U1VD0i/9tppOuv8/sam7sOjx34TxSFbA==",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "17.0.25",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.25.tgz",
-      "integrity": "sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==",
-      "dependencies": {
-        "@types/react": "^17"
-      }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.10",
@@ -3402,12 +3372,11 @@
       "dev": true
     },
     "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
       "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
+        "@babel/runtime": "^7.1.2"
       }
     },
     "node_modules/domexception": {
@@ -6198,6 +6167,11 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q=="
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -7859,19 +7833,24 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
       "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
+        "dom-helpers": "^3.4.0",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
       },
       "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
+        "react": ">=15.0.0",
+        "react-dom": ">=15.0.0"
       }
     },
     "node_modules/readable-stream": {

--- a/solution/ui/regulations/package.json
+++ b/solution/ui/regulations/package.json
@@ -16,7 +16,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@cmsgov/design-system": "^2.5.0",
+    "@cmsgov/design-system": "2.5.0",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@vitejs/plugin-vue": "^4.6.2",
     "@vue/test-utils": "^2.4.6",


### PR DESCRIPTION
**Description**

[EREGCSC-2779](https://jiraent.cms.gov/browse/EREGCSC-2779) (Vitest fixes) introduced a regression where the CMS Design System npm package was updated to a newer minor version.  Our targeted version is `2.5.0`, but the [pull request for 2779](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1404) rebuilt the `package-lock.json` file to install `2.13.0`.

We don't want `2.13.0` because it includes unwanted style changes.  Specifically, element `focus` styles are pink instead of blue.

We've previously attempted to upgrade to `2.13.0` based on a Snyk suggestion, but that upgrade [was reverted](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1044) back to `2.5.0` for this same reason.

Except we didn't actually lock the version to `2.5.0`.  Note this line from `package.json`:

```
"@cmsgov/design-system": "^2.5.0",
```

The caret (`^`) before the version indicates that minor (`0.X`) and patch (`0.0.X`) versions can be updated if available and compatible.  See [NPM documentation here](https://docs.npmjs.com/cli/v6/using-npm/semver#caret-ranges-123-025-004).  This means that when rebuilding the `package-lock` file, the most recent `2.X.X` version will be installed.  In our case, `2.13.0` is the most recent version and was installed.

This issue is happening now because the `package-lock.json` file was recently rebuilt as part of EREGCSC-2779.

**This pull request changes:**

- Removes caret from CMS Design System version number

**Steps to manually verify this change:**

1. Green check marks
2. Use `tab` to navigate around the site via the keyboard.  Ensure that you don't see any pink focus styles around any elements.

