### PR TITLE
EREGCSC-2805 Update SecurityHub Jira sync

### DIFF
--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -5,6 +5,7 @@ on:
     - cron: "25 1 * * *" # daily at 6:25 am EST
 permissions:
   id-token: write
+  contents: read
 jobs:
   sync:
     strategy:
@@ -25,7 +26,7 @@ jobs:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
       - name: Sync Security Hub and Jira
-        uses: Enterprise-CMCS/security-hub-visibility@v1.0.5
+        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v2.0.9
         with:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-username: noVal # required variable for package but not for Enterprise Jira


### PR DESCRIPTION
Resolves #2805

**Description-**

This PR updates the SecurityHub JIRA sync action to the latest version.

**This pull request changes...**

- SecurityHub JIRA sync action is updated to the latest version.

**Steps to manually verify this change...**

1. Deploy to prod.
2. Cron is set to `cron: "25 1 * * *"`, so check GitHub's Actions tab the next day after 6:25am EST to verify that the action succeeds.

