### PR TITLE
EREGCSC-2739 -- Link sign-in page to account access instructions

### DIFF
--- a/solution/backend/regulations/templates/regulations/login.html
+++ b/solution/backend/regulations/templates/regulations/login.html
@@ -1,32 +1,26 @@
 {% extends "regulations/base.html" %}
 {% load static %}
-
 {% block custom_styles %}
     <link rel="stylesheet" href="{% static '/vite/index.css' %}" />
 {% endblock %}
-
-{% block title_prefix %}Single sign-on to CMCS | {% endblock %}
-
+{% block title_prefix %}Single sign-on to CMCS |{% endblock %}
 {% block header %}
     {% include "regulations/partials/header.html" with location="login_page" %}
 {% endblock %}
-
 {% block body %}
-<div class="login-container">
-    <div class="nav-container">
-        <div class="content">
-            <h1>Sign in with your CMS account</h1>
-        </div>
-    </div>
-    <div>
+    <div class="site-container">
         <main class="login">
-            <form action="{% url 'oidc_authentication_init' %}" method="get">
-                <input type="hidden" name="next" value="{{ next }}">
-                <button type="submit" class="action-btn default-btn">Continue to CMS IDM</button>
-            </form>
-            <p>Requires an eRegulations job code, available to Policy Repository pilot participants.</p>
-            <p>For help, contact <a href="mailto:stephanie.boyd@cms.hhs.gov">stephanie.boyd@cms.hhs.gov</a> or <a href="mailto:julian.rodriguez@a1msolutions.com">julian.rodriguez@a1msolutions.com</a>.</p>
+            <section>
+                <h1>Sign in with your CMS account</h1>
+                <form action="{% url 'oidc_authentication_init' %}" method="get">
+                    <input type="hidden" name="next" value="{{ next }}">
+                    <button type="submit" class="action-btn default-btn">Continue to CMS IDM</button>
+                </form>
+                <p>Requires an eRegulations job code, available to Policy Repository pilot participants.</p>
+                <p>
+                    For help, contact <a href="mailto:stephanie.boyd@cms.hhs.gov">stephanie.boyd@cms.hhs.gov</a> or <a href="mailto:julian.rodriguez@a1msolutions.com">julian.rodriguez@a1msolutions.com</a>.
+                </p>
+            </section>
         </main>
     </div>
-</div>
 {% endblock %}

--- a/solution/backend/regulations/templates/regulations/login.html
+++ b/solution/backend/regulations/templates/regulations/login.html
@@ -16,9 +16,8 @@
                     <input type="hidden" name="next" value="{{ next }}">
                     <button type="submit" class="action-btn default-btn">Continue to CMS IDM</button>
                 </form>
-                <p>Requires an eRegulations job code, available to Policy Repository pilot participants.</p>
                 <p>
-                    For help, contact <a href="mailto:stephanie.boyd@cms.hhs.gov">stephanie.boyd@cms.hhs.gov</a> or <a href="mailto:julian.rodriguez@a1msolutions.com">julian.rodriguez@a1msolutions.com</a>.
+                    New to signing in to eRegulations? <a href="{% url 'get_account_access' %}">Get account access</a>.
                 </p>
             </section>
         </main>

--- a/solution/backend/regulations/templates/regulations/login.html
+++ b/solution/backend/regulations/templates/regulations/login.html
@@ -16,9 +16,7 @@
                     <input type="hidden" name="next" value="{{ next }}">
                     <button type="submit" class="action-btn default-btn">Continue to CMS IDM</button>
                 </form>
-                <p>
-                    New to signing in to eRegulations? <a href="{% url 'get_account_access' %}">Get account access</a>.
-                </p>
+                <p data-testid="new-user-msg">New to signing in to eRegulations? <a data-testid="new-user-link" href="{% url 'get_account_access' %}">Get account access</a>.</p>
             </section>
         </main>
     </div>

--- a/solution/ui/e2e/cypress/e2e/custom-login-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/custom-login-page.cy.js
@@ -17,6 +17,28 @@ describe("custom login page", { scrollBehavior: "center" }, () => {
         cy.get(".header--sign-in span.disabled").should("exist");
     });
 
+    it("custom-login-page - renders a custom login page", () => {
+        cy.viewport("macbook-15");
+        cy.visit("/login");
+        cy.get(".login h1").should(
+            "have.text",
+            "Sign in with your CMS account",
+        );
+        cy.get(".login form")
+            .should("exist")
+            .and("have.text", "Continue to CMS IDM");
+        cy.get("p[data-testid='new-user-msg']").should(
+            "have.text",
+            "New to signing in to eRegulations? Get account access.",
+        );
+        cy.get("a[data-testid='new-user-link']")
+            .should("have.text", "Get account access")
+            .and("have.attr", "href")
+            .and("include", "/get-account-access");
+        cy.get("a[data-testid='new-user-link']").click();
+        cy.url().should("include", "/get-account-access");
+    });
+
     it("custom-login-page - jumps to a regulation Part using the jump-to select", () => {
         cy.viewport("macbook-15");
         cy.visit("/login");

--- a/solution/ui/regulations/css/scss/partials/_login.scss
+++ b/solution/ui/regulations/css/scss/partials/_login.scss
@@ -9,6 +9,7 @@ main.login {
     margin: var(--spacer-3) auto var(--spacer-7);
     max-width: var(--text-max-width);
     max-height: 100%;
+
     button.action-btn.default-btn {
         margin-top: 16px;
         color: #fff;


### PR DESCRIPTION
Resolves [EREGCSC-2739](https://jiraent.cms.gov/browse/EREGCSC-2739)

**Description**

If a person visits our sign in page and doesn't have access to internal eRegs materials, we want to offer convenient instructions for how to get access. To do this, the sign page should give a brief bit of explanation with a link to the instructions.

**This pull request changes:**

- Refactors HTML markup in Custom Sign In page to match tag hierarchy found in `/about` and `/get-account-access` pages
- Updates copy text below CMS IDM button
   - Removes email addresses
   - Adds link to new "Get Account Access" page on eRegs
- Expands Cypress end to end test suite for custom login page to verify changes listed above

**Steps to manually verify this change:**

1. Green check marks
2. Visit [experimental deployment](https://3tc79jp3ma.execute-api.us-east-1.amazonaws.com/dev1519)
3. Go to `/login` page
4. Compare to[ Figma comp](https://www.figma.com/proto/RonM8dMInKz3ZliDACzr96/Logged-Out?page-id=121%3A6697&node-id=121-14139&t=VO6BQ7jJC98hL0GT-0&scaling=min-zoom&starting-point-node-id=122%3A9055&hide-ui=1)
5. Ensure copy text matches AC in JIRA story
   - "New to signing in to eRegulations? Get account access."
6. Ensure "Get account access" link take you to `/get-account-access`

