### PR TITLE
EREGCSC-2860-B [Hotfix] Remove "hello world" stack deploy from deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,19 +70,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1
-      - name: deploy hello world CDK stack
-        env:
-          STAGE: ${{ matrix.environment }}
-          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        run: |
-          pushd cdk-eregs
-          npm install -g aws-cdk
-          npm install
-          cdk synth -c stage=${STAGE} -c account=${AWS_ACCOUNT_ID} -c region=${AWS_DEFAULT_REGION}
-          cdk deploy -c stage=${STAGE} -c account=${AWS_ACCOUNT_ID} -c region=${AWS_DEFAULT_REGION} \
-            ${STAGE}-HelloWorldStack --require-approval never
-          popd
       - name: deploy static assets
         run: |
           pushd solution/static-assets


### PR DESCRIPTION
Resolves #2860

**Description-**

Previous PR (#1473) fails to deploy to prod because "deploy.yml" was still looking for the experimental hello world stack.

**This pull request changes...**

- Removes the experimental hello world stack deploy action from "deploy.yml"

**Steps to manually verify this change...**

1. Approve and merge
2. Deploy through to prod
3. Verify green for each deploy

