### PR TITLE
EREGCSC-2823 Fix for unapproved resources showing in search

### DIFF
--- a/solution/backend/content_search/tests/test_search.py
+++ b/solution/backend/content_search/tests/test_search.py
@@ -94,10 +94,11 @@ class SearchTest(TestCase):
         response = self.client.get("/v3/content-search/?show_internal=false&show_regulations=false")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_public_resources_access_logged_in(self):
-        self.login()
-        response = self.client.get("/v3/resources/public")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    def test_unapproved_is_hidden(self):
+        PublicLink.objects.create(approved=False, title="Unapproved")
+        response = self.client.get("/v3/content-search/?q=unapproved")
+        data = get_paginated_data(response)
+        self.assertEqual(data['count'], 0)
 
     def test_single_response_queries(self):
         self.login()

--- a/solution/backend/content_search/tests/test_search.py
+++ b/solution/backend/content_search/tests/test_search.py
@@ -96,9 +96,11 @@ class SearchTest(TestCase):
 
     def test_unapproved_is_hidden(self):
         PublicLink.objects.create(approved=False, title="Unapproved")
+        PublicLink.objects.create(approved=True, title="Not unapproved")
         response = self.client.get("/v3/content-search/?q=unapproved")
         data = get_paginated_data(response)
-        self.assertEqual(data['count'], 0)
+        self.assertEqual(data['count'], 1)
+        self.assertEqual(data['results'][0]['resource']['title'], "Not unapproved")
 
     def test_single_response_queries(self):
         self.login()

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -100,6 +100,9 @@ class ContentSearchViewSet(viewsets.ReadOnlyModelViewSet):
 
         query = ContentIndex.objects.defer("content")
 
+        # Filter out unapproved resources
+        query = query.filter(resource__approved=True)
+
         # Filter inclusively by citations if this array exists
         citation_filter = get_citation_filter(citations, "resource__cfr_citations__")
         if citation_filter:


### PR DESCRIPTION
Resolves #2823

**Description-**

The `content-search` endpoint is not filtering out unapproved resources, resulting in unapproved resources showing in search results if indexed.

**This pull request changes...**

- Unapproved resources are filtered out from content-search results.
- Added a test to verify that this is the case.
- Removed an irrelevant content-search test that was testing the resources app.

**Steps to manually verify this change...**

1. Go to the search page and search for any term. Make note of the first result's ID.
2. Go to the admin panel and find the instance corresponding to the first result on the search page.
3. Mark that resource as unapproved and save it.
4. Refresh the search page. That result should now be missing, as expected.

