### PR TITLE
EREGCSC-2865 -- Remove old video link from "about" page

### DIFF
--- a/solution/backend/regulations/templates/regulations/about.html
+++ b/solution/backend/regulations/templates/regulations/about.html
@@ -18,20 +18,6 @@
                 guidance, and other related policy materials. Our team updates
                 content and functionality several times a week.
             </p>
-            <p>
-                All documents on this site are publicly available and compiled
-                from other sources.
-            </p>
-            <p>
-                <a
-                    href="https://www.youtube.com/watch?v=dqy8WCFedU4"
-                    class="external"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                >
-                    View a 6-minute video demonstration.
-                </a>
-            </p>
         </section>
 
         <section>
@@ -105,13 +91,6 @@
                                 >not official legal editions</a
                             >
                             of the CFR.
-                            <a
-                                href="https://www.ecfr.gov/cgi-bin/ECFR?page=userinfo"
-                                class="external"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                >Learn more.</a
-                            >
                         </p>
                     </div>
                     <div class="ds-l-col--6">
@@ -202,6 +181,10 @@
                                 >New &amp; Notable Resource Center</a
                             >, we add a link to display in the sidebar of each
                             relevant section and subpart.
+                        </p>
+                        <p>
+                            CMCS staff may also add internal documents useful for 
+                            policy research, only visible to logged-in staff.
                         </p>
                     </div>
                     <div class="ds-l-col--6">


### PR DESCRIPTION
Resolves [EREGCSC-2865](https://jiraent.cms.gov/browse/EREGCSC-2865)

**Description-**

We updated our homepage demo video link at #1445, but I just noticed we have a link on the "about" page as well. Since this fix would take probably longer to describe in a Jira story than implement, I went ahead and did it.

This change only impacts the "about" page. It:

- Removes the redundant video link
- Fixes other outdated info on the about page

**Steps to manually verify this change...**

1. Visit the "about" page on the experimental branch
2. It should no longer say "View a 6-minute video demonstration."
3. Nothing should be broken
