### PR TITLE
[Hotfix] Reader Sidebar rules lost their pipe separator

### DIFF
--- a/solution/ui/regulations/css/scss/_application_settings.scss
+++ b/solution/ui/regulations/css/scss/_application_settings.scss
@@ -595,6 +595,12 @@ select {
     @include common-chip-colors;
 }
 
+@mixin recent-date-pipe {
+    padding-right: var(--spacer-1);
+    margin-right: var(--spacer-1);
+    border-right: 1px solid $mid_gray;
+}
+
 .login-cta__div {
     background-color: $secondary_background_color;
     border: 1px solid $border_color;

--- a/solution/ui/regulations/css/scss/partials/_site_homepage.scss
+++ b/solution/ui/regulations/css/scss/partials/_site_homepage.scss
@@ -511,9 +511,7 @@
                         font-weight: 400;
 
                         &--bar {
-                            padding-right: var(--spacer-1);
-                            margin-right: var(--spacer-1);
-                            border-right: 1px solid $mid_gray;
+                            @include recent-date-pipe;
                         }
                     }
 

--- a/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
+++ b/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
@@ -94,6 +94,10 @@
 
     .recent-date {
         font-weight: bold;
+
+        &--bar {
+            @include recent-date-pipe;
+        }
     }
 
     .recent-fr-citation {


### PR DESCRIPTION
Resolves iteration bug caused by [EREGCSC-2932](https://jiraent.cms.gov/browse/EREGCSC-2932) ([pull request](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1573))

**Description**

Fixes a regression where Related Rules in the Reader view sidebar lost the pipe that separates date and Document ID.  This regression was caused by EREGCSC-2932, which updated the pipe separator styles for the homepage items but did not properly account for side effects elsewhere in the app.

**This pull request changes:**

- Creates SCSS mixin to encapsulate `recent-date--bar` styles to be reused throughout the app
- Uses this mixin for Related Rules on the homepage and in the Reader View sidebar

**Steps to manually verify this change:**

1. Green check marks
2. Reader view sidebar rules have a pipe separator that matches results items everywhere else on the site

