### PR TITLE
EREGCSC-2685 -- Move subject page search box to filter region

### DIFF
--- a/solution/ui/e2e/cypress/e2e/search.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/search.spec.cy.js
@@ -87,7 +87,7 @@ describe("Search flow", () => {
         cy.viewport("macbook-15");
         cy.visit(`/search`, { timeout: 60000 });
         cy.get("input#main-content")
-            .should("be.visible")
+            .should("exist")
             .type("test search", { force: true });
         cy.get('[data-testid="search-form-submit"]').click({
             force: true,
@@ -106,7 +106,7 @@ describe("Search flow", () => {
         });
 
         cy.get("input#main-content")
-            .should("be.visible")
+            .should("exist")
             .type("test", { force: true });
 
         cy.findByDisplayValue("test")
@@ -148,7 +148,7 @@ describe("Search flow", () => {
         });
 
         cy.get("input#main-content")
-            .should("be.visible")
+            .should("exist")
             .type(`${SEARCH_TERM_2}`, { force: true });
         cy.get('[data-testid="search-form-submit"]').click({
             force: true,
@@ -184,7 +184,7 @@ describe("Search flow", () => {
         });
 
         cy.get("input#main-content")
-            .should("be.visible")
+            .should("exist")
             .type(`${SEARCH_TERM}`, { force: true });
         cy.get('[data-testid="search-form-submit"]').click({
             force: true,

--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -216,6 +216,46 @@ describe("Find by Subjects", () => {
             .and("include", "subjects=3");
     });
 
+    it("clearing the search input should not reload the page", () => {
+        cy.viewport("macbook-15");
+        cy.eregsLogin({ username, password });
+        cy.visit("/subjects");
+
+        // select subject
+        cy.get(
+            ".subj-toc__list li[data-testid=subject-toc-li-3] a",
+        ).scrollIntoView();
+        cy.get(".subj-toc__list li[data-testid=subject-toc-li-3] a")
+            .should("have.text", "Access to Services")
+            .click({ force: true });
+
+        // select category
+        cy.get("div[data-testid='category-select']").click();
+        cy.get("div[data-testid='external-0']").click({ force: true });
+
+        cy.url().should(
+            "include",
+            "/subjects?subjects=3&categories=1&type=external",
+        );
+
+        cy.get("input#main-content").invoke("val").should("eq", "");
+
+        cy.get("input#main-content").type("mock", { force: true });
+
+        cy.get("input#main-content").invoke("val").should("eq", "mock");
+
+        cy.get(".search-field")
+            .find(".v-field__clearable i")
+            .click({ force: true });
+
+        cy.get("input#main-content").invoke("val").should("eq", "");
+
+        cy.url().should(
+            "include",
+            "/subjects?subjects=3&categories=1&type=external",
+        );
+    });
+
     it("should display the appropriate results column header when viewing the items within a subject.", () => {
         cy.intercept("**/v3/resources/?&page_size=50&group_resources=false", {
             fixture: "policy-docs-subjects.json",

--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -58,12 +58,12 @@ const _beforePaginate = () => {
 };
 
 Cypress.Commands.add("getPolicyDocs", ({ username, password }) => {
-    cy.intercept("**/v3/content-search/?q=mock**", {
+    cy.intercept("**/v3/resources/?subjects=3**", {
         fixture: "policy-docs-search.json",
     }).as("subjectFiles");
     cy.viewport("macbook-15");
     cy.eregsLogin({ username, password, landingPage: "/subjects/" });
-    cy.visit("/subjects/?q=mock");
+    cy.visit("/subjects/?subjects=3");
     cy.injectAxe();
     cy.wait("@subjectFiles").then((interception) => {
         expect(interception.response.statusCode).to.eq(200);
@@ -249,7 +249,7 @@ describe("Find by Subjects", () => {
         );
     });
 
-    it("loads the correct subject and search query when the URL is changed", () => {
+    it("loads the correct subject when the URL is changed", () => {
         cy.viewport("macbook-15");
         cy.eregsLogin({
             username,
@@ -302,20 +302,6 @@ describe("Find by Subjects", () => {
         cy.go("back");
         cy.url().should("include", "/subjects?subjects=2");
         cy.get(`button[data-testid=remove-subject-3]`).should("not.exist");
-
-        cy.get("input#main-content")
-            .should("be.visible")
-            .type("test", { force: true });
-        cy.get('[data-testid="search-form-submit"]').click({
-            force: true,
-        });
-        cy.url().should("include", "/subjects?subjects=2");
-
-        cy.get(`button[data-testid=remove-subject-2]`).click({
-            force: true,
-        });
-        cy.get(`button[data-testid=remove-subject-2]`).should("not.exist");
-        cy.url().should("include", "/subjects");
     });
 
     it("should display and fetch the correct subjects on load if they are included in URL", () => {
@@ -391,16 +377,6 @@ describe("Find by Subjects", () => {
             force: true,
         });
         cy.url().should("include", "/subjects?subjects=3");
-        cy.get("input#main-content")
-            .should("be.visible")
-            .type("test search", { force: true });
-        cy.get('[data-testid="search-form-submit"]').click({
-            force: true,
-        });
-        cy.url().should("include", "/subjects?subjects=3&q=test+search");
-        cy.get(".search-form .form-helper-text .search-suggestion").should(
-            "not.exist",
-        );
         cy.get(".document__subjects a").eq(0).should("have.text", "FMAP");
         cy.get(".document__subjects a")
             .eq(1)
@@ -413,7 +389,6 @@ describe("Find by Subjects", () => {
             force: true,
         });
         cy.url().should("include", "/subjects?subjects=167&type=all");
-        cy.get("input#main-content").should("have.value", "");
     });
 
     it("should display correct subject ID number in the URL if one is included in the URL on load and different one is selected via the Subject Selector", () => {
@@ -773,7 +748,7 @@ describe("Find by Subjects", () => {
 
         // Add text query and submit
         cy.get("input#main-content")
-            .should("be.visible")
+            .should("exist")
             .type("test", { force: true });
         cy.get('[data-testid="search-form-submit"]').click({
             force: true,

--- a/solution/ui/e2e/cypress/support/common-commands/policyDocs.js
+++ b/solution/ui/e2e/cypress/support/common-commands/policyDocs.js
@@ -19,7 +19,7 @@ export const checkPolicyDocs = ({ username, password, landingPage }) => {
         landingPage,
     });
     cy.get("input#main-content")
-        .should("be.visible")
+        .should("exist")
         .type("mock", { force: true });
     cy.get('[data-testid="search-form-submit"]').click({
         force: true,

--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -141,17 +141,12 @@
 .search-field {
     background-color: #fff;
 
-    .v-field__input {
-        padding-left: 12px;
+    label.v-field-label {
+        margin-inline-start: var(--spacer-2);
+    }
 
-        &::placeholder {
-            letter-spacing: normal;
-            position: absolute;
-            top: calc(50% + 0.5px);
-            transform: translateY(-50%);
-            opacity: 1;
-            color: #0009;
-        }
+    .v-field__input {
+        padding-left: var(--spacer-2);
     }
 
     .v-field__append-inner i,

--- a/solution/ui/regulations/css/scss/partials/_search.scss
+++ b/solution/ui/regulations/css/scss/partials/_search.scss
@@ -143,6 +143,8 @@
 
     label.v-field-label {
         margin-inline-start: var(--spacer-2);
+        color: $secondary_text_color;
+        opacity: 1;
     }
 
     .v-field__input {

--- a/solution/ui/regulations/css/scss/partials/_subjects.scss
+++ b/solution/ui/regulations/css/scss/partials/_subjects.scss
@@ -370,7 +370,6 @@
                 }
             }
         }
-
     }
 
     .loading__span {
@@ -472,6 +471,15 @@
         gap: 1rem;
         align-items: center;
         margin-bottom: 1rem;
+    }
+
+    .subject__search--row {
+        padding: 0 var(--spacer-4);
+        margin-bottom: var(--spacer-4);
+
+        .search-field {
+            width: 320px;
+        }
     }
 
     .doc__list {

--- a/solution/ui/regulations/css/scss/partials/_subjects.scss
+++ b/solution/ui/regulations/css/scss/partials/_subjects.scss
@@ -307,6 +307,11 @@
         padding-left: 0px;
         padding-right: 0px;
 
+        @media (max-width: 543px) {
+            padding-left: var(--spacer-6);
+            padding-right: var(--spacer-6);
+        }
+
         @include screen-md {
             padding-right: 1rem;
             border-right: 2px solid $border_color;

--- a/solution/ui/regulations/css/scss/partials/_subjects.scss
+++ b/solution/ui/regulations/css/scss/partials/_subjects.scss
@@ -476,6 +476,20 @@
         gap: 1rem;
         align-items: center;
         margin-bottom: 1rem;
+
+        .doc-type__toggle fieldset {
+            @media (max-width: 475px) {
+                flex-direction: column;
+            }
+        }
+
+        .ds-c-choice-wrapper label {
+            @media (max-width: 475px) {
+                width: calc(100% - 28px);
+                display: flex;
+                justify-content: space-between;
+            }
+        }
     }
 
     .subject__search--row {

--- a/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchErrorMsg.vue
@@ -18,10 +18,10 @@ const props = defineProps({
 <template>
     <div class="error-msg__container">
         <span class="error__msg" data-testid="error__msg">
-            <span class="error__msg--apology" v-if="showApology"
+            <span v-if="showApology" class="error__msg--apology"
                 >Sorry, we’re unable to display results<span
-                    class="error__msg--query"
                     v-if="searchQuery"
+                    class="error__msg--query"
                 >
                     for <strong>{{ searchQuery }}</strong></span
                 >

--- a/solution/ui/regulations/eregs-vite/src/components/SearchInput.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchInput.vue
@@ -2,6 +2,7 @@
     <form ref="formRef" :class="formClass" @submit.prevent="submitForm">
         <v-text-field
             id="main-content"
+            ref="searchInput"
             v-model="searchInputValue"
             clearable
             variant="outlined"
@@ -103,10 +104,16 @@ export default {
             type: Boolean,
             default: false,
         },
+        redirectTo: {
+            type: String,
+            default: undefined,
+        },
     },
 
     created() {
-        this.searchInputValue = this.searchQuery;
+        if (this.parent !== "subjects") {
+            this.searchInputValue = this.searchQuery;
+        }
     },
     data() {
         return {
@@ -129,6 +136,10 @@ export default {
     methods: {
         submitForm() {
             this.$emit("execute-search", { query: this.searchInputValue });
+
+            // clear search input so input is clear if user clicks back button
+            // to return to this page
+            this.$refs.searchInput.reset();
         },
         clearForm() {
             this.searchInputValue = undefined;
@@ -139,7 +150,7 @@ export default {
         },
         synonymLink(synonym) {
             this.$router.push({
-                name: this.parent,
+                name: this.redirectTo || this.parent,
                 query: {
                     ...this.queryParams,
                     page: undefined,
@@ -149,7 +160,7 @@ export default {
         },
         quotedLink() {
             this.$router.push({
-                name: this.parent,
+                name: this.redirectTo || this.parent,
                 query: {
                     ...this.queryParams,
                     page: undefined,

--- a/solution/ui/regulations/eregs-vite/src/components/SearchInput.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchInput.vue
@@ -13,7 +13,7 @@
             clear-icon="mdi-close"
             hide-details
             single-line
-            @update:modelValue="updateSearchValue"
+            @update:model-value="updateSearchValue"
         >
             <template #clear>
                 <v-icon

--- a/solution/ui/regulations/eregs-vite/src/components/SearchInput.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/SearchInput.vue
@@ -6,7 +6,7 @@
             clearable
             variant="outlined"
             density="compact"
-            :placeholder="label"
+            :label="label"
             :aria-label="label"
             type="input"
             class="search-field"

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/DocumentTypeSelector.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/DocumentTypeSelector.vue
@@ -44,8 +44,6 @@ if (!isAuthenticated)
 
 const { counts, fetchCounts } = useCounts();
 
-fetchCounts({ apiUrl, queryParams: $route.query });
-
 // v-model with a ref to control if the checkbox is displayed as checked or not
 let boxesArr;
 
@@ -105,16 +103,21 @@ const onCheckboxChange = (event) => {
 watch(
     () => $route.query,
     (newQuery) => {
-        const { type: typeParams, q } = newQuery;
+        const { type: typeParams, subjects, q } = newQuery;
 
-        fetchCounts({ apiUrl, queryParams: { q } });
+        if (props.parent === "search") {
+            fetchCounts({ apiUrl, queryParams: { q } });
+        } else {
+            fetchCounts({ apiUrl, queryParams: { subjects } });
+        }
 
         if (_isUndefined(typeParams) || typeParams.includes("all")) {
             checkedBoxes.value = [];
         } else {
             checkedBoxes.value = typeParams.split(",");
         }
-    }
+    },
+    { immediate: true }
 );
 
 const onPopState = (event) => {
@@ -136,7 +139,7 @@ const makeLabel = ({ type }) => {
 };
 
 const makeCount = ({ type }) => {
-    if (props.loading) return "";
+    if (props.loading || counts.value.loading) return "";
 
     const mappedType = COUNT_TYPES_MAP[type];
 

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicyResults.vue
@@ -175,10 +175,6 @@ const props = defineProps({
         type: Array,
         default: () => [],
     },
-    view: {
-        type: String,
-        default: undefined,
-    },
 });
 
 const $route = useRoute();
@@ -228,12 +224,6 @@ const currentPageResultsRange = getCurrentPageResultsRange({
 
 <template>
     <div class="doc__list">
-        <h2
-            v-if="view !== 'search' && searchQuery"
-            class="search-results__heading"
-        >
-            Search Results
-        </h2>
         <div class="search-results-count">
             <span v-if="results.length > 0"
                 >{{ currentPageResultsRange[0] }} -
@@ -242,17 +232,6 @@ const currentPageResultsRange = getCurrentPageResultsRange({
             {{ resultsCount }} <span v-if="searchQuery">result</span
             ><span v-else>document</span>
             <span v-if="results.length != 1">s</span>
-            <template v-if="view !== 'search'">
-                <span v-if="searchQuery">
-                    for
-                    <span class="search-query__span">{{
-                        searchQuery
-                    }}</span></span
-                >
-                <span v-if="searchQuery && selectedSubjectParts[0]">
-                    within {{ selectedSubjectParts[1][0] }}</span
-                >
-            </template>
         </div>
         <slot name="empty-state"></slot>
         <ResultsItem

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/PolicySidebar.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/PolicySidebar.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { inject} from "vue";
+import { inject } from "vue";
 import { useRoute } from "vue-router";
 import useLoginRedirectUrl from "composables/login";
 
@@ -9,8 +9,11 @@ const isAuthenticated = inject("isAuthenticated");
 
 const $route = useRoute();
 
-const loginUrl = useLoginRedirectUrl({ customLoginUrl, homeUrl, route: $route });
-
+const loginUrl = useLoginRedirectUrl({
+    customLoginUrl,
+    homeUrl,
+    route: $route,
+});
 </script>
 
 <template>
@@ -20,7 +23,6 @@ const loginUrl = useLoginRedirectUrl({ customLoginUrl, homeUrl, route: $route })
         </slot>
         <div class="sidebar-filters__container">
             <slot name="selections"> </slot>
-            <slot name="search"> </slot>
             <template v-if="!isAuthenticated">
                 <div class="div__login-sidebar">
                     CMCS staff participating in the Policy Repository pilot can

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -46,9 +46,16 @@ router.beforeEach((to) => {
             document.title = pageTitle;
         }
 
+        // strip out q param if it exists; it's not needed for subjects
+        const { q, ...qlessQuery} = to.query;
+
         if (isAuthenticated === "False" && to.query?.type) {
-            const { type, ...typelessQuery } = to.query;
+            const { type, ...typelessQuery } = qlessQuery;
             return { name: "subjects", query: typelessQuery };
+        }
+
+        if (q) {
+            return { name: "subjects", query: qlessQuery };
         }
     }
 

--- a/solution/ui/regulations/eregs-vite/src/main.js
+++ b/solution/ui/regulations/eregs-vite/src/main.js
@@ -47,7 +47,7 @@ router.beforeEach((to) => {
         }
 
         // strip out q param if it exists; it's not needed for subjects
-        const { q, ...qlessQuery} = to.query;
+        const { q, ...qlessQuery } = to.query;
 
         if (isAuthenticated === "False" && to.query?.type) {
             const { type, ...typelessQuery } = qlessQuery;

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -396,7 +396,6 @@ getDocsOnLoad();
                         :has-editable-job-code="hasEditableJobCode"
                         :search-query="searchQuery"
                         :selected-subject-parts="selectedSubjectParts"
-                        view="search"
                     />
                     <div class="pagination-expand-row">
                         <div class="pagination-expand-container">
@@ -405,7 +404,6 @@ getDocsOnLoad();
                                 :count="policyDocList.count"
                                 :page="parseInt($route.query.page, 10) || 1"
                                 :page-size="pageSize"
-                                view="search"
                             />
                         </div>
                     </div>

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -290,6 +290,18 @@ const setSelectedSubjectParts = () => {
     }
 };
 
+const getSearchInputLabel = (selectedSubjectParts) => {
+    if (policyDocSubjects.value.loading) {
+        return "Loading...";
+    }
+
+    if (selectedSubjectParts.length) {
+        return `Search within ${selectedSubjectParts[0][0] || selectedSubjectParts[1][0]}`;
+    }
+
+    return "Search for a document";
+};
+
 watch(
     () => policyDocSubjects.value.loading,
     async (newLoading) => {
@@ -408,16 +420,6 @@ getDocSubjects();
                         <template #selections>
                             <PolicySelections />
                         </template>
-                        <template #search>
-                            <SearchInput
-                                form-class="search-form"
-                                label="Search for a document"
-                                parent="subjects"
-                                :search-query="searchQuery"
-                                @execute-search="executeSearch"
-                                @clear-form="clearSearchInput"
-                            />
-                        </template>
                         <template #filters>
                             <SubjectSelector
                                 :policy-doc-subjects="policyDocSubjects"
@@ -460,14 +462,18 @@ getDocSubjects();
                                 />
                             </FetchItemsContainer>
                         </div>
-                        <SearchInput
-                            form-class="search-form"
-                            label="Search for a document"
-                            parent="search"
-                            :search-query="searchQuery"
-                            @execute-search="executeSearch"
-                            @clear-form="clearSearchInput"
-                        />
+                        <div class="subject__search--row">
+                            <SearchInput
+                                form-class="search-form"
+                                :label="
+                                    getSearchInputLabel(selectedSubjectParts)
+                                "
+                                parent="search"
+                                :search-query="searchQuery"
+                                @execute-search="executeSearch"
+                                @clear-form="clearSearchInput"
+                            />
+                        </div>
                         <template
                             v-if="
                                 policyDocList.loading ||

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -64,7 +64,11 @@ provide("FilterTypesDict", FilterTypesDict);
 // provide router query params to remove on child component change
 const commonRemoveList = ["page", "categories", "intcategories"];
 const policySelectionsRemoveList = ["subjects"];
-const searchInputRemoveList = commonRemoveList.concat(["q"]);
+const searchInputRemoveList = commonRemoveList.concat([
+    "q",
+    "type",
+    "categories",
+]);
 
 provide("commonRemoveList", commonRemoveList);
 provide("policySelectionsRemoveList", policySelectionsRemoveList);
@@ -105,7 +109,7 @@ const executeSearch = (payload) => {
     });
 
     $router.push({
-        name: "subjects",
+        name: "search",
         query: {
             ...cleanedRoute,
             q: payload.query,
@@ -456,6 +460,14 @@ getDocSubjects();
                                 />
                             </FetchItemsContainer>
                         </div>
+                        <SearchInput
+                            form-class="search-form"
+                            label="Search for a document"
+                            parent="search"
+                            :search-query="searchQuery"
+                            @execute-search="executeSearch"
+                            @clear-form="clearSearchInput"
+                        />
                         <template
                             v-if="
                                 policyDocList.loading ||

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -102,29 +102,9 @@ const executeSearch = (payload) => {
         removeList: searchInputRemoveList,
     });
 
-    $router.push({
-        name: "search",
-        query: {
-            ...cleanedRoute,
-            q: payload.query,
-        },
-    });
-};
-
-const clearSearchInput = () => {
-    const routeClone = { ...$route.query };
-
-    const cleanedRoute = useRemoveList({
-        route: routeClone,
-        removeList: searchInputRemoveList,
-    });
-
-    $router.push({
-        name: "subjects",
-        query: {
-            ...cleanedRoute,
-        },
-    });
+    const redirectParams = new URLSearchParams(cleanedRoute);
+    const redirectPath = `${homeUrl}search/?${redirectParams.toString() ? redirectParams.toString() + "&" : ""}q=${payload.query}`;
+    window.location.assign(redirectPath);
 };
 
 // partsLastUpdated fetch for related regulations citations filtering
@@ -457,7 +437,6 @@ getDocSubjects();
                                 "
                                 parent="search"
                                 @execute-search="executeSearch"
-                                @clear-form="clearSearchInput"
                             />
                         </div>
                         <template

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -435,7 +435,8 @@ getDocSubjects();
                                 :label="
                                     getSearchInputLabel(selectedSubjectParts)
                                 "
-                                parent="search"
+                                parent="subjects"
+                                redirect-to="search"
                                 @execute-search="executeSearch"
                             />
                         </div>

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -63,7 +63,7 @@ provide("FilterTypesDict", FilterTypesDict);
 
 // provide router query params to remove on child component change
 const commonRemoveList = ["page", "categories", "intcategories"];
-const policySelectionsRemoveList = ["subjects"];
+const policySelectionsRemoveList = ["subjects", "q"];
 const searchInputRemoveList = commonRemoveList.concat([
     "q",
     "type",
@@ -92,12 +92,6 @@ const allDocTypesOnly = (queryParams) => {
     }
 
     return false;
-};
-
-// search query refs and methods
-const searchQuery = ref($route.query.q || "");
-const clearSearchQuery = () => {
-    searchQuery.value = "";
 };
 
 const executeSearch = (payload) => {
@@ -191,11 +185,6 @@ const setSelectedParams = (subjectsListRef) => (param) => {
         return;
     }
 
-    if (paramType === "q") {
-        searchQuery.value = paramValue;
-        return;
-    }
-
     const paramList = !_isArray(paramValue) ? [paramValue] : paramValue;
     paramList.forEach((paramId) => {
         const subject = subjectsListRef.value.results.filter(
@@ -252,7 +241,6 @@ const getDocSubjects = async () => {
         if (!allDocTypesOnly($route.query)) {
             // wipe everything clean to start
             clearSelectedParams();
-            clearSearchQuery();
 
             // now that everything is cleaned, iterate over new query params
             Object.entries($route.query).forEach((param) => {
@@ -335,7 +323,6 @@ watch(
 
         // wipe everything clean to start
         clearSelectedParams();
-        clearSearchQuery();
 
         const sanitizedQueryParams = Object.entries(newQueryParams).filter(
             ([key]) => PARAM_VALIDATION_DICT[key]
@@ -437,7 +424,7 @@ getDocSubjects();
                     />
                     <template v-else>
                         <div
-                            v-if="selectedSubjectParts.length && !searchQuery"
+                            v-if="selectedSubjectParts.length"
                             class="subject__heading"
                         >
                             <SelectedSubjectHeading
@@ -469,7 +456,6 @@ getDocSubjects();
                                     getSearchInputLabel(selectedSubjectParts)
                                 "
                                 parent="search"
-                                :search-query="searchQuery"
                                 @execute-search="executeSearch"
                                 @clear-form="clearSearchInput"
                             />
@@ -485,16 +471,12 @@ getDocSubjects();
                         <template v-else-if="policyDocList.error">
                             <div class="doc__list">
                                 <h2
-                                    v-if="
-                                        !selectedSubjectParts.length ||
-                                        searchQuery
-                                    "
+                                    v-if="!selectedSubjectParts.length"
                                     class="search-results__heading"
                                 >
                                     Search Results
                                 </h2>
                                 <SearchErrorMsg
-                                    :search-query="searchQuery"
                                     show-apology
                                     :survey-url="surveyUrl"
                                 />
@@ -509,7 +491,6 @@ getDocSubjects();
                                 :page-size="pageSize"
                                 :parts-last-updated="partsLastUpdated.results"
                                 :has-editable-job-code="hasEditableJobCode"
-                                :search-query="searchQuery"
                                 :selected-subject-parts="selectedSubjectParts"
                             />
                             <div class="pagination-expand-row">


### PR DESCRIPTION
Resolves [EREGCSC-2685](https://jiraent.cms.gov/browse/EREGCSC-2685)

**Description**

Removes ability to search by query string on the Subjects page.  The Search Input still exists on the page, but it is moved out of the left sidebar and to the top center of the Subjects page.  When a user searches by query string, they are redirected away from the Subjects page to the Search page with only their selected subject preserved.

**This pull request changes:**

- Moves Search Input element from left sidebar of Subjects page to top center of page with the other filters (Choose Category, Document Type selector)
- Removes `q` param from URL if user attempts to visit Subjects page with a link that includes `q` param
- Removes/refactors all logic on the Subjects page associated with search querystrings
- Updates Subjects end to end test suite to remove assertions that tested searching by query string
- Adds new end to end tests and assertions that verify the redirection to the Search page
- Various narrow/mobile style tweaks
- Includes `fetchCounts` fix: the counts on the Subject page are now based on the selected subject, while the counts on the Search page are still based on the search query

**Steps to manually verify this change:**

1. Green check marks
2. [Visit experimental deployment](https://bm3gws9jr4.execute-api.us-east-1.amazonaws.com/dev1461)
3. Visit `/subjects` page and select a subject
   - Notice that the search input is no longer in the left sidebar; it is at the top center of the screen under the other filters (Category select, Document Type checkboxes)
4. The placeholder test in the search input should read "Search within X" where X is the name of the selected subject
5. Select a category
6. Type a search query into the Search Input and click submit/press enter
7. You should be taken to the Search page for that search query
   - The subject should be preserved
   - The category and document type should NOT be preserved.  No categories or document types should be selected

