### PR TITLE
EREGCSC-2905 -- Automate prompts for major updates for key components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,23 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 1
-    ignore: 
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
+    # Enable version updates for npm
+    - package-ecosystem: "npm"
+      # Look for `package.json` and `lock` files in the `root` directory
+      directory: "/"
+      # Check the npm registry for updates every day (weekdays)
+      schedule:
+          interval: "daily"
+      # Limit the number of open pull requests to 1
+      open-pull-requests-limit: 1
+      # Increase the minimum version for all npm dependencies
+      versioning-strategy: "increase"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      open-pull-requests-limit: 1
+      ignore:
+          - dependency-name: "*"
+            update-types: ["version-update:semver-patch"]

--- a/.github/workflows/deploy-experimental.yml
+++ b/.github/workflows/deploy-experimental.yml
@@ -567,7 +567,7 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-22.04
-    needs: build-and-deploy-vue
+    needs: [deploy-django, build-and-deploy-vue]
     steps:
       - name: Find PR number
         uses: jwalton/gh-find-current-pr@v1

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SelectedSubjectChip.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SelectedSubjectChip.test.js
@@ -7,7 +7,7 @@ describe("SelectedSubjectChip", () => {
         const parent1 = "subjects";
         expect(SelectedSubjectChip.getButtonTextClasses(parent1)).toStrictEqual(
             {
-                "subjects-li__button-text--sidebar": true,
+                "subjects-li__button-text--sidebar": false,
             }
         );
 

--- a/solution/ui/regulations/eregs-vite/src/components/subjects/SelectedSubjectChip.test.js
+++ b/solution/ui/regulations/eregs-vite/src/components/subjects/SelectedSubjectChip.test.js
@@ -7,7 +7,7 @@ describe("SelectedSubjectChip", () => {
         const parent1 = "subjects";
         expect(SelectedSubjectChip.getButtonTextClasses(parent1)).toStrictEqual(
             {
-                "subjects-li__button-text--sidebar": false,
+                "subjects-li__button-text--sidebar": true,
             }
         );
 


### PR DESCRIPTION
Resolves [EREGCSC-2905](https://jiraent.cms.gov/browse/EREGCSC-2905)

**Description**

Make Dependabot a bit more aggressive when it comes to upgrading our `npm` dependencies.  

To do this, we will allow dependabot to create pull requests every weekday, but will limit the number of open pull requests to one.  This way, we can move as fast as we want with these PRs -- we can have a new one every day if needed, or we can allow an open PR to sit for several days before being reviewed without worrying about new PRs being created.

**This pull request changes:**

- Adds section to `dependabot.yml` for `npm` ecosystem
- Sets pull request creation interval to `daily` (weekdays)
- Limits open PRs for `npm` ecosystem to `1` (one)
- Increase minimum required version in `package.json` to the recently updated version

**Steps to manually verify this change:**

1. Green check marks
2. `npm` ecosystem pull requests are created more often than we're used to seeing them

