### PR TITLE
EREGCSC-2904 Set statement_timeout back to 10 seconds

### DIFF
--- a/solution/backend/cmcs_regulations/settings/deploy.py
+++ b/solution/backend/cmcs_regulations/settings/deploy.py
@@ -14,7 +14,7 @@ DATABASES = {
         **default_database_values,
         'NAME': os.environ.get('DB_NAME', 'eregs'),
         'OPTIONS': {
-            'connect_timeout': 20,
+            'connect_timeout': 10,
         },
     },
     'postgres': {

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -272,7 +272,7 @@ resources:
           random_page_cost: 1
           track_activity_query_size: 16384
           idle_in_transaction_session_timeout: 7200000
-          statement_timeout: 20000
+          statement_timeout: 10000
           search_path: '"$user",public'
           log_hostname: 1
           pgaudit.role: "rds_pgaudit"

--- a/solution/backend/serverless.yml
+++ b/solution/backend/serverless.yml
@@ -251,6 +251,7 @@ resources:
         Family: aurora-postgresql15
         Parameters:
           rds.force_ssl: 1
+          statement_timeout: 10000  # Required for ATO compliance
 
     AuroraRDSInstanceParameter15:
       Type: AWS::RDS::DBParameterGroup
@@ -272,7 +273,7 @@ resources:
           random_page_cost: 1
           track_activity_query_size: 16384
           idle_in_transaction_session_timeout: 7200000
-          statement_timeout: 10000
+          statement_timeout: 10000  # Required for ATO compliance
           search_path: '"$user",public'
           log_hostname: 1
           pgaudit.role: "rds_pgaudit"


### PR DESCRIPTION
Resolves #2904

**Description-**

To be ATO compliant, our Postgres timeouts must be no greater than 10 seconds. Due to inefficiencies in prior API versions leading to DB timeouts, we increased this timeout to 20 seconds but never reset it back down.

**This pull request changes...**

- Set `statement_timeout` to 10000 (10 seconds) in Serverless config.
- Set `connect_timeout` to 10 seconds in deploy config.

**Steps to manually verify this change...**

To verify the cluster parameter group has the correct parameter value:

1. Log into AWS -> RDS.
2. Go to prod DB cluster, then click the Configuration tab.
3. Click the link under "DB cluster parameter group".
4. Under the "Filter parameters" text box, enter "statement_timeout".
5. You should see the `statement_timeout` setting with a value of 10000.

To verify the parameter is taking effect:

1. On the VPN, log into the DB with the command `psql -h <HOSTNAME> -d eregs -U eregsuser -p 3306`.
2. Run the command `SELECT setting FROM pg_settings WHERE name = 'statement_timeout';`.
3. You should see a result of `10000` come back.

