### PR TITLE
EREGCSC-2323 Add counts for subjects and categories to counts API

### DIFF
--- a/solution/backend/content_search/serializers.py
+++ b/solution/backend/content_search/serializers.py
@@ -23,7 +23,20 @@ class ContentSearchSerializer(serializers.Serializer):
     reg_text = IndexedRegulationTextSerializer()
 
 
+class SubjectCountSerializer(serializers.Serializer):
+    subject = serializers.IntegerField()
+    count = serializers.IntegerField()
+
+
+class CategoryCountSerializer(serializers.Serializer):
+    category = serializers.IntegerField()
+    count = serializers.IntegerField()
+
+
 class ContentCountSerializer(serializers.Serializer):
     internal_resource_count = serializers.IntegerField()
     public_resource_count = serializers.IntegerField()
     regulation_text_count = serializers.IntegerField()
+
+    subjects = SubjectCountSerializer(many=True)
+    categories = CategoryCountSerializer(many=True)

--- a/solution/backend/content_search/serializers.py
+++ b/solution/backend/content_search/serializers.py
@@ -30,6 +30,7 @@ class SubjectCountSerializer(serializers.Serializer):
 
 class CategoryCountSerializer(serializers.Serializer):
     category = serializers.IntegerField()
+    parent = serializers.IntegerField()
     count = serializers.IntegerField()
 
 

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -274,6 +274,7 @@ class ContentCountViewSet(viewsets.ViewSet):
             regulation_text_count=Count("reg_text"),
         )
 
+        # List of subjects that are in the results and the number of resources in the result set that are associated with them
         aggregates["subjects"] = AbstractResource.objects \
             .filter(index__pk__in=pks) \
             .exclude(subjects__isnull=True) \
@@ -282,6 +283,8 @@ class ContentCountViewSet(viewsets.ViewSet):
             .values("subject", "count") \
             .order_by("-count", "subject")
 
+        # List of categories that are in the results and the number of resources in the result set that are associated with them
+        # Note that resources are already filtered by user visibility, so by extension, we don't need to filter categories
         aggregates["categories"] = AbstractResource.objects \
             .filter(index__pk__in=pks) \
             .exclude(category__isnull=True) \

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -289,7 +289,7 @@ class ContentCountViewSet(viewsets.ViewSet):
             .filter(index__pk__in=pks) \
             .exclude(category__isnull=True) \
             .values("category") \
-            .annotate(count=Count("category")) \
+            .annotate(parent=F("category__parent"), count=Count("category")) \
             .order_by("-count", "category")
 
         # Serialize and return the results

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -182,7 +182,10 @@ class ContentSearchViewSet(viewsets.ReadOnlyModelViewSet):
     description="Retrieve the number of results for a given set of filters. "
                 "This endpoint allows you to get the number of results per type (public, internal, reg-text) "
                 "without retrieving the actual content. Useful for pagination and displaying the number of results. "
-                "Note that internal resources are only counted if the user is authenticated.",
+                "Note that internal resources are only counted if the user is authenticated. "
+                "This endpoint also displays the number of resources found within each subject and category that have results. "
+                "Subjects and categories are listed only by PK. To retrieve more metadata about these types, use the subjects "
+                "and categories endpoints available within the Resources app.",
     responses={200: ContentCountSerializer},
     parameters=[
         OpenApiParameter(


### PR DESCRIPTION
Resolves #2323

**Description-**

To enable subject and category dropdowns to display accurate counts, we need the count API (`/v3/content-search/counts`) to display a list of relevant subjects and categories (filtered by search results) and the number of relevant resources associated with them.

**This pull request changes...**

- Count API displays `subjects` list: an array of dicts containing the subject PK and the count of resources within the search result set associated with that subject.
- Count API displays `categories` list: an array of dicts containing the category PK, the category's parent's PK (if applicable, or null), and the count of resources within the search result set associated with that category.

**Steps to manually verify this change...**

1. Head to `/v3/content-search/counts` and verify that `subjects` and `categories` are present, the results look sane, and the page loads relatively fast.
2. Add some filters: try adding `?q={your search term}`, `?citations={title}.{part}.{section}`, `?subjects={pk}`, `?categories={pk}`, etc. Make sure results are sane with no errors.
3. Verify unit tests pass.

