### PR TITLE
[hotfix] Remove parser 'npm install' for remove actions

### DIFF
--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -46,7 +46,6 @@ jobs:
         run: |
           pushd solution/parser
           npm install serverless@">=3.38.0 <4" -g
-          npm install
           chmod +x ~/work/cmcs-eregulations/cmcs-eregulations/.github/workflows/delete_cloudformation_stacks.sh 
           ~/work/cmcs-eregulations/cmcs-eregulations/.github/workflows/delete_cloudformation_stacks.sh cmcs-eregs-parser-dev${PR} $PR "./serverless-ecfr.yml"
           ~/work/cmcs-eregulations/cmcs-eregulations/.github/workflows/delete_cloudformation_stacks.sh cmcs-eregs-fr-parser-dev${PR} $PR "./serverless-fr.yml"

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -44,6 +44,5 @@ jobs:
         run: |
           pushd serverless
           npm install serverless@">=3.38.0 <4" -g
-          npm install
           serverless remove --config ./serverless-parser.yml
           popd


### PR DESCRIPTION
Resolves #n/a

**Description-**

`solution/parser` no longer contains package.json because `serverless-go-plugin` was removed. We removed `npm install` for the deploy actions but forgot to remove it for the remove actions, causing remove to fail.

**This pull request changes...**

- Remove `npm install` under the parser section of the remove GitHub actions.

**Steps to manually verify this change...**

1. Deploy this to prod and verify that the remove action passes.
2. Try to fix previous failures: merge main into the failing PR branches and re-run the remove action.

