### PR TITLE
EREGCSC-2859-J Add SG for VPN access to the database, rearrange remove steps

### DIFF
--- a/.github/workflows/remove-experimental-cdk.yml
+++ b/.github/workflows/remove-experimental-cdk.yml
@@ -39,29 +39,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1
-      - name: Destroy PR-Specific Static-Asset Stack
-        env:
-            PR_NUMBER: ${{ github.event.number }}
-            AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-            AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
-            CDK_DEBUG: true
-            ENVIRONMENT_NAME: ${{ env.ENVIRONMENT_NAME }}
-        run: |
-            pushd cdk-eregs
-            npm install -g aws-cdk@latest @aws-sdk/client-ssm
-            npm install
-            
-            # Generate the exact stack name for this PR
-            STACK_NAME="cms-eregs-eph-${PR_NUMBER}-static-assets"
-            
-            echo "Destroying PR-specific stack: ${STACK_NAME}"
-            cdk destroy "${STACK_NAME}" \
-            -c environment=${{ env.ENVIRONMENT_NAME }} \
-            --force \
-            --app "npx ts-node bin/zip-lambdas.ts"
-            
-            echo "Cleanup completed for stack: ${STACK_NAME}"
-            popd
+      
       - name: Destroy PR-Specific Redirect Stack
         env:
           PR_NUMBER: ${{ github.event.number }}
@@ -132,12 +110,7 @@ jobs:
           FR_PARSER_STACK="cms-eregs-eph-${PR_NUMBER}-fr-parser"
           ECFR_PARSER_STACK="cms-eregs-eph-${PR_NUMBER}-ecfr-parser"
           API_STACK="cms-eregs-eph-${PR_NUMBER}-api"
-          # Destroy text-extractor stack
-          echo "Destroying PR-specific stack: ${TEXT_EXTRACTOR_STACK}"
-          cdk destroy "${TEXT_EXTRACTOR_STACK}" \
-          -c environment=${{ env.ENVIRONMENT_NAME }} \
-          --force \
-          --app "npx ts-node bin/docker-lambdas.ts"
+          
           
           # Destroy fr-parser stack
           echo "Destroying PR-specific stack: ${FR_PARSER_STACK}"
@@ -159,6 +132,34 @@ jobs:
           -c environment=${{ env.ENVIRONMENT_NAME }} \
           --force \
           --app "npx ts-node bin/docker-lambdas.ts"
-          
+          # Destroy text-extractor stack
+          echo "Destroying PR-specific stack: ${TEXT_EXTRACTOR_STACK}"
+          cdk destroy "${TEXT_EXTRACTOR_STACK}" \
+          -c environment=${{ env.ENVIRONMENT_NAME }} \
+          --force \
+          --app "npx ts-node bin/docker-lambdas.ts"
           echo "Cleanup completed for all Docker-based stacks"
           popd
+      - name: Destroy PR-Specific Static-Asset Stack
+        env:
+            PR_NUMBER: ${{ github.event.number }}
+            AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+            AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+            CDK_DEBUG: true
+            ENVIRONMENT_NAME: ${{ env.ENVIRONMENT_NAME }}
+        run: |
+            pushd cdk-eregs
+            npm install -g aws-cdk@latest @aws-sdk/client-ssm
+            npm install
+            
+            # Generate the exact stack name for this PR
+            STACK_NAME="cms-eregs-eph-${PR_NUMBER}-static-assets"
+            
+            echo "Destroying PR-specific stack: ${STACK_NAME}"
+            cdk destroy "${STACK_NAME}" \
+            -c environment=${{ env.ENVIRONMENT_NAME }} \
+            --force \
+            --app "npx ts-node bin/zip-lambdas.ts"
+            
+            echo "Cleanup completed for stack: ${STACK_NAME}"
+            popd

--- a/solution/backend/serverless_functions/experimental_functions.yml
+++ b/solution/backend/serverless_functions/experimental_functions.yml
@@ -37,7 +37,6 @@ reg_core_migrate:
 create_database:
   environment:
     STAGE: ${self:custom.stage}
-    DB_NAME: eregs
   handler: createdb.handler
   timeout: 300
   layers:
@@ -45,7 +44,6 @@ create_database:
 drop_database:
   environment:
     STAGE: ${self:custom.stage}
-    DB_NAME: eregs
   handler: dropdb.handler
   timeout: 300
   layers:


### PR DESCRIPTION

Description
Adds required security groups to the RDS cluster via SSM parameters to enable VPN access to the database.
This pull request changes...

Adds AWS SSM parameter lookups for required security groups
Imports and attaches three additional security groups to RDS cluster:

CMS Cloud Shared Services
CMS Cloud VPN
CMS Cloud Security Tools


Configures security groups via SSM parameters for flexible management

Steps to manually verify this change...

Deploy the stack and verify the RDS cluster has all security groups attached
Check AWS Console > RDS > DB Security Groups to confirm presence of:

Database-specific security group
cmscloud-shared-services
cmscloud-vpn
cmscloud-security-tools


Attempt to connect to the database via VPN to verify access is working

Reorders stack destruction sequence to respect CloudFormation export dependencies:

Redirect API Stack
Maintenance API Stack
Docker Lambda Stacks (Text Extractor, FR Parser, eCFR Parser, API)
Static Assets Stack