### PR TITLE
EREGCSC-2922-H Miscellaneous CDK bug fixes

### DIFF
--- a/.github/workflows/remove-experimental-cdk.yml
+++ b/.github/workflows/remove-experimental-cdk.yml
@@ -139,9 +139,12 @@ jobs:
           echo "Cleanup completed for all Docker-based stacks"
           popd
       - name: Cleanup Static Assets
-        if: success() && steps.findPr.outputs.pr
         env:
-          PR_NUMBER: ${{ steps.findPr.outputs.pr }}
+          PR_NUMBER: ${{ github.event.number }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+          CDK_DEBUG: true
+          ENVIRONMENT_NAME: ${{ env.ENVIRONMENT_NAME }}
         run: |
           pushd cdk-eregs
           npm install -g aws-cdk@latest @aws-sdk/client-ssm

--- a/.github/workflows/update-cdk-bootstrap.yml
+++ b/.github/workflows/update-cdk-bootstrap.yml
@@ -47,7 +47,7 @@ jobs:
           pushd cdk-eregs/bootstrap
 
           echo "Downloading latest bootstrap template..."
-          curl -s "https://raw.githubusercontent.com/aws/aws-cdk/refs/heads/main/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml" -o latest-template.yaml > /dev/null
+          curl -s "https://raw.githubusercontent.com/aws/aws-cdk-cli/refs/heads/main/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml" -o latest-template.yaml > /dev/null
 
           echo "Applying CMS-specific changes to the template..."
           pip install -r requirements.txt

--- a/cdk-eregs/bin/docker-lambdas.ts
+++ b/cdk-eregs/bin/docker-lambdas.ts
@@ -120,6 +120,7 @@ async function main() {
       env,
       lambdaConfig: {
         timeout: 900,
+        memorySize: 1024,
       },
       environmentConfig: {
         logLevel,
@@ -132,6 +133,7 @@ async function main() {
       env,
       lambdaConfig: {
         timeout: 900,
+        memorySize: 1024,
       },
       environmentConfig: {
         logLevel,

--- a/cdk-eregs/lib/stacks/ecfr-parser-stack.ts
+++ b/cdk-eregs/lib/stacks/ecfr-parser-stack.ts
@@ -13,6 +13,8 @@ import { StageConfig } from '../../config/stage-config';
 import * as path from 'path';
 
 interface LambdaConfig {
+  /** Memory allocation in MB for the Lambda function */
+  memorySize: number;
   timeout: number;
 }
 
@@ -56,6 +58,7 @@ export class EcfrParserStack extends cdk.Stack {
         
       }),
       timeout: cdk.Duration.seconds(props.lambdaConfig.timeout || 900),
+      memorySize: props.lambdaConfig.memorySize,
       environment: {
         PARSER_ON_LAMBDA: 'true',
         EREGS_USERNAME: props.environmentConfig.httpUser,

--- a/cdk-eregs/lib/stacks/fr-parser-stack.ts
+++ b/cdk-eregs/lib/stacks/fr-parser-stack.ts
@@ -13,6 +13,8 @@ import { StageConfig } from '../../config/stage-config';
 import * as path from 'path';
 
 interface LambdaConfig {
+  /** Memory allocation in MB for the Lambda function */
+  memorySize: number;
   timeout: number;
 }
 
@@ -50,6 +52,7 @@ export class FrParserStack extends cdk.Stack {
         file: 'fr-parser/Dockerfile',
       }),
       timeout: cdk.Duration.seconds(props.lambdaConfig.timeout || 900),
+      memorySize: props.lambdaConfig.memorySize,
       environment: {
         PARSER_ON_LAMBDA: 'true',
         EREGS_USERNAME: props.environmentConfig.httpUser,

--- a/cdk-eregs/lib/stacks/text-extract-stack.ts
+++ b/cdk-eregs/lib/stacks/text-extract-stack.ts
@@ -214,12 +214,10 @@ export class TextExtractorStack extends cdk.Stack {
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: [
-            's3:PutObject',
             's3:GetObject',
-            's3:DeleteObject'
           ],
           resources: [
-            `arn:aws:s3:::file-repo-eregs-${this.stageConfig.environment}*`
+            `arn:aws:s3:::cms-eregs-${this.stageConfig.environment}-file-repo-eregs`
           ],
         }),
       ],

--- a/cdk-eregs/lib/stacks/text-extract-stack.ts
+++ b/cdk-eregs/lib/stacks/text-extract-stack.ts
@@ -217,7 +217,7 @@ export class TextExtractorStack extends cdk.Stack {
             's3:GetObject',
           ],
           resources: [
-            `arn:aws:s3:::cms-eregs-${this.stageConfig.stageName}-file-repo-eregs`
+            `arn:aws:s3:::cms-eregs-${this.stageConfig.stageName}-file-repo-eregs*`
           ],
         }),
       ],

--- a/cdk-eregs/lib/stacks/text-extract-stack.ts
+++ b/cdk-eregs/lib/stacks/text-extract-stack.ts
@@ -217,7 +217,7 @@ export class TextExtractorStack extends cdk.Stack {
             's3:GetObject',
           ],
           resources: [
-            `arn:aws:s3:::cms-eregs-${this.stageConfig.environment}-file-repo-eregs`
+            `arn:aws:s3:::cms-eregs-${this.stageConfig.stageName}-file-repo-eregs`
           ],
         }),
       ],


### PR DESCRIPTION
Resolves #2922

**Description-**

CDK validation in prod uncovered a few minor issues to fix. This PR fixes them.

**This pull request changes...**

- Memory size for eCFR/FR parsers were incorrectly set to 128MB instead of 1024MB.
- Fixed a typo in the Text Extractor -> File Repo Bucket access policy that prevented the text extractor from reading the S3 bucket.
- Remove accidentally copied if statement from remove-experimental-cdk.yml's static assets remove step, that was causing the step to be skipped.
- Related: Update CDK Bootstrap action failing because AWS moved the `bootstrap-template.yaml` file from [here](https://raw.githubusercontent.com/aws/aws-cdk/refs/heads/main/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml) to [here](https://raw.githubusercontent.com/aws/aws-cdk-cli/refs/heads/main/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml). Replaced the URL in the action to fix.

**Steps to manually verify this change...**

1. In the CDK ephemeral environment, upload a test file (simple txt file is fine) to the admin panel.
2. Save the new file. The popup message should indicate that text extraction is requested for the new resource.
3. Go to AWS console -> cloudwatch -> logs for CDK text extractor for this PR.
4. Open the log and verify the extraction completed successfully, in particular that no policy errors occurred.
5. Go to Lambda -> CDK eCFR/FR parsers for this PR.
6. Under the lambda configuration tab, verify the memory size is 1024MB for both lambda functions.
7. Approve and merge.
8. Verify remove-experimental-cdk action completes successfully and completely for this PR.
9. Repeat validation steps 1-6 for prod.
10. Manually run the "Update CDK Bootstrap" action and verify it does not fail.
