### PR TITLE
EREGCSC-2922-E Advance CDK deploy to prod account

### DIFF
--- a/.github/workflows/deploy-cdk.yml
+++ b/.github/workflows/deploy-cdk.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:      
       max-parallel: 1      
       matrix:        
-        environment: ["dev", "val"]
+        environment: ["dev", "val", "prod"]
     environment:
       name: ${{ matrix.environment }}
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Resolves #2922

**Description-**

We have successfully deployed the parallel CDK environment to both dev and val. Now we want to advance it to val for final validation.

**This pull request changes...**

- Permit deploy-cdk action to deploy to dev, val, and prod (with approval interim steps)

**Steps to manually verify this change...**

1. Approve and merge
2. Wait for dev to deploy, approve to val
3. Wait for val to deploy, approve to prod
4. Wait for prod to deploy, then validate

