### PR TITLE
EREGCSC-2905-A -- Increment open Pull Request limit to 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,19 @@ updates:
       open-pull-requests-limit: 2
       # Increase the minimum version for all npm dependencies
       versioning-strategy: "increase"
+      groups:
+          vite:
+            patterns:
+              - "vite"
+          vuetify:
+            patterns:
+              - "vuetify*"
+          vue:
+            patterns:
+              - "vue*"
+          vitest:
+            patterns:
+              - "vitest*"
 
     - package-ecosystem: "github-actions"
       directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       schedule:
           interval: "daily"
       # Limit the number of open pull requests to 1
-      open-pull-requests-limit: 1
+      open-pull-requests-limit: 2
       # Increase the minimum version for all npm dependencies
       versioning-strategy: "increase"
 
@@ -21,7 +21,7 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
-      open-pull-requests-limit: 1
+      open-pull-requests-limit: 2
       ignore:
           - dependency-name: "*"
             update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Resolves [EREGCSC-2905](https://jiraent.cms.gov/browse/EREGCSC-2905)

**Description**

Further refinement of Dependabot configuration work.  The expectation was that each defined `package-ecosystem` would have a maximum of one PR open; with two `package-ecosystems` defined, the expected number of PRs open at any given time would be a maximum of two.

Instead, we're only seeing one pull request.  We'd like to tweak this setting to get two PRs open concurrently.

**This pull request changes:**

- updates `open-pull-request-limit` to `2` for each package ecosystem
- Adds `groups` option to group certain dependencies together into a single pull request

**Steps to manually verify this change:**

1. Green check marks
2. Merge to `main` and see if a second dependabot PR joins the currently open one

