### PR TITLE
EREGCSC-2915-B Attempt to fix get-api-url step in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,13 +139,19 @@ jobs:
         run: |
           pushd cdk-eregs
           API_STACK="cms-eregs-${{ matrix.environment }}-api"
-          API_URL=$(cat api-outputs.json | jq -r ".[\"$API_STACK\"].ApiUrl")
+          API_URL=$(cat api-outputs.json | jq -r ".[\"$API_STACK\"].ApiEndpoint")
           API_URL=${API_URL%/}
-          echo "api_url=${API_URL}" >> $GITHUB_OUTPUT
+          # Debug what we're setting
+          echo "Setting API URL: $API_URL"
+          # Use the exact same name as in the outputs section
+          echo "api_url=$(echo $API_URL)" >> $GITHUB_OUTPUT
+          # Verify it was set
+          echo "GITHUB_OUTPUT contents:"
+          cat $GITHUB_OUTPUT
           popd
 
       - name: Deploy FR Parser
-        env:        
+        env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
           CDK_DEBUG: true


### PR DESCRIPTION
Resolves #2915

**Description-**

Dev deploy failed because cypress couldn't get the API URL.

**This pull request changes...**

- Modify get-api-url step to more closely match the deploy-experimental version of it.

**Steps to manually verify this change...**

1. Approve and deploy
2. Verify dev cypress test succeeds

