### PR TITLE
[Offboarding] Remove Parissa from `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @PhilR8 @cgodwin1 @peggles2
+*  @PhilR8 @cgodwin1


### PR DESCRIPTION
Resolves offboarding checklist item

**Description**

Parissa has been offboarded from the team and this PR removes her Github account from the project's `CODEOWNERS` file.

**This pull request changes:**

- Removes Parissa's Github username from `CODEOWNERS`
- and then there were two

**Steps to manually verify this change...**

1. `CODEOWNERS` file is reduced to two current devs

