### PR TITLE
EREGCSC-2859-I Remove if conditions on dev deploy lambda invoke

### DIFF
--- a/.github/workflows/deploy-cdk-dev.yml
+++ b/.github/workflows/deploy-cdk-dev.yml
@@ -188,7 +188,6 @@ jobs:
           popd
 
       - name: Invoke setup functions after site lambdas deployed
-        if: success() && steps.findPr.outputs.number
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
Resolves #2859

**Description-**

Previous deploy to dev skipped the lambda invoke step (migrate, createsu) due to an accidentally copied `if` statement in the action that can't ever be true because it's not a pull request.

**This pull request changes...**

- Removed the `if` statement so lambda invoke can run.

**Steps to manually verify this change...**

1. Approve and deploy.
2. In the "Deploy CDK to DEV" action, verify the step "Invoke setup functions after site lambdas deployed" runs and has a green check.
3. Check the CDK dev site to make sure migration completed. (No 500 error.)

