### PR TITLE
EREGCSC-2850 Enable querying for item counts when document type is not selected

### DIFF
--- a/solution/backend/cmcs_regulations/utils/pagination.py
+++ b/solution/backend/cmcs_regulations/utils/pagination.py
@@ -1,4 +1,3 @@
-from django.db.models import Count
 from drf_spectacular.utils import OpenApiParameter
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
@@ -6,9 +5,6 @@ from rest_framework.response import Response
 
 # Generic pagination for viewsets.
 # Provides a "page_size" parameter for controlling the number of results per page. Default page size is 100.
-#
-# To include counts of types in the response, subclass this and override `get_count_map` to return a list
-# of dictionaries of the form: {"name": "name_of_count", "count_field": "field_to_count", "filter": Q() filter or None}.
 #
 # To include additional attributes, override `get_additional_attributes` and return a dictionary of additional attributes.
 class ViewSetPagination(PageNumberPagination):
@@ -34,18 +30,6 @@ class ViewSetPagination(PageNumberPagination):
     max_page_size = 1000
     page_size = 100
 
-    def get_count_map(self):
-        return None
-
-    def get_additional_counts(self):
-        additional_counts = self.get_count_map()
-        if not additional_counts:
-            return {}
-        counts = self.queryset.aggregate(
-            **{count["name"]: Count(count["count_field"], filter=count["filter"]) for count in additional_counts}
-        )
-        return {count["name"]: counts[count["name"]] for count in additional_counts}
-
     def get_additional_attributes(self):
         return {}
 
@@ -58,7 +42,6 @@ class ViewSetPagination(PageNumberPagination):
     def get_paginated_response(self, data):
         return Response({
             **self.get_additional_attributes(),
-            **self.get_additional_counts(),
             **{
                 "next": self.get_next_link(),
                 "previous": self.get_previous_link(),

--- a/solution/backend/cmcs_regulations/utils/pagination.py
+++ b/solution/backend/cmcs_regulations/utils/pagination.py
@@ -7,6 +7,8 @@ from rest_framework.response import Response
 # Provides a "page_size" parameter for controlling the number of results per page. Default page size is 100.
 #
 # To include additional attributes, override `get_additional_attributes` and return a dictionary of additional attributes.
+# To reflect additional attributes in the OpenAPI schema, override `get_additional_attribute_schemas` and return a dictionary.
+#    - See `get_paginated_response_schema` for an example of an additional attribute schema.
 class ViewSetPagination(PageNumberPagination):
     QUERY_PARAMETERS = [
         OpenApiParameter(
@@ -33,6 +35,9 @@ class ViewSetPagination(PageNumberPagination):
     def get_additional_attributes(self):
         return {}
 
+    def get_additional_attribute_schemas(self):
+        return {}
+
     def paginate_queryset(self, queryset, request, view=None):
         self.queryset = queryset
         self.request = request
@@ -49,3 +54,26 @@ class ViewSetPagination(PageNumberPagination):
                 "results": data,
             },
         })
+
+    def get_paginated_response_schema(self, schema):
+        return {
+            "type": "object",
+            "required": ["count", "results"],
+            "properties": {
+                **self.get_additional_attribute_schemas(),
+                "next": {
+                    "type": "string",
+                    "format": "uri",
+                    "nullable": True,
+                    "example": "http://api.example.org/accounts/?page=4",
+                },
+                "previous": {
+                    "type": "string",
+                    "format": "uri",
+                    "nullable": True,
+                    "example": "http://api.example.org/accounts/?page=2",
+                },
+                "count": {"type": "integer", "example": 123},
+                "results": schema,
+            },
+        }

--- a/solution/backend/content_search/serializers.py
+++ b/solution/backend/content_search/serializers.py
@@ -21,3 +21,9 @@ class ContentSearchSerializer(serializers.Serializer):
 
     resource = AbstractResourceSerializer()
     reg_text = IndexedRegulationTextSerializer()
+
+
+class ContentCountSerializer(serializers.Serializer):
+    internal_resource_count = serializers.IntegerField()
+    public_resource_count = serializers.IntegerField()
+    regulation_text_count = serializers.IntegerField()

--- a/solution/backend/content_search/tests/test_search.py
+++ b/solution/backend/content_search/tests/test_search.py
@@ -92,36 +92,26 @@ class SearchTest(TestCase):
 
     def test_counts_logged_in(self):
         self.login()
-        response = self.client.get("/v3/content-search/?q=test")
-        data = get_paginated_data(response)
-        self.assertEqual(len(data["results"]), 3)
-        self.assertIn("count", data)
-        self.assertIn("internal_count", data)
-        self.assertIn("public_count", data)
-        self.assertEqual(data["internal_count"], 1)
-        self.assertEqual(data["public_count"], 2)
+        data = self.client.get("/v3/content-search/counts?q=test").data
+        self.assertEqual(data["internal_resource_count"], 1)
+        self.assertEqual(data["public_resource_count"], 2)
+        data = self.client.get("/v3/content-search/?q=test").data
+        self.assertEqual(data["count"], 3)
 
     def test_counts_logged_out(self):
-        response = self.client.get("/v3/content-search/?q=test")
-        data = get_paginated_data(response)
-        self.assertEqual(len(data["results"]), 2)
-        self.assertIn("count", data)
-        self.assertIn("internal_count", data)
-        self.assertIn("public_count", data)
-        self.assertEqual(data["internal_count"], 0)
-        self.assertEqual(data["public_count"], 2)
+        data = self.client.get("/v3/content-search/counts?q=test").data
+        self.assertEqual(data["internal_resource_count"], 0)
+        self.assertEqual(data["public_resource_count"], 2)
+        data = self.client.get("/v3/content-search/?q=test").data
+        self.assertEqual(data["count"], 2)
 
     def test_reg_text_count(self):
-        response = self.client.get("/v3/content-search/?q=federal")
-        data = get_paginated_data(response)
-        self.assertEqual(len(data["results"]), 3)
-        self.assertIn("count", data)
-        self.assertIn("internal_count", data)
-        self.assertIn("public_count", data)
-        self.assertIn("reg_text_count", data)
-        self.assertEqual(data["internal_count"], 0)
-        self.assertEqual(data["public_count"], 1)
-        self.assertEqual(data["reg_text_count"], 2)
+        data = self.client.get("/v3/content-search/counts?q=federal").data
+        self.assertEqual(data["internal_resource_count"], 0)
+        self.assertEqual(data["public_resource_count"], 1)
+        self.assertEqual(data["regulation_text_count"], 2)
+        data = self.client.get("/v3/content-search/?q=federal").data
+        self.assertEqual(data["count"], 3)
 
     def test_no_query_not_logged_in(self):
         response = self.client.get("/v3/content-search?show_internal=true&show_regulations=false")

--- a/solution/backend/content_search/urls.py
+++ b/solution/backend/content_search/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
     path("", ContentSearchViewSet.as_view({
         "get": "list",
     })),
-    path("count", ContentCountViewSet.as_view({
+    path("counts", ContentCountViewSet.as_view({
         "get": "list",
     }), name="content_count"),
 ]

--- a/solution/backend/content_search/urls.py
+++ b/solution/backend/content_search/urls.py
@@ -1,9 +1,12 @@
 from django.urls import path
 
-from .views import ContentSearchViewSet
+from .views import ContentCountViewSet, ContentSearchViewSet
 
 urlpatterns = [
     path("", ContentSearchViewSet.as_view({
         "get": "list",
     })),
+    path("count", ContentCountViewSet.as_view({
+        "get": "list",
+    }), name="content_count"),
 ]

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -71,7 +71,8 @@ class ContentSearchPagination(ViewSetPagination):
             required=False,
             type=str,
             description="Show ('true') or hide ('false') internal resources, including files and internal links. "
-                        "Default is true.",
+                        "Default is true. Note that internal resources are only shown if the user is authenticated. "
+                        "If the user is not authenticated, this flag will have no effect.",
             location=OpenApiParameter.QUERY,
         ),
         OpenApiParameter(

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -26,6 +26,16 @@ class ContentSearchPagination(ViewSetPagination):
             "count_url": ContentCountViewSet.generate_url(self.request),
         }}
 
+    def get_additional_attribute_schemas(self):
+        return {**super().get_additional_attribute_schemas(), **{
+            "count_url": {
+                "type": "string",
+                "format": "uri",
+                "nullable": True,
+                "example": "http://api.example.org/content_count/?q=example",
+            },
+        }}
+
 
 @extend_schema(
     tags=["content_search"],

--- a/solution/backend/resources/tests/test_resources_endpoints.py
+++ b/solution/backend/resources/tests/test_resources_endpoints.py
@@ -47,24 +47,20 @@ class TestResourcesEndpoint(TestCase):
 
     def test_counts_logged_in(self):
         self.login()
-        response = self.client.get("/v3/resources/?group_resources=false")
-        data = get_paginated_data(response)
-        self.assertEqual(len(data["results"]), 3)
-        self.assertIn("count", data)
-        self.assertIn("internal_count", data)
-        self.assertIn("public_count", data)
-        self.assertEqual(data["internal_count"], 1)
-        self.assertEqual(data["public_count"], 2)
+        data = self.client.get("/v3/resources/?group_resources=false").data
+        self.assertEqual(data["count"], 3)
+        self.assertIn("count_url", data)
+        data = self.client.get(data["count_url"]).data
+        self.assertEqual(data["internal_resource_count"], 1)
+        self.assertEqual(data["public_resource_count"], 2)
 
     def test_counts_logged_out(self):
-        response = self.client.get("/v3/resources/?group_resources=false")
-        data = get_paginated_data(response)
-        self.assertEqual(len(data["results"]), 2)
-        self.assertIn("count", data)
-        self.assertIn("internal_count", data)
-        self.assertIn("public_count", data)
-        self.assertEqual(data["internal_count"], 0)
-        self.assertEqual(data["public_count"], 2)
+        data = self.client.get("/v3/resources/?group_resources=false").data
+        self.assertEqual(data["count"], 2)
+        self.assertIn("count_url", data)
+        data = self.client.get(data["count_url"]).data
+        self.assertEqual(data["internal_resource_count"], 0)
+        self.assertEqual(data["public_resource_count"], 2)
 
     def test_duplicate_groups(self):
         # If groups are duplicated, then len(response.data) will be greater than 1

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -47,14 +47,14 @@ logger = logging.getLogger(__name__)
 
 
 class ResourceCountPagination(ViewSetPagination):
-    def get_count_map(self):
-        prefix = "" if self.view.model == AbstractResource else "abstractresource_ptr__"
-        internal_filter = Q(**{f"{prefix}abstractinternalresource__isnull": False})
-        public_filter = Q(**{f"{prefix}abstractpublicresource__isnull": False})
-        return [
-            {"name": "internal_count", "count_field": "pk", "filter": internal_filter},
-            {"name": "public_count", "count_field": "pk", "filter": public_filter},
-        ]
+    def get_additional_attributes(self):
+        try:
+            from content_search.views import ContentCountViewSet
+            return {**super().get_additional_attributes(), **{
+                "count_url": ContentCountViewSet.generate_url(self.request),
+            }}
+        except ImportError:
+            return super().get_additional_attributes()
 
 
 RESOURCE_ENDPOINT_PARAMETERS = [

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -56,6 +56,16 @@ class ResourceCountPagination(ViewSetPagination):
         except ImportError:
             return super().get_additional_attributes()
 
+    def get_additional_attribute_schemas(self):
+        return {**super().get_additional_attribute_schemas(), **{
+            "count_url": {
+                "type": "string",
+                "format": "uri",
+                "nullable": True,
+                "example": "http://api.example.org/content_count/?q=example",
+            },
+        }}
+
 
 RESOURCE_ENDPOINT_PARAMETERS = [
     CITATION_FILTER_PARAMETER,

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -57,14 +57,18 @@ class ResourceCountPagination(ViewSetPagination):
             return super().get_additional_attributes()
 
     def get_additional_attribute_schemas(self):
-        return {**super().get_additional_attribute_schemas(), **{
-            "count_url": {
-                "type": "string",
-                "format": "uri",
-                "nullable": True,
-                "example": "http://api.example.org/content_count/?q=example",
-            },
-        }}
+        try:
+            from content_search.views import ContentCountViewSet  # noqa
+            return {**super().get_additional_attribute_schemas(), **{
+                "count_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "nullable": True,
+                    "example": "http://api.example.org/content_count/?q=example",
+                },
+            }}
+        except ImportError:
+            return super().get_additional_attribute_schemas()
 
 
 RESOURCE_ENDPOINT_PARAMETERS = [


### PR DESCRIPTION
Resolves #2850

**Description-**

Counts were not properly displayed when one of the show_* flags was passed to the content-search endpoint, or from the subjects page if internal or public were unselected. This is because all filtering was done first before counting. To solve this problem (and reduce endpoint overhead), we decided to move counting to a separate endpoint dedicated to only this task (`/v3/content-search/counts`).

**This pull request changes...**

- New pagination function removed (`get_additional_attributes()` is retained).
- New endpoint `/v3/content-search/counts` exists and returns counts of public, internal, and reg text for given filters.
- Endpoint is linked to from the pagination header of the `/v3/content-search` and `/v3/resources` endpoints via `count_url`.
    - For `/v3/resources`, this is done in a way that avoids a permanent dependency (by catching `ImportError` if `ContentCountViewSet` does not exist).
- Tests reflect that total count must equal all combined counts.
- Updated OpenAPI schema for pagination to reflect `count_url` parameter.

**Steps to manually verify this change...**

1. Visit `/v3/content-search` and apply several filters (for example `?q=test`, `?q=test&citations=42.433.10`, `?q=test&show_public=false`).
2. Note the existence of `count_url` and visit that URL to see the broken down counts for each test search. Ensure that this is an accurate cont.
3. Do steps 1-2 for `/v3/resources`, omitting the `?q=test` parameter.

