### PR TITLE
EREGCSC-2905-B -- Add list of directories for npm ecosystem package.json locations in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
           interval: "daily"
       # Limit the number of open pull requests to 1
       open-pull-requests-limit: 2
-      # Increase the minimum version for all npm dependencies
-      versioning-strategy: "increase"
       groups:
           vite:
             patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,21 @@
 
 version: 2
 updates:
-    # Enable version updates for npm
+    # Enable version updates for npm dependencies in root of front end project
     - package-ecosystem: "npm"
-      # Look for `package.json` and `lock` files in the `root` directory
-      directory: "/"
+      # Look for `package.json` and `lock` files
+      directories:
+        - "/solution/ui/e2e" # Cypress tests
+        - "/solution/ui/regulations" # Vitest, bundling
+        - "/solution/ui/regulations/eregs-component-lib" # Django template components
+        - "/solution/ui/regulations/eregs-vite" # Single Page App dependencies
       # Check the npm registry for updates every day (weekdays)
       schedule:
           interval: "daily"
       # Limit the number of open pull requests to 1
       open-pull-requests-limit: 2
+      # Increase the minimum version for all npm dependencies
+      versioning-strategy: "increase"
       groups:
           vite:
             patterns:

--- a/solution/ui/e2e/cypress/e2e/part.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/part.spec.cy.js
@@ -287,6 +287,9 @@ describe("Part View", () => {
     });
 
     it("loads reg history tooltip correctly", () => {
+        cy.intercept("**/v3/title/42/part/433/history/section/8", {
+            fixture: "42.433.history.json",
+        }).as("history433");
         cy.viewport("macbook-15");
         cy.visit("/42/433/");
         cy.contains("Subpart A").click({ force: true });
@@ -300,17 +303,12 @@ describe("Part View", () => {
         cy.get(
             "#433-8 .reg-history-link-container .tooltip.clicked .tooltip-title"
         ).contains("View § 433.8 Effective In");
-        // this next assertion is based on actual data returned from the API
-        // it recently broke because the latest year changed from 2021 to 2022
-        // so I'm commenting it out for now until we can figure out a better way
-        //cy.get(
-        //"#433-8 .reg-history-link-container .tooltip.clicked .gov-info-links a:nth-child(1)"
-        //).contains("2021");
         cy.get(
             "#433-8 .reg-history-link-container .tooltip.clicked .gov-info-links a:nth-child(1)"
         )
             .should("have.attr", "href")
-            .and("include", "govinfo.gov");
+            .and("include", "govinfo.gov")
+            .and("include", "CFR-1997");
         cy.get(
             "#433-8 .reg-history-link-container .tooltip.clicked button.close-btn"
         ).click({ force: true });

--- a/solution/ui/e2e/cypress/fixtures/42.433.history.json
+++ b/solution/ui/e2e/cypress/fixtures/42.433.history.json
@@ -1,0 +1,10 @@
+[
+    {
+        "link": "https://www.govinfo.gov/content/pkg/CFR-1996-title42-vol3/pdf/CFR-1996-title42-vol3-sec433-8.pdf",
+        "year": "1996"
+    },
+    {
+        "link": "https://www.govinfo.gov/content/pkg/CFR-1997-title42-vol3/pdf/CFR-1997-title42-vol3-sec433-8.pdf",
+        "year": "1997"
+    }
+]


### PR DESCRIPTION
Resolves [EREGCSC-2905](https://jiraent.cms.gov/browse/EREGCSC-2905)

**Description**

Further refinement of Dependabot configuration work.

Since we began updating the `dependabot.yml` file, we've been seeing some [failures of the Dependabot Github Action](https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/workflows/dependabot/dependabot-updates).  The [error](https://github.com/Enterprise-CMCS/cmcs-eregulations/network/updates/952232478) is:

```
Dependabot couldn't find a package.json
Dependabot requires a package.json to evaluate your JavaScript dependencies. It had expected to find one at the path: /package.json.
```

To attempt to fix this error, `dependabot.yml` is being updated to use the `directories` option to specify locations of multiple `package.json` files.

See:
- [Controlling which dependencies are updated by Dependabot / Defining multiple locations for manifest files](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files) (Github Docs)
- [Existing `dependabot.yml` example with multiple `directories`](https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/.github/dependabot.yml)
- [Long Github Issues discussion about `groups` and `directories` options](https://github.com/dependabot/dependabot-core/issues/2178)

**This pull request changes:**

- Changes `directory: "/"` to `directories: <list/of/directories>` for `npm` package ecosystem
- Updates Cypress test in `part` test suite to mock async call to `/v3/title/{title}/part/{part}/history/section/{section}` endpoint
   - Adds related fixture file

**Steps to manually verify this change:**

1. Green check marks
2. Dependabot action does not fail
