### PR TITLE
EREGCSC-2945 - Add resource policy to WAF construct

### DIFF
--- a/cdk-eregs/lib/constructs/waf-construct.ts
+++ b/cdk-eregs/lib/constructs/waf-construct.ts
@@ -24,7 +24,7 @@ export class WafConstruct extends Construct {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
-    // CRITICAL FIX: Add resource policy to allow WAF log delivery
+     //Add resource policy to allow WAF log delivery
     const logResourcePolicy = new logs.CfnResourcePolicy(this, 'WafLogResourcePolicy', {
       policyName: stageConfig.getResourceName('waf-logs-delivery-policy'),
       policyDocument: JSON.stringify({
@@ -33,7 +33,7 @@ export class WafConstruct extends Construct {
           {
             Effect: 'Allow',
             Principal: {
-              Service: 'delivery.logs.amazonaws.com'  // This is the critical service principal
+              Service: 'delivery.logs.amazonaws.com'  
             },
             Action: [
               'logs:CreateLogStream',


### PR DESCRIPTION
Resolves [EREGCSC-2945](https://jiraent.cms.gov/browse/EREGCSC-2945)

**Description**

This addresses an error we were getting when deploying site Lambdas.

**This pull request changes...**

- Fixes WAF logging issue in ephemeral environments by adding the required log resource policy
- Ensures WAF service can deliver logs to CloudWatch by using the correct service principal and resource format

**Steps to manually verify this change...**

- Deploy an ephemeral environment
- Verify that the WAF resource is created successfully without errors
- Check CloudWatch logs to confirm WAF logs are being delivered properly
- Verify API Gateway works as expected with WAF protection