### PR TITLE
EREGCSC-2812 -- Condense related citations on items

### DIFF
--- a/solution/ui/e2e/cypress/support/common-commands/policyDocs.js
+++ b/solution/ui/e2e/cypress/support/common-commands/policyDocs.js
@@ -1,4 +1,7 @@
 export const checkPolicyDocs = ({ username, password, landingPage }) => {
+    cy.intercept("**/v3/title/42/parts", {
+        fixture: "parts-last-updated.json",
+    }).as("partsLastUpdated");
     cy.intercept("**/v3/content-search/?q=mock**", {
         fixture: "policy-docs-search.json",
     }).as("queriedFiles");
@@ -18,16 +21,16 @@ export const checkPolicyDocs = ({ username, password, landingPage }) => {
     cy.get("input#main-content")
         .should("be.visible")
         .type("mock", { force: true });
-        cy.get('[data-testid="search-form-submit"]').click({
-            force: true,
-        });
+    cy.get('[data-testid="search-form-submit"]').click({
+        force: true,
+    });
 
     cy.wait("@queriedFiles");
 
-    // Internal doc
+    //----- Internal doc
     cy.get('[data-testid="results-item-categories"] .doc-type__label')
         .first()
-        .should("include.text", " Internal")
+        .should("include.text", " Internal");
 
     cy.get('[data-testid="results-item-categories"] i')
         .first()
@@ -37,10 +40,59 @@ export const checkPolicyDocs = ({ username, password, landingPage }) => {
         .first()
         .should("include.text", "TestCat");
 
-    // Regulations Doc
+    // should have show related citations button 3541
+    cy.get(".doc-list__document")
+        .first()
+        .find(".related-citations__btn--collapse")
+        .should("include.text", "Show Related Citations");
+
+    // related citations should be hidden by default
+    cy.get(".doc-list__document")
+        .first()
+        .find(".collapse-content")
+        .should("have.class", "invisible")
+        .and("not.be.visible");
+
+    // clicking the show related citations button should expand the related citations
+    cy.get(".doc-list__document")
+        .first()
+        .find(".related-citations__btn--collapse")
+        .click();
+
+    cy.get(".doc-list__document")
+        .first()
+        .find(".related-citations__btn--collapse")
+        .should("include.text", "Hide Related Citations");
+
+    cy.get(".doc-list__document")
+        .first()
+        .find(".collapse-content")
+        .should("not.have.class", "invisible")
+        .and("be.visible")
+        .find(".related-sections")
+        .should("include.text", "Regulations: 42 CFR § 440.130")
+
+    // clicking the hide related citations button should collapse the related citations
+    cy.get(".doc-list__document")
+        .first()
+        .find(".related-citations__btn--collapse")
+        .click();
+
+    cy.get(".doc-list__document")
+        .first()
+        .find(".related-citations__btn--collapse")
+        .should("include.text", "Show Related Citations");
+
+    cy.get(".doc-list__document")
+        .first()
+        .find(".collapse-content")
+        .should("have.class", "invisible")
+        .and("not.be.visible");
+
+    //----- Regulations Doc
     cy.get('[data-testid="results-item-categories"] .doc-type__label')
         .eq(1)
-        .should("include.text", "Public")
+        .should("include.text", "Public");
 
     cy.get('[data-testid="results-item-categories"] i')
         .eq(1)
@@ -50,7 +102,13 @@ export const checkPolicyDocs = ({ username, password, landingPage }) => {
         .eq(1)
         .should("include.text", "Regulations");
 
-    // Public doc
+    // should NOT have show/hide related citations button
+    cy.get(".doc-list__document")
+        .eq(1)
+        .find(".related-citations__btn--collapse")
+        .should("not.exist");
+
+    //----- Public doc
     cy.get('[data-testid="results-item-categories"] .doc-type__label')
         .eq(2)
         .should("include.text", " Public");
@@ -67,6 +125,12 @@ export const checkPolicyDocs = ({ username, password, landingPage }) => {
         .eq(1)
         .should("include.text", "State Medicaid Director Letter (SMDL)");
 
+    // should have show/hide related citations button 2057
+    cy.get(".doc-list__document")
+        .eq(2)
+        .find(".related-citations__btn--collapse")
+        .should("include.text", "Show Related Citations");
+
     // FR Doc
     cy.get('[data-testid="results-item-categories"] .doc-type__label')
         .eq(3)
@@ -79,4 +143,10 @@ export const checkPolicyDocs = ({ username, password, landingPage }) => {
     cy.get('[data-testid="results-item-categories"] .category-label')
         .eq(2)
         .should("include.text", "Proposed and Final Rules");
+
+    // should have show/hide related citations button 2302
+    cy.get(".doc-list__document")
+        .eq(3)
+        .find(".related-citations__btn--collapse")
+        .should("include.text", "Show Related Citations");
 };

--- a/solution/ui/regulations/css/scss/partials/_results_item.scss
+++ b/solution/ui/regulations/css/scss/partials/_results_item.scss
@@ -112,6 +112,13 @@
     .search-highlight {
         font-weight: bold;
     }
+
+    .collapsible-title {
+        font-size: $font-size-sm;
+        font-weight: 400;
+        width: auto;
+    }
+
 }
 
 .related-sections {

--- a/solution/ui/regulations/css/scss/partials/_results_item.scss
+++ b/solution/ui/regulations/css/scss/partials/_results_item.scss
@@ -118,6 +118,7 @@
         line-height: 22px;
         font-weight: 400;
         width: auto;
+        margin-top: var(--spacer-2);
 
         &.visible {
             color: $primary_link_color;

--- a/solution/ui/regulations/css/scss/partials/_results_item.scss
+++ b/solution/ui/regulations/css/scss/partials/_results_item.scss
@@ -115,10 +115,19 @@
 
     .collapsible-title {
         font-size: $font-size-sm;
+        line-height: 22px;
         font-weight: 400;
         width: auto;
-    }
 
+        &.visible {
+            color: $primary_link_color;
+        }
+
+        i {
+            font-size: $font-size-xs;
+            margin: auto 0 auto var(--spacer-1);
+        }
+    }
 }
 
 .related-sections {

--- a/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
+++ b/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
@@ -170,17 +170,17 @@
 
 .supplemental-content-container
     .supplemental-content-category
-    .category-content:not(.show-more-content),
+    .collapse-content:not(.show-more-content),
 .internal-docs__container
     .supplemental-content-category
-    .category-content:not(.show-more-content) {
+    .collapse-content:not(.show-more-content) {
     margin-left: 10px;
     margin-right: 20px;
 }
 
 .supplemental-content-container
     .supplemental-content-category
-    .category-content.additional-rules {
+    .collapse-content.additional-rules {
     margin: inherit;
 }
 
@@ -203,12 +203,12 @@
         display: table-cell;
     }
 
-    .category-content {
+    .collapse-content {
         margin-top: 1em;
     }
 }
 
-.category-content {
+.collapse-content {
     &.additional-rules .related-rule:first-child {
         padding: 0;
     }

--- a/solution/ui/regulations/eregs-component-lib/src/components/CollapseButton.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/CollapseButton.vue
@@ -23,7 +23,7 @@ export default {
     name: "CollapseButton",
 
     inject: {
-        getStateOverride: { default: null, },
+        getStateOverride: { default: null },
     },
 
     props: {
@@ -36,7 +36,7 @@ export default {
             type: String,
             required: true,
         },
-        "keep-contents-on-toggle": {
+        keepContentsOnToggle: {
             type: Boolean,
             required: false,
             default: false,
@@ -73,7 +73,7 @@ export default {
         eventbus.on("collapse-toggle", this.toggle);
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
         eventbus.off("collapse-toggle", this.toggle);
     },
 

--- a/solution/ui/regulations/eregs-component-lib/src/components/Collapsible.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/Collapsible.vue
@@ -1,9 +1,9 @@
 <template>
     <div
         ref="target"
-        v-bind:data-test="dataName"
-        v-bind:class="{ invisible: !visible }"
-        v-bind:style="[styles]"
+        :data-test="dataName"
+        :class="{ invisible: !visible }"
+        :style="[styles]"
     >
         <slot></slot>
     </div>
@@ -13,7 +13,7 @@
 import eventbus from "../eventbus";
 
 export default {
-    name: "collapsible",
+    name: "Collapsible",
 
     created: function () {
         requestAnimationFrame(() => {
@@ -30,7 +30,7 @@ export default {
         window.addEventListener("transitionend", this.toggleDisplay);
     },
 
-    destroyed: function () {
+    unmounted: function () {
         window.removeEventListener("resize", this.resize);
         window.removeEventListener("transitionend", this.toggleDisplay);
     },
@@ -70,10 +70,10 @@ export default {
     },
 
     methods: {
-        resize: function (e) {
+        resize: function () {
             this.computeHeight();
         },
-        toggleDisplay: function (e) {
+        toggleDisplay: function () {
             if (this.visible) {
                 this.$refs.target.style.height = "auto";
                 if (this.state === "collapsed" && this.overflow) {

--- a/solution/ui/regulations/eregs-component-lib/src/components/RelatedRuleList.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/RelatedRuleList.vue
@@ -47,7 +47,7 @@
         <collapsible
             :name="innerName"
             state="collapsed"
-            class="category-content additional-rules"
+            class="collapse-content additional-rules"
             overflow
         >
             <template v-for="(rule, i) in additionalRules" :key="i">

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContent.vue
@@ -168,10 +168,10 @@ export default {
         });
         this.categories = getDefaultCategories();
     },
-    beforeDestroy() {
+    beforeUnmount() {
         eventbus.off(EventCodes.SetSection);
     },
-    destroyed() {
+    unmounted() {
         window.removeEventListener("hashchange", this.handleHashChange);
     },
 

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentCategory.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentCategory.vue
@@ -36,7 +36,7 @@
             <collapsible
                 :name="name"
                 state="collapsed"
-                class="category-content"
+                class="collapse-content"
                 overflow
             >
                 <supplemental-content-category

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentList.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentList.vue
@@ -36,7 +36,7 @@
         <collapsible
             :name="innerName"
             state="collapsed"
-            class="category-content show-more-content"
+            class="collapse-content show-more-content"
         >
             <supplemental-content-object
                 v-for="(content, index) in additionalContent"

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/RelatedSections.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/RelatedSections.vue
@@ -63,8 +63,8 @@ const groupedLocations = _groupBy(filteredLocations, "title");
                     </span>
                 </template>
                 <span
-                    :key="i + title + i"
                     v-if="i + 1 != Object.keys(groupedLocations).length"
+                    :key="i + title + i"
                     class="pipe-separator"
                 >
                     |

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/RelatedSections.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/results-item-parts/RelatedSections.vue
@@ -35,9 +35,7 @@ const groupedLocations = _groupBy(filteredLocations, "title");
 
 <template>
     <div class="related-sections">
-        <span class="related-sections-title">
-            {{ label }}<span v-if="locationsCount !== 1">s</span>:
-        </span>
+        <span class="related-sections-title"> {{ label }}: </span>
         <template v-if="locationsCount > 0">
             <template
                 v-for="(locations, title, i) in groupedLocations"

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.test.js
@@ -352,23 +352,23 @@ describe("showResultSnippet", () => {
 
 describe("getCollapseName", () => {
     const doc1 = {
-        node_id: "doc1",
-        id: "doc1",
-    };
-
-    const doc2 = {
-        node_id: "doc2",
+        node_id: "doc1-node_id",
+        id: "doc1-id",
     };
 
     it("returns the id if id exists", async () => {
         expect(PolicyResults.getCollapseName(doc1)).toBe(
-            "related citations collapsible doc1"
+            "related citations collapsible doc1-id"
         );
     });
 
+    const doc2 = {
+        node_id: "doc2-node_id",
+    };
+
     it("returns the node_id if no id", async () => {
         expect(PolicyResults.getCollapseName(doc2)).toBe(
-            "related citations collapsible doc2"
+            "related citations collapsible doc2-node_id"
         );
     });
 });

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.test.js
@@ -44,8 +44,7 @@ const MOCK_RESULTS = [
             document_id: "",
             title: "",
             date: "2021-06-28",
-            url:
-                "https://innovation.cms.gov/data-and-reports/2021/sim-rd2-test-final-appendix",
+            url: "https://innovation.cms.gov/data-and-reports/2021/sim-rd2-test-final-appendix",
             related_resources: null,
         },
         reg_text: null,
@@ -64,8 +63,7 @@ const MOCK_RESULTS = [
             document_id: "",
             title: "",
             date: "2021-06-28",
-            url:
-                "https://innovation.cms.gov/data-and-reports/2021/sim-rd2-test-final-appendix",
+            url: "https://innovation.cms.gov/data-and-reports/2021/sim-rd2-test-final-appendix",
             related_resources: null,
         },
         reg_text: null,
@@ -349,5 +347,73 @@ describe("showResultSnippet", () => {
 
     it("/content-search external and does NOT have a content_headline", async () => {
         expect(PolicyResults.showResultSnippet(cs_external_2)).toBe(false);
+    });
+});
+
+describe("getCollapseName", () => {
+    const doc1 = {
+        node_id: "doc1",
+        id: "doc1",
+    };
+
+    const doc2 = {
+        node_id: "doc2",
+    };
+
+    it("returns the id if id exists", async () => {
+        expect(PolicyResults.getCollapseName(doc1)).toBe(
+            "related citations collapsible doc1"
+        );
+    });
+
+    it("returns the node_id if no id", async () => {
+        expect(PolicyResults.getCollapseName(doc2)).toBe(
+            "related citations collapsible doc2"
+        );
+    });
+});
+
+describe("hasRegulationCitations", () => {
+    const partsLastUpdated = {
+        438: "2024-07-09",
+    };
+
+    const doc1 = {
+        cfr_citations: [{ title: "42", part: "438" }],
+    };
+
+    it("returns true if the document has cfr_citations with an updated part", async () => {
+        expect(
+            PolicyResults.hasRegulationCitations({
+                doc: doc1,
+                partsLastUpdated,
+            })
+        ).toBe(true);
+    });
+
+    const doc2 = {
+        cfr_citations: [{ title: "42", part: "439" }],
+    };
+
+    it("returns false if the document has cfr_citations with an unknown part", async () => {
+        expect(
+            PolicyResults.hasRegulationCitations({
+                doc: doc2,
+                partsLastUpdated,
+            })
+        ).toBe(false);
+    });
+
+    const doc3 = {
+        cfr_citations: [],
+    };
+
+    it("returns false if the document has no cfr_citations", async () => {
+        expect(
+            PolicyResults.hasRegulationCitations({
+                doc: doc3,
+                partsLastUpdated,
+            })
+        ).toBe(false);
     });
 });

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -358,8 +358,14 @@ const currentPageResultsRange = getCurrentPageResultsRange({
                     state="collapsed"
                     class="related-citations__btn--collapse"
                 >
-                    <template #expanded>Hide Related Citations</template>
-                    <template #collapsed>Show Related Citations</template>
+                    <template #expanded
+                        >Hide Related Citations
+                        <i class="fa fa-chevron-up"></i>
+                    </template>
+                    <template #collapsed
+                        >Show Related Citations
+                        <i class="fa fa-chevron-down"></i>
+                    </template>
                 </CollapseButton>
                 <Collapsible
                     :name="getCollapseName(doc)"

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -13,6 +13,9 @@ import {
     DOCUMENT_TYPES_MAP,
 } from "utilities/utils";
 
+import CollapseButton from "eregsComponentLib/src/components/CollapseButton.vue";
+import Collapsible from "eregsComponentLib/src/components/Collapsible.vue";
+
 import CategoryLabel from "sharedComponents/results-item-parts/CategoryLabel.vue";
 import DivisionLabel from "sharedComponents/results-item-parts/DivisionLabel.vue";
 import DocTypeLabel from "sharedComponents/results-item-parts/DocTypeLabel.vue";
@@ -108,6 +111,19 @@ const getResultSnippet = (item) => {
 
 const partDocumentTitleLabel = (string) => string.toLowerCase();
 
+const getCollapseName = (doc) => `related-citations-${doc.node_id}`;
+
+const hasRegulationCitations = ({ doc, partsLastUpdated }) => {
+    const regCitations = doc.cfr_citations
+        ? doc.cfr_citations.filter((location) => {
+              const { part } = location;
+              return partsLastUpdated[part];
+          })
+        : [];
+
+    return regCitations.length > 0;
+};
+
 export default {
     addSurroundingEllipses,
     getParentCategoryName,
@@ -115,6 +131,8 @@ export default {
     getResultSnippet,
     partDocumentTitleLabel,
     showResultSnippet,
+    getCollapseName,
+    hasRegulationCitations,
 };
 </script>
 
@@ -331,13 +349,32 @@ const currentPageResultsRange = getCurrentPageResultsRange({
                 </div>
             </template>
             <template #sections>
-                <RelatedSections
-                    v-if="doc.type !== 'reg_text'"
-                    :base="homeUrl"
-                    :item="doc"
-                    :parts-last-updated="partsLastUpdated"
-                    label="Related Regulation Citation"
-                />
+                <CollapseButton
+                    v-if="
+                        doc.type !== 'reg_text' &&
+                        hasRegulationCitations({ doc, partsLastUpdated })
+                    "
+                    :name="getCollapseName(doc)"
+                    state="collapsed"
+                    class="related-citations__btn--collapse"
+                >
+                    <template #expanded>Hide Related Citations</template>
+                    <template #collapsed>Show Related Citations</template>
+                </CollapseButton>
+                <Collapsible
+                    :name="getCollapseName(doc)"
+                    state="collapsed"
+                    class="category-content"
+                    overflow
+                >
+                    <RelatedSections
+                        v-if="doc.type !== 'reg_text'"
+                        :base="homeUrl"
+                        :item="doc"
+                        :parts-last-updated="partsLastUpdated"
+                        label="Regulation"
+                    />
+                </Collapsible>
             </template>
         </ResultsItem>
     </div>

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -111,7 +111,8 @@ const getResultSnippet = (item) => {
 
 const partDocumentTitleLabel = (string) => string.toLowerCase();
 
-const getCollapseName = (doc) => `related-citations-${doc.node_id}`;
+const getCollapseName = (doc) =>
+    `related citations collapsible ${doc.id ?? doc.node_id}`;
 
 const hasRegulationCitations = ({ doc, partsLastUpdated }) => {
     const regCitations = doc.cfr_citations
@@ -378,7 +379,7 @@ const currentPageResultsRange = getCurrentPageResultsRange({
                         :base="homeUrl"
                         :item="doc"
                         :parts-last-updated="partsLastUpdated"
-                        label="Regulation"
+                        label="Regulations"
                     />
                 </Collapsible>
             </template>

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -371,7 +371,7 @@ const currentPageResultsRange = getCurrentPageResultsRange({
                 <Collapsible
                     :name="getCollapseName(doc)"
                     state="collapsed"
-                    class="category-content"
+                    class="collapse-content"
                     overflow
                 >
                     <RelatedSections


### PR DESCRIPTION
Resolves [EREGCSC-2812](https://jiraent.cms.gov/browse/EREGCSC-2812)

**Description**

The "Related Regulations" information for each search result item can get very long.  We want to hide this information until the user clicks a "Show Related Citations" button, which will reveal the list of related citations.  Clicking the button again will collapse and hide the list of related citations.

**This pull request changes:**

- Uses existing `CollapseButton.vue` and `Collapsible.vue` components to hide and show `RelatedRegulations.vue` component on the Search page and the Subjects page
- Uses ESLint autofix on `Collapsible`/`CollapseButton` components to fix various linting issues (these components are old!)
- Adds CSS style rules to match [Figma comp](https://www.figma.com/design/RT4uGuU9fI5AC6OXtnG50g/Citation-Display?node-id=5-12628&node-type=frame&m=dev)
- Adds Vitest unit tests and Cypress end to end tests

**Steps to manually verify this change:**

1. Green check marks
2. Visit `/search/` and `/subjects/` page on [experimental deployment](https://igni8k9vp1.execute-api.us-east-1.amazonaws.com/dev1446/)
3. Ensure that Related Citations list for each result item is hidden on load
4. Toggle "Show Related Citations" and "Hide Related Citations" button to ensure that list can be expanded and then hidden
5. Ensure that `reg_text` result items do not have a Show/Hide button
6. Ensure that any internal or public document that does not have any related citations does not have a Show/Hide button

