### PR TITLE
EREGCSC-2687 Fix for items with identical ranks being sorted in an undefined way

### DIFF
--- a/solution/backend/content_search/models.py
+++ b/solution/backend/content_search/models.py
@@ -66,7 +66,7 @@ class ContentIndexQuerySet(models.QuerySet):
             RawSQL("vector_column", [], output_field=SearchVectorField()),
             self._get_search_query_object(search_query), cover_density=cover_density))\
             .filter(rank__gt=rank_filter)\
-            .order_by('-rank')
+            .order_by('-rank', '-id')
 
     def generate_headlines(self, search_query):
         query_object = self._get_search_query_object(search_query)


### PR DESCRIPTION
Resolves #2687

**Description-**

A while back we noticed an issue where differing page sizes would be sorted differently. Today a bug popped up where two nearly identical searches are being sorted differently. The only difference was that `show_internal` and `show_regulations` were both changed from true to false, as public items were _always_ first in this particular search.

Noticed that the items in question had identical ranks (0.9999997) and realized that we are only sorting by rank and not specifying a secondary sort parameter for items with identical rank.

This PR fixes this (for now) by changing `order_by("-rank")` to `order_by("-rank", "-id")`. In theory this is a good approximation of sort by date as larger IDs should represent newer documents. In the future, we need to find a way to represent a date field in the Content Index model so we can do a proper sort by date for all Resource subtypes, but not Reg Text.

**This pull request changes...**

- Added `-id` to the search result `order_by`, after `-rank`.

**Steps to manually verify this change...**

1. Go to the experimental deploy.
2. Log in to the admin panel, then navigate to the search page.
3. Search for `managed care SNP`, and take note of the first few items which are all "public" resources.
4. Click the "Public Resources" checkbox and wait for the page to reload.
5. Ensure that the first few "public" resources are the same as before.

