### PR TITLE
Add CDK configuration for maintainance stacks to experimental deployment

### DIFF
--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -157,7 +157,32 @@ jobs:
             cdk deploy "*redirect-api" \
             -c environment=${{ env.ENVIRONMENT_NAME }} \
             --require-approval never
-            popd   
+            popd    
+  deploy-Maintenance-Api-CDK:
+    environment:
+      name: "dev"
+    env:
+      ENVIRONMENT_NAME: "dev"
+    runs-on: ubuntu-22.04
+    steps:
+      # Checkout the code
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      # Find the PR number.  This is not always trivial which is why this uses an existign action
+      - name: Find PR number
+        uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+        with:
+          # Can be "open", "closed", or "all".  Defaults to "open".
+          state: open
+      # Configure AWS credentials for GitHub Actions
+      - name: Configure AWS credentials for GitHub Actions
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
+          aws-region: us-east-1           
       - name: Deploy Maintenance-api Lambda via CDK
         id: deploy-maintenance-api
         if: success() && steps.findPr.outputs.number
@@ -175,7 +200,7 @@ jobs:
             cdk deploy "*maintenance-api" \
             -c environment=${{ env.ENVIRONMENT_NAME }} \
             --require-approval never
-            popd   
+            popd    
   deploy-text-extractor:
     environment:
       name: "dev"

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -158,6 +158,24 @@ jobs:
             -c environment=${{ env.ENVIRONMENT_NAME }} \
             --require-approval never
             popd   
+      - name: Deploy Maintenance-api Lambda via CDK
+        id: deploy-maintenance-api
+        if: success() && steps.findPr.outputs.number
+        env:
+            PR_NUMBER: ${{ steps.findPr.outputs.pr }}
+            RUN_ID: ${{ github.run_id }}
+            AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+            AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+            CDK_DEBUG: true
+            ENVIRONMENT_NAME: ${{ env.ENVIRONMENT_NAME }}
+        run: |
+            pushd cdk-eregs
+            npm install -g aws-cdk@latest @aws-sdk/client-ssm
+            npm install
+            cdk deploy "*maintenance-api" \
+            -c environment=${{ env.ENVIRONMENT_NAME }} \
+            --require-approval never
+            popd   
   deploy-text-extractor:
     environment:
       name: "dev"

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -138,7 +138,7 @@ jobs:
           npm install
           
           # Generate the exact stack name for this PR
-          STACK_NAME="cms-eregs-eph-${PR_NUMBER}-maintenance--api"
+          STACK_NAME="cms-eregs-eph-${PR_NUMBER}-maintenance-api"
           
           echo "Destroying PR-specific stack: ${STACK_NAME}"
           cdk destroy "${STACK_NAME}" \

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -125,3 +125,25 @@ jobs:
           
           echo "Cleanup completed for stack: ${STACK_NAME}"
           popd
+      - name: Destroy PR-Maintenance Stack
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          CDK_DEBUG: true
+          ENVIRONMENT_NAME: ${{ env.ENVIRONMENT_NAME }}
+        run: |
+          pushd cdk-eregs
+          npm install -g aws-cdk@latest @aws-sdk/client-ssm
+          npm install
+          
+          # Generate the exact stack name for this PR
+          STACK_NAME="cms-eregs-eph-${PR_NUMBER}-maintenance--api"
+          
+          echo "Destroying PR-specific stack: ${STACK_NAME}"
+          cdk destroy "${STACK_NAME}" \
+          -c environment=${{ env.ENVIRONMENT_NAME }} \
+          --force
+          
+          echo "Cleanup completed for stack: ${STACK_NAME}"
+          popd

--- a/cdk-eregs/bin/cdk-eregs.ts
+++ b/cdk-eregs/bin/cdk-eregs.ts
@@ -8,6 +8,7 @@ import { IamPathAspect } from '../lib/aspects/iam-path';
 import { IamPermissionsBoundaryAspect } from '../lib/aspects/iam-permissions-boundary-aspect';
 import { EphemeralRemovalPolicyAspect } from '../lib/aspects/removal-policy-aspect';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { MaintenanceApiStack } from '../lib/stacks/maintainance-stack';
 // import { StackFactory } from '../lib/factories/stack-factory';
 // import { getStackConfigs } from '../config/stack-definition';
 async function main() {
@@ -88,7 +89,16 @@ async function main() {
       loggingLevel: cdk.aws_apigateway.MethodLoggingLevel.INFO,
     },
   }, stageConfig);
-
+  new MaintenanceApiStack(app, stageConfig.getResourceName('maintenance-api'), {
+    lambdaConfig: {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      memorySize: 1024,
+      timeout: 30,
+    },
+    apiConfig: {
+      loggingLevel: cdk.aws_apigateway.MethodLoggingLevel.INFO,
+    },
+  }, stageConfig);
   // Apply aspects
   await applyGlobalAspects(app, stageConfig);
 

--- a/cdk-eregs/bin/cdk-eregs.ts
+++ b/cdk-eregs/bin/cdk-eregs.ts
@@ -9,6 +9,7 @@ import { IamPermissionsBoundaryAspect } from '../lib/aspects/iam-permissions-bou
 import { EphemeralRemovalPolicyAspect } from '../lib/aspects/removal-policy-aspect';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { MaintenanceApiStack } from '../lib/stacks/maintainance-stack';
+
 // import { StackFactory } from '../lib/factories/stack-factory';
 // import { getStackConfigs } from '../config/stack-definition';
 async function main() {
@@ -99,6 +100,8 @@ async function main() {
       loggingLevel: cdk.aws_apigateway.MethodLoggingLevel.INFO,
     },
   }, stageConfig);
+  // Example deployment in app.ts
+
   // Apply aspects
   await applyGlobalAspects(app, stageConfig);
 

--- a/cdk-eregs/config/stage-config.ts
+++ b/cdk-eregs/config/stage-config.ts
@@ -13,6 +13,7 @@ const AWS_SERVICES = {
   SNS: 'sns',
   SQS: 'sqs',
   EVENTS: 'events',
+  TEXTRACT: 'textract',
 } as const;
 
 /**

--- a/cdk-eregs/lib/stacks/maintainance-stack.ts
+++ b/cdk-eregs/lib/stacks/maintainance-stack.ts
@@ -1,0 +1,191 @@
+// lib/stacks/maintenance-api-stack.ts
+import * as cdk from 'aws-cdk-lib';
+import {
+  aws_iam as iam,
+  aws_logs as logs,
+  aws_lambda as lambda,
+  aws_apigateway as apigateway,
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { StageConfig } from '../../config/stage-config';
+
+/**
+ * Configuration for the Lambda function
+ */
+interface LambdaConfig {
+  runtime: lambda.Runtime;
+  memorySize: number;
+  timeout: number;
+  handler?: string;
+  codePath?: string;
+}
+
+/**
+ * Configuration for the API Gateway
+ */
+interface ApiGatewayConfig {
+  binaryMediaTypes?: string[];
+  endpointType?: apigateway.EndpointType;
+  loggingLevel?: apigateway.MethodLoggingLevel;
+}
+
+/**
+ * Properties for the MaintenanceApiStack
+ */
+export interface MaintenanceApiStackProps extends cdk.StackProps {
+  lambdaConfig: LambdaConfig;
+  apiConfig?: ApiGatewayConfig;
+}
+
+const DEFAULT_API_CONFIG: ApiGatewayConfig = {
+  binaryMediaTypes: ['multipart/form-data', 'application/pdf'],
+  endpointType: apigateway.EndpointType.EDGE,
+  loggingLevel: apigateway.MethodLoggingLevel.INFO,
+};
+
+export class MaintenanceApiStack extends cdk.Stack {
+  public readonly lambdaFunction: lambda.Function;
+  public readonly api: apigateway.RestApi;
+  private readonly stageConfig: StageConfig;
+
+  constructor(
+    scope: Construct, 
+    id: string, 
+    props: MaintenanceApiStackProps,
+    stageConfig: StageConfig
+  ) {
+    super(scope, id, props);
+    this.stageConfig = stageConfig;
+
+    const apiConfig = { ...DEFAULT_API_CONFIG, ...props.apiConfig };
+
+    const { lambdaRole, logGroup } = this.createLambdaInfrastructure();
+    this.lambdaFunction = this.createLambdaFunction(lambdaRole, logGroup, props.lambdaConfig);
+    this.api = this.createApiGateway(apiConfig);
+    this.configureApiGateway();
+    this.createStackOutputs();
+  }
+
+  private createLambdaInfrastructure() {
+    // Lambda CloudWatch Log Group
+    const logGroup = new logs.LogGroup(this, 'MaintenanceFunctionLogGroup', {
+      logGroupName: `/aws/lambda/maintenance-api-${this.stageConfig.environment}-maintenanceFunction`,
+    });
+
+    // Lambda IAM Role
+    const lambdaRole = new iam.Role(this, 'LambdaFunctionRole', {
+      path: '/delegatedadmin/developer/',
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      permissionsBoundary: iam.ManagedPolicy.fromManagedPolicyArn(
+        this,
+        'PermissionsBoundary',
+        `arn:aws:iam::${this.account}:policy/cms-cloud-admin/developer-boundary-policy`
+      ),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole'),
+      ],
+      inlinePolicies: {
+        LambdaPolicy: this.createLambdaPolicy(),
+      },
+    });
+
+    return { lambdaRole, logGroup };
+  }
+
+  private createLambdaPolicy(): iam.PolicyDocument {
+    return new iam.PolicyDocument({
+      statements: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+          resources: [`arn:aws:logs:${this.region}:${this.account}:log-group:/aws/lambda/*:*:*`],
+        }),
+      ],
+    });
+  }
+
+  private createLambdaFunction(
+    role: iam.Role,
+    logGroup: logs.LogGroup,
+    config: LambdaConfig,
+  ): lambda.Function {
+    const fn = new lambda.Function(this, 'MaintenanceFunctionLambda', {
+      functionName: `maintenance-api-${this.stageConfig.environment}-maintenanceFunction`,
+      runtime: config.runtime,
+      handler: 'maintenance_lambda.handler',
+      code: lambda.Code.fromAsset(config.codePath ?? '../solution/backend/'),
+      memorySize: config.memorySize,
+      timeout: cdk.Duration.seconds(config.timeout),
+      role,
+    });
+
+    // Create version (matches template)
+    new lambda.Version(this, 'MaintenanceFunctionVersion', {
+      lambda: fn,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    return fn;
+  }
+
+  private createApiGateway(config: ApiGatewayConfig): apigateway.RestApi {
+    const api = new apigateway.RestApi(this, 'ApiGatewayRestApi', {
+      restApiName: `${this.stageConfig.environment}-maintenance-api`,
+      binaryMediaTypes: config.binaryMediaTypes,
+      endpointConfiguration: {
+        types: [config.endpointType!],
+      },
+      deployOptions: {
+        stageName: this.stageConfig.environment,
+        loggingLevel: config.loggingLevel,
+      },
+    });
+
+    // API Gateway Log Group
+    new logs.LogGroup(this, 'ApiGatewayLogGroup', {
+      logGroupName: `/aws/api-gateway/maintenance-api-${this.stageConfig.environment}`,
+    });
+
+    return api;
+  }
+
+  private configureApiGateway() {
+    const integration = new apigateway.LambdaIntegration(this.lambdaFunction, { proxy: true });
+
+    // Lambda permission for API Gateway
+    new lambda.CfnPermission(this, 'MaintenanceFunctionLambdaPermissionApiGateway', {
+      action: 'lambda:InvokeFunction',
+      functionName: this.lambdaFunction.functionArn,
+      principal: 'apigateway.amazonaws.com',
+      sourceArn: `arn:${this.partition}:execute-api:${this.region}:${this.account}:${this.api.restApiId}/*/*`,
+    });
+    
+    this.api.root.addMethod('ANY', integration, { 
+      apiKeyRequired: false, 
+      methodResponses: [] 
+    });
+    
+    const proxyResource = this.api.root.addResource('{proxy+}');
+    proxyResource.addMethod('ANY', integration, { 
+      apiKeyRequired: false, 
+      methodResponses: [] 
+    });
+  }
+
+  private createStackOutputs() {
+    const outputs: Record<string, cdk.CfnOutputProps> = {
+      MaintenanceFunctionLambdaFunctionQualifiedArn: {
+        value: this.lambdaFunction.currentVersion.functionArn,
+        description: 'Current Lambda function version',
+        exportName: `sls-maintenance-api-${this.stageConfig.environment}-MaintenanceFunctionLambdaFunctionQualifiedArn`,
+      },
+      ServiceEndpoint: {
+        value: `https://${this.api.restApiId}.execute-api.${this.region}.${cdk.Aws.URL_SUFFIX}/${this.stageConfig.environment}`,
+        description: 'URL of the service endpoint',
+        exportName: `sls-maintenance-api-${this.stageConfig.environment}-ServiceEndpoint`,
+      },
+    };
+
+    Object.entries(outputs).forEach(([name, props]) => new cdk.CfnOutput(this, name, props));
+  }
+}


### PR DESCRIPTION
# Deploy Maintenance API to Ephemeral Environment

Resolves #EREGCSC-2861

## Description
This pull request changes:
- Implements automated deployment of Maintenance API to ephemeral environments for PR testing
- Adds GitHub Actions workflow for PR-specific stack deployment
- Matches exact configuration from existing serverless deployment:
  - Lambda: Python 3.12, 1024MB, 30s timeout
  - API Gateway: Edge endpoint with binary media types
  - IAM: Correct paths and permission boundaries
  - Logging: Proper CloudWatch configuration

## Steps to manually verify this change:
1. Open a new PR
   - Verify GitHub Action triggers automatically
   - Check CDK deployment logs show correct configurations


2. Test deployed endpoint
   - Find API Gateway URL aws console
   - Verify maintenance API responds correctly
   - Check AWS Console for PR-specific resources (format: cms-eregs-eph-{pr-number}-maintenance-api)

3. Close PR to verify cleanup
   - Observe cleanup workflow trigger
   - Verify stack is destroyed
   - Check AWS Console to confirm resource removal

## Comments
1. Resource naming pattern: cms-eregs-eph-{pr-number}-maintenance-api
2. Matches exactly: memory, timeout, runtime, IAM settings from serverless
3. Ephemeral resources auto-destroy on PR close/merge