### PR TITLE
EREGCSC-2922-D Replace inputs.environment with matrix.environment

### DIFF
--- a/.github/workflows/deploy-cdk.yml
+++ b/.github/workflows/deploy-cdk.yml
@@ -34,7 +34,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1
 
-      - name: Deploy static assets
+      - name: Deploy static assets infrastructure
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
@@ -45,10 +45,10 @@ jobs:
           npm install
           
           # Get exact stack name
-          STATICASSET_STACK="cms-eregs-${{ inputs.environment }}-static-assets"
+          STATICASSET_STACK="cms-eregs-${{ matrix.environment }}-static-assets"
           
           cdk deploy ${STATICASSET_STACK} \
-          -c environment=${{ inputs.environment }} \
+          -c environment=${{ matrix.environment }} \
           -c deploymentType=infrastructure \
           --require-approval never \
           --exclusively \
@@ -60,7 +60,7 @@ jobs:
         id: get-static-url
         run: |
           pushd cdk-eregs
-          STATIC_STACK="cms-eregs-${{ inputs.environment }}-static-assets"
+          STATIC_STACK="cms-eregs-${{ matrix.environment }}-static-assets"
           STATIC_URL=$(cat static-outputs.json | jq -r ".[\"$STATIC_STACK\"].StaticURL")
           echo "static_url=${STATIC_URL}" >> $GITHUB_OUTPUT
           popd
@@ -76,11 +76,11 @@ jobs:
           npm install
           
           # Get exact stack names
-          REDIRECT_STACK="cms-eregs-${{ inputs.environment }}-redirect-api"
-          MAINTENANCE_STACK="cms-eregs-${{ inputs.environment }}-maintenance-api"
+          REDIRECT_STACK="cms-eregs-${{ matrix.environment }}-redirect-api"
+          MAINTENANCE_STACK="cms-eregs-${{ matrix.environment }}-maintenance-api"
           
           cdk deploy ${REDIRECT_STACK} ${MAINTENANCE_STACK} \
-          -c environment=${{ inputs.environment }} \
+          -c environment=${{ matrix.environment }} \
           --require-approval never \
           --exclusively \
           --app "npx ts-node bin/zip-lambdas.ts"
@@ -96,10 +96,10 @@ jobs:
           npm install -g aws-cdk@latest @aws-sdk/client-ssm
           npm install
           
-          TEXT_EXTRACTOR_STACK="cms-eregs-${{ inputs.environment }}-text-extractor"
+          TEXT_EXTRACTOR_STACK="cms-eregs-${{ matrix.environment }}-text-extractor"
           
           cdk deploy $TEXT_EXTRACTOR_STACK \
-          -c environment=${{ inputs.environment }} \
+          -c environment=${{ matrix.environment }} \
           --require-approval never \
           --exclusively \
           --app "npx ts-node bin/docker-lambdas.ts"
@@ -116,10 +116,10 @@ jobs:
           npm install
           
           # Get exact stack name
-          API_STACK="cms-eregs-${{ inputs.environment }}-api"
+          API_STACK="cms-eregs-${{ matrix.environment }}-api"
           
           cdk deploy $API_STACK \
-          -c environment=${{ inputs.environment }} \
+          -c environment=${{ matrix.environment }} \
           -c buildId="${GITHUB_RUN_ID}" \
           --require-approval never \
           --exclusively \
@@ -133,8 +133,8 @@ jobs:
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
           CDK_DEBUG: true
         run: |
-          aws lambda invoke --function-name cms-eregs-${{ inputs.environment }}-migrate /dev/stdout | tee -a aws.log
-          aws lambda invoke --function-name cms-eregs-${{ inputs.environment }}-createsu /dev/stdout | tee -a aws.log 
+          aws lambda invoke --function-name cms-eregs-${{ matrix.environment }}-migrate /dev/stdout | tee -a aws.log
+          aws lambda invoke --function-name cms-eregs-${{ matrix.environment }}-createsu /dev/stdout | tee -a aws.log 
           # Check for invocation errors
           ! grep -q FunctionError aws.log
 
@@ -142,7 +142,7 @@ jobs:
         id: get-api-url
         run: |
           pushd cdk-eregs
-          API_STACK="cms-eregs-${{ inputs.environment }}-api"
+          API_STACK="cms-eregs-${{ matrix.environment }}-api"
           API_URL=$(cat api-outputs.json | jq -r ".[\"$API_STACK\"].ApiUrl")
           API_URL=${API_URL%/}
           echo "api_url=${API_URL}" >> $GITHUB_OUTPUT
@@ -158,10 +158,10 @@ jobs:
           npm install -g aws-cdk@latest @aws-sdk/client-ssm
           npm install
           
-          FR_PARSER_STACK="cms-eregs-${{ inputs.environment }}-fr-parser"
+          FR_PARSER_STACK="cms-eregs-${{ matrix.environment }}-fr-parser"
           
           cdk deploy $FR_PARSER_STACK \
-          -c environment=${{ inputs.environment }} \
+          -c environment=${{ matrix.environment }} \
           --require-approval never \
           --exclusively \
           --app "npx ts-node bin/docker-lambdas.ts"
@@ -177,10 +177,10 @@ jobs:
           npm install -g aws-cdk@latest @aws-sdk/client-ssm
           npm install
           
-          ECFR_PARSER_STACK="cms-eregs-${{ inputs.environment }}-ecfr-parser"
+          ECFR_PARSER_STACK="cms-eregs-${{ matrix.environment }}-ecfr-parser"
           
           cdk deploy $ECFR_PARSER_STACK \
-          -c environment=${{ inputs.environment }} \
+          -c environment=${{ matrix.environment }} \
           --require-approval never \
           --exclusively \
           --app "npx ts-node bin/docker-lambdas.ts"
@@ -212,7 +212,7 @@ jobs:
         env:
           STATIC_URL: ${{ steps.get-static-url.outputs.static_url }}
           STATIC_ROOT: ../static-assets/regulations
-          VITE_ENV: ${{ inputs.environment }}
+          VITE_ENV: ${{ matrix.environment }}
         run: |
           pushd solution/backend
           python manage.py collectstatic --noinput
@@ -223,7 +223,7 @@ jobs:
         env:
           STATIC_URL: ${{ steps.get-static-url.outputs.static_url }}
           STATIC_ROOT: ../static-assets/regulations
-          VITE_ENV: ${{ inputs.environment }}
+          VITE_ENV: ${{ matrix.environment }}
         run: |
           pushd solution
           make regulations
@@ -240,10 +240,10 @@ jobs:
           npm install
           
           # Get exact stack name
-          STATICASSET_STACK="cms-eregs-${{ inputs.environment }}-static-assets"
+          STATICASSET_STACK="cms-eregs-${{ matrix.environment }}-static-assets"
           
           cdk deploy ${STATICASSET_STACK} \
-          -c environment=${{ inputs.environment }} \
+          -c environment=${{ matrix.environment }} \
           -c deploymentType=content \
           --require-approval never \
           --exclusively \


### PR DESCRIPTION
Resolves #2922

**Description-**

The previous PR (#1567) failed because I forgot to replace `inputs.environment` with `matrix.environment`.

**This pull request changes...**

- Replace `inputs.environment` with `matrix.environment`

**Steps to manually verify this change...**

1. Verify it deploys (see #1567 steps)

