### PR TITLE
[Hotfix] Edit button not working on policy results

### DIFF
--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -245,7 +245,7 @@ const currentPageResultsRange = getCurrentPageResultsRange({
                 <a
                     v-if="hasEditableJobCode && doc.id"
                     class="edit-button"
-                    :href="`${apiUrl}resources/${doc.id}/edit'`"
+                    :href="`${apiUrl}resources/${doc.id}/edit`"
                 >
                     Edit
                     <i class="fas fa-edit"></i>


### PR DESCRIPTION
Resolves issue on `prod`

**Description**

When logged in as an admin, users have the ability to click an "Edit" button for any search result on the Subjects page.  This button will take the user directly to the admin panel and allow them to edit the document.

The edit button is not currently working on `prod`; the user is shown an error screen with a 404 error.

This error is being caused by a dangling and unnecessary apostrophe that is being erroneously added to the end of the Edit button's `href` attribute.

**This pull request changes:**

- Removes dangling apostrophe from Edit button link

**Steps to manually verify this change:**

1. Green check marks
2. Log in to experimental deployment with an admin account and visit Subjects page
3. Click Edit button and make sure it takes you to the admin panel for the expected document

