### PR TITLE
EREGCSC-2934 -- Adjust regulation history display

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_buttons_and_tooltip.scss
+++ b/solution/ui/regulations/css/scss/partials/_buttons_and_tooltip.scss
@@ -224,9 +224,9 @@
                         40px
                 );
 
-                @include screen-sm {
+                @include screen-md {
                     width: calc(100% - var(--spacer-1) - var(--spacer-1));
-                    max-width: 435px;
+                    max-width: 440px;
                 }
 
                 .gov-info-links {
@@ -240,16 +240,11 @@
                     }
 
                     .links-container {
-                        height: 280px;
                         display: flex;
                         flex-wrap: wrap;
-                        flex-direction: column;
+                        flex-direction: row;
                         padding: 10px 10px 0;
                         box-sizing: content-box;
-
-                        @include screen-sm {
-                            height: 180px;
-                        }
 
                         a {
                             font-size: 14px;


### PR DESCRIPTION
Resolves [EREGCSC-2934](https://jiraent.cms.gov/browse/EREGCSC-2934)

**Description**

In order to help policy researchers who need to view past versions of a regulation, each regulation section provides the option to "view regulation history", with a list of years linked to past versions.

We need this list to read left to right starting at the top right of the list.

We also need the popup to dynamically size itself better.  Specifically: the list should be as tall as it needs to be without any list items overflowing outside of the tooltip container.

**This pull request changes:**

- Updates CSS style rules to make tooltip list work as described above
- Refactors tooltip Vue components to use Composition API (?)
- TBD

**Steps to manually verify this change:**

1. Green check marks
2. TBD

