### PR TITLE
EREGCSC-2905-C -- Reduce number of open pull requests per ecosystem to one

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       schedule:
           interval: "daily"
       # Limit the number of open pull requests to 1
-      open-pull-requests-limit: 2
+      open-pull-requests-limit: 1
       # Increase the minimum version for all npm dependencies
       versioning-strategy: "increase"
       groups:
@@ -38,7 +38,7 @@ updates:
       directory: "/"
       schedule:
           interval: "weekly"
-      open-pull-requests-limit: 2
+      open-pull-requests-limit: 1
       ignore:
           - dependency-name: "*"
             update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Resolves [EREGCSC-2905](https://jiraent.cms.gov/browse/EREGCSC-2905)

**Description**

Further refinement of Dependabot configuration work.

Recent changes to our `dependabot.yml` config file have made Dependabot more aggressive.  That's good!

However, we'd like it to be a tiny but less aggressive by restricting the number of open pull requests per package ecosystem (npm, GitHub actions, etc) to one.

**This pull request changes:**

- Reduces `open-pull-requests-limit` option for each package ecosystem to `1`

**Steps to manually verify this change:**

1. Green check marks
2. Merge to `main` and verify that no more than one `npm` pull request is open at a single time

