### PR TITLE
EREGCSC-2922-G Re-enable custom SSL cert for static assets stack

### DIFF
--- a/cdk-eregs/bin/static-assets.ts
+++ b/cdk-eregs/bin/static-assets.ts
@@ -64,6 +64,7 @@ async function main() {
     });
     const deploymentType = app.node.tryGetContext('deploymentType') || 'content';  
     new StaticAssetsStack(app, `${stageConfig.getResourceName('static-assets')}`, {
+      certificateArn: await getParameterValue(`/eregulations/acm-cert-arn`),
       prNumber,
       deploymentType,  // Pass the deployment type to the stack
       env: {

--- a/cdk-eregs/lib/stacks/static-assets-stack.ts
+++ b/cdk-eregs/lib/stacks/static-assets-stack.ts
@@ -68,10 +68,9 @@ export class StaticAssetsStack extends cdk.Stack {
    * @throws {Error} If certificate ARN is missing in production environment
    */
   private validateCertificateConfig(props: StaticAssetsStackProps): void {
-    // TODO: why do we need this?
-    // if (this.stageConfig.environment === 'prod' && !props.certificateArn) {
-    //   throw new Error('SSL Certificate ARN is required for production environment');
-    // }
+    if (this.stageConfig.environment === 'prod' && !props.certificateArn) {
+      throw new Error('SSL Certificate ARN is required for production environment');
+    }
   }
 
   /**


### PR DESCRIPTION
Resolves #2922

**Description-**

To push through with deploying to prod last week, we temporarily disabled enforcement of a custom SSL cert for the static assets stack (#1570). We need to re-enable this feature.

**This pull request changes...**

- Pull certificate ARN from SSM.
- Re-add enforcement check in the static-assets stack.

**Steps to manually verify this change...**

[wait]

