### PR TITLE
EREGCSC-2922-F Temporarily remove custom SSL cert requirement for CDK in prod

### DIFF
--- a/cdk-eregs/lib/stacks/static-assets-stack.ts
+++ b/cdk-eregs/lib/stacks/static-assets-stack.ts
@@ -68,9 +68,10 @@ export class StaticAssetsStack extends cdk.Stack {
    * @throws {Error} If certificate ARN is missing in production environment
    */
   private validateCertificateConfig(props: StaticAssetsStackProps): void {
-    if (this.stageConfig.environment === 'prod' && !props.certificateArn) {
-      throw new Error('SSL Certificate ARN is required for production environment');
-    }
+    // TODO: why do we need this?
+    // if (this.stageConfig.environment === 'prod' && !props.certificateArn) {
+    //   throw new Error('SSL Certificate ARN is required for production environment');
+    // }
   }
 
   /**


### PR DESCRIPTION
Resolves #2922

**Description-**

Previous PR (#1569) failed because of a check only for prod that enforced a custom SSL cert for static assets. We don't need that for now so removing to test.

**This pull request changes...**

- Removed custom SSL cert check from static assets stack.

**Steps to manually verify this change...**

1. See previous PR's steps (#1569)

