### PR TITLE
EREGCSC-2922 Advance CDK deploy to val account

### DIFF
--- a/.github/workflows/deploy-cdk.yml
+++ b/.github/workflows/deploy-cdk.yml
@@ -1,4 +1,4 @@
-name: Deploy CDK to DEV
+name: Deploy CDK
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ jobs:
     strategy:      
       max-parallel: 1      
       matrix:        
-        environment: ["dev"]    
+        environment: ["dev", "val"]
     runs-on: ubuntu-22.04    
     environment:      
       name: ${{ matrix.environment }}
@@ -70,7 +70,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: ["dev"]
+        environment: ["dev", "val"]
     runs-on: ubuntu-22.04
     environment:
       name: ${{ matrix.environment }}
@@ -111,7 +111,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: ["dev"]
+        environment: ["dev", "val"]
     runs-on: ubuntu-22.04
     environment:
       name: ${{ matrix.environment }}
@@ -149,7 +149,7 @@ jobs:
     strategy:      
       max-parallel: 1      
       matrix:        
-        environment: ["dev"]    
+        environment: ["dev", "val"]    
     runs-on: ubuntu-22.04    
     environment:      
       name: ${{ matrix.environment }}
@@ -213,7 +213,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: ["dev"]
+        environment: ["dev", "val"]
     runs-on: ubuntu-22.04
     environment:
       name: ${{ matrix.environment }}
@@ -252,7 +252,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: ["dev"]
+        environment: ["dev", "val"]
     runs-on: ubuntu-22.04
     environment:
       name: ${{ matrix.environment }}
@@ -291,7 +291,7 @@ jobs:
     strategy:      
       max-parallel: 1      
       matrix:        
-        environment: ["dev"]    
+        environment: ["dev", "val"]    
     runs-on: ubuntu-22.04    
     environment:      
       name: ${{ matrix.environment }}

--- a/.github/workflows/deploy-cdk.yml
+++ b/.github/workflows/deploy-cdk.yml
@@ -193,11 +193,10 @@ jobs:
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
           CDK_DEBUG: true
         run: |
-          # This unusual bash syntax is necessary because the AWS CLI doesn't return a non-zero exit code when the lambda fails.
-          # If lambda fails, "FunctionError" will be present in the stdout output. First copy the output to stderr so we can see it,
-          # then grep for "FunctionError" and fail if it's present (grep returns 0 if it finds the string, then we invert that with '!')
-          ! aws lambda invoke --function-name cms-eregs-${{ matrix.environment }}-migrate /dev/stdout | tee /dev/stderr | grep FunctionError > /dev/null
-          ! aws lambda invoke --function-name cms-eregs-${{ matrix.environment }}-createsu /dev/stdout | tee /dev/stderr | grep FunctionError > /dev/null
+          aws lambda invoke --function-name cms-eregs-${{ matrix.environment }}-migrate /dev/stdout | tee -a aws.log
+          aws lambda invoke --function-name cms-eregs-${{ matrix.environment }}-createsu /dev/stdout | tee -a aws.log 
+          # Check for invocation errors
+          ! grep -q FunctionError aws.log
 
       - name: Get API URL
         id: get-api-url

--- a/.github/workflows/deploy-experimental-cdk.yml
+++ b/.github/workflows/deploy-experimental-cdk.yml
@@ -399,12 +399,11 @@ jobs:
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
           CDK_DEBUG: true
         run: |
-          # This unusual bash syntax is necessary because the AWS CLI doesn't return a non-zero exit code when the lambda fails.
-          # If lambda fails, "FunctionError" will be present in the stdout output. First copy the output to stderr so we can see it,
-          # then grep for "FunctionError" and fail if it's present (grep returns 0 if it finds the string, then we invert that with '!')
-          ! aws lambda invoke --function-name cms-eregs-eph-$PR_NUMBER-createdb /dev/stdout | tee /dev/stderr | grep FunctionError > /dev/null
-          ! aws lambda invoke --function-name cms-eregs-eph-$PR_NUMBER-migrate /dev/stdout | tee /dev/stderr | grep FunctionError > /dev/null
-          ! aws lambda invoke --function-name cms-eregs-eph-$PR_NUMBER-createsu /dev/stdout | tee /dev/stderr | grep FunctionError > /dev/null
+          aws lambda invoke --function-name cms-eregs-eph-$PR_NUMBER-createdb /dev/stdout | tee -a aws.log
+          aws lambda invoke --function-name cms-eregs-eph-$PR_NUMBER-migrate /dev/stdout | tee -a aws.log
+          aws lambda invoke --function-name cms-eregs-eph-$PR_NUMBER-createsu /dev/stdout | tee -a aws.log
+          # Check for invocation errors
+          ! grep -q FunctionError aws.log
 
       - name: Get API URL
         id: get-api-url

--- a/.github/workflows/remove-experimental-cdk.yml
+++ b/.github/workflows/remove-experimental-cdk.yml
@@ -99,18 +99,16 @@ jobs:
           npm install
 
           # Delete the database for this ephemeral environment
-          # This unusual bash syntax is necessary because the AWS CLI doesn't return a non-zero exit code when the lambda fails.
-          # If lambda fails, "FunctionError" will be present in the stdout output. First copy the output to stderr so we can see it,
-          # then grep for "FunctionError" and fail if it's present (grep returns 0 if it finds the string, then we invert that with '!')
           echo "Deleting database for PR: ${PR_NUMBER}"
-          ! aws lambda invoke --function-name cms-eregs-eph-$PR_NUMBER-dropdb /dev/stdout | tee /dev/stderr | grep FunctionError > /dev/null
+          aws lambda invoke --function-name cms-eregs-eph-$PR_NUMBER-dropdb /dev/stdout | tee -a aws.log
+          # Check for invocation errors
+          ! grep -q FunctionError aws.log
           
           # Generate the stack names for this PR
           TEXT_EXTRACTOR_STACK="cms-eregs-eph-${PR_NUMBER}-text-extractor"
           FR_PARSER_STACK="cms-eregs-eph-${PR_NUMBER}-fr-parser"
           ECFR_PARSER_STACK="cms-eregs-eph-${PR_NUMBER}-ecfr-parser"
           API_STACK="cms-eregs-eph-${PR_NUMBER}-api"
-          
           
           # Destroy fr-parser stack
           echo "Destroying PR-specific stack: ${FR_PARSER_STACK}"


### PR DESCRIPTION
Resolves #2922

**Description-**

CDK is validated in dev, we want to advance to val for further testing and validation before deploying to prod.

**This pull request changes...**

- Rename action "Deploy CDK to Dev" to "Deploy CDK"
- Change matrix in action to permit Github Actions to deploy the CDK version of the site to val
- Semi-related fix: syntax for aws lambda invoke for CDK would silently fail if AWS CLI returned an error before invocation occured

**Steps to manually verify this change...**

1. Approve and merge this PR
2. Check the "Deploy CDK" action for success deploying to dev
3. On success, approve deploy to val
4. Validate successful deploy in val (check AWS console, check the site, etc.)

