### PR TITLE
EREGCSC-2939 -- Add reader job code to "Get Account Access" page

### DIFF
--- a/solution/backend/regulations/templates/regulations/get_account_access.html
+++ b/solution/backend/regulations/templates/regulations/get_account_access.html
@@ -57,8 +57,18 @@
                                 Select <strong>Job Code</strong> from the first drop-down menu.
                             </li>
                             <li>Select = from the middle drop-down menu.</li>
-                            <li>Type or copy EREGS_EDITOR_PRD into the empty field.</li>
-                            <li>Click Search to the right of the job code field.</li>
+                            <li>
+                                Type or copy <em>one</em> of the following job codes into the empty field:
+                                <ol type="i">
+                                    <li>
+                                        To view internal documents (default for most staff): <strong>EREGS_READER_PRD</strong>
+                                    </li>
+                                    <li>
+                                        To view, add, and remove internal documents (if directed by your leadership): <strong>EREGS_EDITOR_PRD</strong>
+                                    </li>
+                                </ol>
+                            </li>
+                            <li>Click <strong>Search</strong> to the right of the job code field.</li>
                         </ol>
                     </li>
                     <li>


### PR DESCRIPTION
Resolves [EREGCSC-2939](https://jiraent.cms.gov/browse/EREGCSC-2939)

**Description**

We want to encourage potential repository users to request the EREGS_READER_PRD job code (which has been re-created), along with EREGS_EDITOR_PRD.

**This pull request changes:**

- Updates copy text on Get Account Access page with new nested ordered list with new job code and description.

**Steps to manually verify this change:**

1. Green check marks
2. Visit experimental deployment an click Get Account Access
3. Step 5 of "Request access for CMCS staff" now has two job codes with associated descriptions: reader and editor
4. Copy test matches text in JIRA story AC

