### PR TITLE
EREGCSC-2583 Update PostgreSQL engine to 15.8

### DIFF
--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -292,7 +292,7 @@ resources:
         DBSubnetGroupName:
           Ref: DBSubnetGroup
         Engine: aurora-postgresql
-        EngineVersion: "15.2"
+        EngineVersion: "15.8"
         DatabaseName: 'eregs'
         BackupRetentionPeriod: 7
         DBClusterParameterGroupName:
@@ -306,7 +306,7 @@ resources:
         DBInstanceClass: db.r6g.large
         StorageEncrypted: true
         Engine: aurora-postgresql
-        EngineVersion: "15.2"
+        EngineVersion: "15.8"
         PubliclyAccessible: false
         DBParameterGroupName:
           Ref: AuroraRDSInstanceParameter15


### PR DESCRIPTION
Resolves #2583

**Description-**

To stay ATO compliant we need to be on the latest patch release for our major PostgreSQL version, which is 15.8.

**This pull request changes...**

- Upgrades PostgreSQL engine version in Serverless config.

**Steps to manually verify this change...**

1. Backup the dev DB. (A snapshot will suffice.)
2. Perform manual engine upgrade on AWS console for dev.
3. Deploy this PR.
4. Verify Serverless does not create a new database or overwrite the existing dev DB.
5. Backup the val DB. (A snapshot will suffice.)
6. Manually upgrade the DB engine on the AWS console for val.
7. Approve deployment to val.
8. Verify Serverless does not create a new database or overwrite the existing val DB.
9. Backup the prod DB. (A snapshot will suffice.)
10. Set maintenance mode lambda for prod:
    a. Go to API Gateway for prod site. (`prod-cmcs-eregs-site`)
    b. Under "Resources", click "ANY", then click the "Integration request" tab.
    c. Click the "Edit" button.
    d. Under the "Lambda function" dropdown, search for "maintenance" and select the maintenance lambda.
    e. Click "Save". Then click "Deploy API" and confirm.
    f. Wait a few minutes for the changes to take effect, then refresh the eRegs prod site and verify it is in maintenance mode.
12. Manually upgrade the DB engine on the AWS console for prod.
13. Approve deployment to prod.
14. Verify Serverless does not create a new database or overwrite the existing prod DB.
15. Finally, for each DB (dev, val, and prod), verify the upgrade finished successfully by logging in with `psql` while on the VPN, then run the command `SELECT version();`. You should see a version string indicating "15.8" as the new version.

You do not need to undo the API Gateway maintenance mode changes- Serverless will handle it automatically as the deploy finishes.