### PR TITLE
[Hotfix] Revert dominikh/staticcheck-action from 1.3.1 to 1.3.0 to address failures

### DIFF
--- a/.github/workflows/parser-checks.yml
+++ b/.github/workflows/parser-checks.yml
@@ -50,7 +50,7 @@ jobs:
         gofmt-path: './solution/parser/${{ matrix.dir }}'
         gofmt-flags: '-l -d'
 
-    - uses: dominikh/staticcheck-action@v1.3.1
+    - uses: dominikh/staticcheck-action@v1.3.0
       with:
         version: "2022.1.3"
         working-directory: "./solution/parser/${{ matrix.dir }}"


### PR DESCRIPTION
Resolves Static Check action failing since 1.3.1 upgrade

**Description**

Dependabot created [pull request ](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1477) that bumped [dominikh/staticcheck-action](https://github.com/dominikh/staticcheck-action) from 1.3.0 to 1.3.1.  Since the version was only incremented by a single patch value, we decided to approve the PR and merge it to `main`, assuming that there would be no breaking changes and that the Parse Checks action would continue to work and succeed as expected.

However, this update broke the Parser Checks action and the checks have consistently failed since this PR was merged.  As such, we are going to revert the action version back to 1.3.0 and to get the Parser Check actions working again.

**This pull request changes:**

- Decrements the version of dominikh/staticcheck-action from 1.3.1 to 1.3.0

**Steps to manually verify this change:**

1. Parser check actions succeed with green check marks when this PR is merged into `main`

