### PR TITLE
[Hotfix] EREGCSC-2734 -- Hide Get Account Access link when logged in on Subjects/Statutes page

### DIFF
--- a/solution/ui/e2e/cypress/e2e/get-access-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/get-access-page.cy.js
@@ -1,6 +1,12 @@
 const username = Cypress.env("TEST_USERNAME");
 const password = Cypress.env("TEST_PASSWORD");
 
+Cypress.Commands.add("checkHeaderLink", ({ shouldBeVisible = false }) => {
+    const desiredState = shouldBeVisible ? "exist" : "not.exist";
+    cy.get("a[data-testid='get-account-access-wide']").should(desiredState);
+    cy.get("a[data-testid='get-account-access-narrow']").should(desiredState);
+});
+
 describe("Get Account Access page", { scrollBehavior: "center" }, () => {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -20,15 +26,15 @@ describe("Get Account Access page", { scrollBehavior: "center" }, () => {
     it("goes to the Get Account Access page from homepage", () => {
         cy.viewport("macbook-15");
         cy.visit("/");
-        cy.get("a[data-testid='get-account-access-narrow']")
-            .should("not.be.visible");
+        cy.get("a[data-testid='get-account-access-narrow']").should(
+            "not.be.visible",
+        );
         cy.get("a[data-testid='get-account-access-wide']")
             .should("be.visible")
             .and("have.text", "Get Account Access")
             .and("have.attr", "class")
             .and("not.match", /active/);
-        cy.get("a[data-testid='get-account-access-wide']")
-            .click();
+        cy.get("a[data-testid='get-account-access-wide']").click();
         cy.url().should("include", "/get-account-access/");
         cy.get("a[data-testid='get-account-access-wide']")
             .should("be.visible")
@@ -41,16 +47,16 @@ describe("Get Account Access page", { scrollBehavior: "center" }, () => {
     it("goes to the Get Account Access page from a SPA page like /subjects", () => {
         cy.viewport("macbook-15");
         cy.visit("/subjects");
-        cy.get("a[data-testid='get-account-access-wide']")
-            .click();
+        cy.get("a[data-testid='get-account-access-wide']").click();
         cy.url().should("include", "/get-account-access/");
     });
 
     it("should have a shorter header label on narrow screens", () => {
         cy.viewport("iphone-x");
         cy.visit("/");
-        cy.get("a[data-testid='get-account-access-wide']")
-            .should("not.be.visible");
+        cy.get("a[data-testid='get-account-access-wide']").should(
+            "not.be.visible",
+        );
         cy.get("a[data-testid='get-account-access-narrow']")
             .should("be.visible")
             .and("have.text", "Get Access")
@@ -61,11 +67,29 @@ describe("Get Account Access page", { scrollBehavior: "center" }, () => {
 
     it("should not show the header link when logged in", () => {
         cy.viewport("macbook-15");
+        cy.visit("/");
+        cy.checkHeaderLink({ shouldBeVisible: true });
+
+        cy.visit("/search");
+        cy.checkHeaderLink({ shouldBeVisible: true });
+
+        cy.visit("/subjects");
+        cy.checkHeaderLink({ shouldBeVisible: true });
+
+        cy.visit("/statutes");
+        cy.checkHeaderLink({ shouldBeVisible: true });
+
         cy.eregsLogin({ username, password, landingPage: "/" });
-        cy.get("a[data-testid='get-account-access-wide']")
-            .should("not.exist");
-        cy.get("a[data-testid='get-account-access-narrow']")
-            .should("not.exist");
+        cy.checkHeaderLink({ shouldBeVisible: false });
+
+        cy.visit("/search");
+        cy.checkHeaderLink({ shouldBeVisible: false });
+
+        cy.visit("/subjects");
+        cy.checkHeaderLink({ shouldBeVisible: false });
+
+        cy.visit("/statutes");
+        cy.checkHeaderLink({ shouldBeVisible: false });
     });
 
     // if subjects page works, statutes and search do as well

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -168,7 +168,7 @@ getStatutesArray();
                     />
                 </template>
                 <template #get-access>
-                    <AccessLink class="header__access-link" :base="homeUrl" />
+                    <AccessLink v-if="!isAuthenticated" :base="homeUrl" />
                 </template>
             </HeaderComponent>
         </header>

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -388,7 +388,7 @@ getDocSubjects();
                     />
                 </template>
                 <template #get-access>
-                    <AccessLink class="header__access-link" :base="homeUrl" />
+                    <AccessLink v-if="!isAuthenticated" :base="homeUrl" />
                 </template>
             </HeaderComponent>
         </header>


### PR DESCRIPTION
Fixes defect found after deploying [EREGCCS-2734](https://jiraent.cms.gov/browse/EREGCSC-2734) to `prod`

**Description**

The "Get Account Access" link in the top left corner of the header should only be visible if the user is not logged in.  Once the user logs in, the "Get Account Access" link should not exist.

Currently, the Subjects and Statutes pages are still showing the "Get Account Access" link in the header when logged in.

**This pull request changes:**

- Adds `v-if` directive to `AccessLink` component when used on Subjects and Statutes pages.
   - The `v-if` directive conditionally renders the component if the directive's expression is truthy
   - The `isAuthenticated` prop is being used in the directive's expression: `!isAuthenticated` must be truthy for the component to render.
   - This expression was present in the Search page, but missing from the Subjects and Statutes page.
- Adds Cypress end to end tests to ensure "Get Account Access" link exists or does not exist where expected

**Steps to manually verify this change...**

1. Green check marks
2. Before logging in, explore around the site and note that the "Get Account Access" link is visible in the header everywhere you go
3. Log in
4. Explore around the site to ensure that "Get Account Access" link in header is not visible when visiting all areas of the experimental deployment while logged
5. Pay special attention to `/subjects` and `/statutes` -- this is where the defect occurs. When logged in, you should not see the "Get Account Access" link on these pages.

