### PR TITLE
EREGCSC-2805-B Remove jira-host setting

### DIFF
--- a/.github/workflows/schedule-jira-sync.yml
+++ b/.github/workflows/schedule-jira-sync.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-username: noVal # required variable for package but not for Enterprise Jira
-          jira-host: ${{secrets.JIRA_HOST}}
           jira-project-key: EREGCSC
           jira-ignore-statuses: Done, Closed, Canceled
           jira-custom-fields: '{ "customfield_10100": "EREGCSC-1989" }'


### PR DESCRIPTION
Resolves #2805

**Description-**

Update docs say: "You don't need to specify the Jira host if it's 'jiraent.cms.gov'. So you can remove this". Including this key causes an error message in the action, so better to remove it.

**This pull request changes...**

- Remove jira-host setting from jira sync github action

**Steps to manually verify this change...**

1. Deploy this to prod.
2. Wait until after 6:25am the following day.
3. Check the securityhub action and the action is successful with no errors.

