### PR TITLE
EREGCSC-2774 Fix for branch access shouldn't enable internal access

### DIFF
--- a/solution/backend/cmcs_regulations/settings/base.py
+++ b/solution/backend/cmcs_regulations/settings/base.py
@@ -83,6 +83,9 @@ REST_FRAMEWORK = {
         'rest_framework.parsers.JSONParser',
     ),
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+    ],
 }
 
 TEMPLATE_CONTEXT_PROCESSORS = (

--- a/solution/backend/resources/views/categories.py
+++ b/solution/backend/resources/views/categories.py
@@ -1,7 +1,6 @@
 from django.db.models import Prefetch
 from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 
 from cmcs_regulations.utils import ViewSetPagination
@@ -44,7 +43,6 @@ class PublicCategoryViewSet(viewsets.ReadOnlyModelViewSet):
 )
 class InternalCategoryViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = ViewSetPagination
-    authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]
     serializer_class = InternalCategoryWithSubCategoriesSerializer
     queryset = InternalCategory.objects.all().prefetch_related(

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -6,7 +6,6 @@ from django.http import JsonResponse
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 
 from cmcs_regulations.utils import ViewSetPagination
@@ -253,7 +252,6 @@ class FederalRegisterLinkViewSet(PublicResourceViewSet):
 
 class InternalResourceViewSet(ResourceViewSet):
     model = AbstractInternalResource
-    authentication_classes = [SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     @extend_schema(


### PR DESCRIPTION
Resolves #2774

**Description-**

Django Rest Framework, by default, allows authentication by Session Auth and Basic Auth. This conflicts with our experimental branch protection, unintentionally authorizing every API request as if a user were logged in. 

**This pull request changes...**

- Set DRF's `DEFAULT_AUTHENTICATION_CLASSES` to only use SessionAuthentication.
- Ensure places where basic (or other auth schemes) are needed have it set manually.

**Steps to manually verify this change...**

1. In the experimental deploy, ensure you are logged out of the admin panel.
2. Visit search/subjects page and make sure no internal resources show up.
3. For extra validation, go to `/v3/content-search/counts` and make sure `internal_resource_count` is set to zero.
4. Log in to the admin panel and refresh the above endpoint to verify the number is no longer zero.

