### PR TITLE
[hotfix 2] Include schema in redirect lambda's URL

### DIFF
--- a/solution/backend/redirect_lambda.py
+++ b/solution/backend/redirect_lambda.py
@@ -7,11 +7,12 @@ def handler(event, context):
 
     # Not using "get" because we want to fail if the environment variable is not set
     new_domain = os.environ["CUSTOM_URL"]
+    redirect_url = urljoin(f"https://{new_domain}", original_path)
 
     response = {
         'statusCode': 302,
         'headers': {
-            'Location': urljoin(new_domain, original_path),
+            'Location': redirect_url,
         },
     }
 


### PR DESCRIPTION
Resolves #n/a

**Description-**

Calling Python's `urljoin()` without a schema (i.e. `https://`) will result in the domain part being ignored entirely. In the redirect lambda, this results in a redirect to `/`, creating an infinite redirect.

**This pull request changes...**

- Add `https://` before the domain

**Steps to manually verify this change...**

1. Deploy this to prod
2. Go to the redirect lambda and verify it redirects successfully

