### PR TITLE
EREGCSC-2363-B Fix escape vulnerability in text extraction user message on admin panel

### DIFF
--- a/solution/backend/resources/admin/resources.py
+++ b/solution/backend/resources/admin/resources.py
@@ -67,12 +67,12 @@ class AbstractResourceAdmin(CustomAdminMixin, admin.ModelAdmin):
             url = f"<a target=\"_blank\" href=\"{reverse('edit', args=[obj.pk])}\">{escape(str(obj))}</a>"
             if fail:
                 logger.error("Failed to invoke text extractor for resource with ID %i: %s", obj.pk, fail[0]["reason"])
-                message = f"Failed to request text extraction for {escape(obj._meta.verbose_name)} \"{url}\". Please ensure "\
+                message = f"Failed to request text extraction for {obj._meta.verbose_name} \"{url}\". Please ensure "\
                           f"the item has a valid URL or attached file, then {get_support_link('contact support')} "\
                           "for assistance if needed."
                 level = messages.WARNING
             else:
-                message = f"Text extraction requested for {escape(obj._meta.verbose_name)} \"{url}\"."
+                message = f"Text extraction requested for {obj._meta.verbose_name} \"{url}\"."
                 level = messages.SUCCESS
             self.message_user(request, format_html(message), level=level)
 

--- a/solution/backend/resources/admin/resources.py
+++ b/solution/backend/resources/admin/resources.py
@@ -9,7 +9,7 @@ from django.db.models import (
 )
 from django.db.models.functions import Concat
 from django.urls import reverse
-from django.utils.html import format_html
+from django.utils.html import escape, format_html
 
 from common.admin import CustomAdminMixin
 from common.filters import IndexPopulatedFilter
@@ -64,15 +64,15 @@ class AbstractResourceAdmin(CustomAdminMixin, admin.ModelAdmin):
         auto_extract = ResourcesConfiguration.get_solo().auto_extract
         if auto_extract and (not change or field_changed(form, "url") or kwargs.pop("force_extract", False)):
             _, fail = call_text_extractor(request, [obj])
-            url = f"<a target=\"_blank\" href=\"{reverse('edit', args=[obj.pk])}\">{str(obj)}</a>"
+            url = f"<a target=\"_blank\" href=\"{reverse('edit', args=[obj.pk])}\">{escape(str(obj))}</a>"
             if fail:
                 logger.error("Failed to invoke text extractor for resource with ID %i: %s", obj.pk, fail[0]["reason"])
-                message = f"Failed to request text extraction for {obj._meta.verbose_name} \"{url}\". Please ensure the item "\
-                          f"has a valid URL or attached file, then {get_support_link('contact support')} "\
+                message = f"Failed to request text extraction for {escape(obj._meta.verbose_name)} \"{url}\". Please ensure "\
+                          f"the item has a valid URL or attached file, then {get_support_link('contact support')} "\
                           "for assistance if needed."
                 level = messages.WARNING
             else:
-                message = f"Text extraction requested for {obj._meta.verbose_name} \"{url}\"."
+                message = f"Text extraction requested for {escape(obj._meta.verbose_name)} \"{url}\"."
                 level = messages.SUCCESS
             self.message_user(request, format_html(message), level=level)
 


### PR DESCRIPTION
Resolves #2363

**Description-**

Pen-testing revealed a vulnerability in the admin panel where it is possible to execute arbitrary code by inserting the code into the title of a resource and saving it. This triggers a text extraction user message to be displayed with the title of the resource in the message.

**This pull request changes...**

- Use Django's `escape()` function around user-entered strings that are displayed in an HTML formatted user message.

**Steps to manually verify this change...**

1. In the experimental deploy, go to the admin panel and sign in.
2. Go to a public link and arbitrarily add junk to the end of the URL to trigger a text extraction event (e.g. if URL is http://google.com, add "/test" to the end).
3. Replace the `title` field with the following: `CCIC"><img src=a onerror=prompt(document.domain);>`
4. Save the resource.
5. You should see a message on the top of the screen like this: `Text extraction requested for Public Link "2000-12-15 CCIC"><img src=a onerror=prompt(document.domain);>".`
6. You should NOT see a popup prompt. If you see no text extraction message at all, go to "Resources Configuration" on the left sidebar and ensure "Auto Extract" is checked.

