### PR TITLE
Ignore patch-level Dependabot updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 1
+    ignore: 
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
This is related to the ticket at [EREGCSC-2654](https://jiraent.cms.gov/browse/EREGCSC-2654) about refactoring our GitHub Actions, but does not resolve it. This is a followup to #1454 (Enable Dependabot to check for GitHub Actions updates).

We want to keep our GitHub Actions updated, but we want to prioritize major and minor version updates instead of all updates, to reduce unnecessary dev work to review and merge patch updates.

**Description-**

**This pull request changes...**

- Ignore patch-level updates for GitHub Actions - based on https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore-patch-updates

**Steps to manually verify this change...**

You could check the linked documentation to make sure this looks right. Otherwise we'll know if this is working if we get weekly automated PRs for updating GitHub Actions that are limited to major and minor version updates.