### PR TITLE
EREGCSC-2900 Prevent text extractor from infinitely retrying, add max pages for PDF extraction

### DIFF
--- a/solution/text-extractor/extractors/pdf.py
+++ b/solution/text-extractor/extractors/pdf.py
@@ -11,11 +11,14 @@ logger = logging.getLogger(__name__)
 
 class PdfExtractor(Extractor):
     file_types = ("pdf",)
-    max_size = 20
+    max_pages = 50
+    output_file_type = "jpeg"
+    
 
-    def __init__(self, file_type: str, config: dict):
+    def __init__(self, file_type: str, config: dict, *args, **kwargs):
         super().__init__(file_type, config)
-        self.extractor = Extractor.get_extractor("jpeg", config)
+        self.output_file_type = kwargs.pop("output_file_type", self.output_file_type)
+        self.extractor = Extractor.get_extractor(self.output_file_type, config)
 
     def _convert_to_images(self, file: bytes, temp_dir: str) -> [str]:
         logger.debug("Converting PDF file to images stored in a temporary directory.")
@@ -23,18 +26,23 @@ class PdfExtractor(Extractor):
             file,
             paths_only=True,
             output_folder=temp_dir,
-            fmt="jpeg",
+            fmt=self.output_file_type,
         )
 
     def _extract(self, file: bytes) -> str:
+        text = ""
+
         with TemporaryDirectory() as temp_dir:
             try:
                 pages = self._convert_to_images(file, temp_dir)
             except Exception as e:
                 raise ExtractorException(f"failed to convert PDF to images: {str(e)}")
 
-            text = ""
             for i, page in enumerate(pages):
+                if i >= self.max_pages:
+                    logger.warning("Reached maximum number of pages to extract: %i", self.max_pages)
+                    break
+
                 logger.debug("Extracting page %i.", i)
                 try:
                     with open(page, "rb") as f:
@@ -47,4 +55,5 @@ class PdfExtractor(Extractor):
                     logger.warning("Page %i failed to extract: %s", i, str(e))
                 except Exception as e:
                     logger.warning("Page %i unexpectedly failed to extract: %s", i, str(e))
+
         return text

--- a/solution/text-extractor/extractors/pdf.py
+++ b/solution/text-extractor/extractors/pdf.py
@@ -13,7 +13,6 @@ class PdfExtractor(Extractor):
     file_types = ("pdf",)
     max_pages = 50
     output_file_type = "jpeg"
-    
 
     def __init__(self, file_type: str, config: dict, *args, **kwargs):
         super().__init__(file_type, config)

--- a/solution/text-extractor/extractors/tests/__init__.py
+++ b/solution/text-extractor/extractors/tests/__init__.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 from extractors import Extractor
 
 
-
 logging.disable(logging.CRITICAL)
 
 

--- a/solution/text-extractor/extractors/tests/test_pdf.py
+++ b/solution/text-extractor/extractors/tests/test_pdf.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from extractors import (
     Extractor,
     ExtractorException,
+    PdfExtractor,
 )
 
 from . import FixtureTestCase
@@ -18,14 +19,37 @@ class MockJpegExtractor:
         return "Sample output"  # Expected file will contain 2 copies of this as there are 2 pages in the PDF
 
 
+class MockNullExtractor:
+    def extract(self, file: bytes) -> str:
+        return "Sample output"
+
+
 def mock_get_extractor(file_type: str, config: dict = {}) -> Extractor:
     if file_type == "jpeg":
         return MockJpegExtractor()
+    if file_type == "null":
+        return MockNullExtractor()
     return orig(file_type, config)
 
 
-# This simple test verifies that multipage support is working and that it is converting PDF pages to jpeg images.
+def mock_convert_to_images(self: PdfExtractor, file: bytes, temp_dir: str) -> [str]:
+    for i in range(self.max_pages + 10):
+        with open(f"{temp_dir}/page{i}.null", "wb") as f:
+            f.write(b"null")
+    return [f"{temp_dir}/page{i}.null" for i in range(self.max_pages + 10)]
+
+
 class TestPdfExtractor(FixtureTestCase):
+    # This simple test verifies that multipage support is working and that it is converting PDF pages to jpeg images.
     @patch.object(Extractor, "get_extractor", mock_get_extractor)
     def test_extract_pdf(self):
         self._test_file_type("pdf")
+
+    # This test verifies that the extractor will only extract up to the maximum number of pages.
+    @patch.object(Extractor, "get_extractor", mock_get_extractor)
+    @patch.object(PdfExtractor, "_convert_to_images", mock_convert_to_images)
+    def test_pdf_max_pages(self, *args):
+        with open(f"{self.BASE_PATH}pdf/sample.pdf", "rb") as f:
+            sample = f.read()
+        output = PdfExtractor("pdf", {}, output_file_type="null").extract(sample)
+        self.assertEqual(output.count("Sample output"), PdfExtractor.max_pages)

--- a/solution/text-extractor/serverless.yml
+++ b/solution/text-extractor/serverless.yml
@@ -45,6 +45,13 @@ resources:
         DelaySeconds: 0
         MessageRetentionPeriod: 345600 # 4 days
         VisibilityTimeout: 900
+        RedrivePolicy:
+          deadLetterTargetArn: !GetAtt DeadLetterQueue.Arn
+          maxReceiveCount: 5 # retry 5 times before moving to dead-letter queue
+    DeadLetterQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        QueueName: ${self:custom.stage}-text-extractor-dl-queue
     LambdaFunctionRole:
       Type: AWS::IAM::Role
       Properties:


### PR DESCRIPTION
Resolves # 2900

**Description-**

We saw an increase in Textract charges this month and tracked it back using Lambda monitor charts to a period between 11/6-11/8 where there was a consistent number of extractor errors. Checking CloudWatch we saw the extractor continually attempting to process an object and timing out after 900 seconds (15 mins).

We were able to reasonably guess that it was the result of the extractor attempting to extract a 500 page PDF that was only 6 MB. Given that the max file size was 20 MB, it didn't exceed that threshold, but since each page is sent to Textract sequentially, we could guess that it would easily exceed 900 seconds. (Max processing time per page is 900/500 = 1.8 sec/page, which we are unlikely to beat.)

Additionally, since the Lambda orchestrator is what is causing the timeout, the Lambda itself never successfully consumes the queue message and it is returned to the queue an indefinite number of times. We can fix this with a dead-letter queue configured to receive failed messages after a certain number of attempts.

**This pull request changes...**

- PDFs are limited by _page_ now instead of size. Extractor will only process up to 50 pages.
- If 50 pages is exceeded, return the first 50 pages worth of text and exit.
- Added a dead-letter queue for the text extractor. If an unhandled error occurs 5 times, send the message to the DLQ and do not reprocess.

**Followups for the future:**

- Handle _all_ errors using the queue instead of retrying internally. (Web extractor retries, etc., should be removed.)
- Find a way to extract PDFs in parallel. Currently, the PDF extractor converts the PDF to a set of images and sends them one-by-one to Textract. What if we instead sent each image/page to the queue to be processed whenever possible?
    - Textract extractor could easily save each image/page to an S3 bucket, which is already a supported backend for the extractor. Then add the option to _delete_ an object from S3 if configured and permitted, and when consumed.
    - We could modify eRegs' backend to permit sending numbered chunks of text for a given Resource object instead of only allowing the entire text to be sent.
    - Could add two fields to the HTTP patch request JSON: "chunk" representing the current chunk number, and "chunks" representing the total number.
    - If the above are non-zero, the update method would put placeholders in the text field until the corresponding chunk comes in, then replace the placeholder with the chunk's value.
    - Estimated points for this work: Maybe a 3. Would be worthwhile in our quest to eliminate timeouts due to Lambda limitations.

**Steps to manually verify this change...**

1. Tests pass (added a test for max page processing).
2. Attempt to extract the 500 page, 6 MB PDF again and verify that it does not fail and does extract some text. (Use the "Index populated" filter on the admin panel, and/or see if it comes up in search results.)
3. Go to AWS for dev -> Simple Queue Service -> dev1483-text-extractor-queue.
4. Notice under "Details", "Dead-letter queue" is set to "Enabled".
5. Go to the "Dead-letter queue" tab.
6. Notice the queue is set to the correct dead-letter queue ARN, and max retries (called "max receives" in SQS lingo) is set to 5.

