### PR TITLE
EREGCSC-2953 Remove dependency on log resource policy

### DIFF
--- a/cdk-eregs/lib/constructs/waf-construct.ts
+++ b/cdk-eregs/lib/constructs/waf-construct.ts
@@ -24,27 +24,6 @@ export class WafConstruct extends Construct {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
 
-     //Add resource policy to allow WAF log delivery
-    const logResourcePolicy = new logs.CfnResourcePolicy(this, 'WafLogResourcePolicy', {
-      policyName: stageConfig.getResourceName('waf-logs-delivery-policy'),
-      policyDocument: JSON.stringify({
-        Version: '2012-10-17',
-        Statement: [
-          {
-            Effect: 'Allow',
-            Principal: {
-              Service: 'delivery.logs.amazonaws.com'  
-            },
-            Action: [
-              'logs:CreateLogStream',
-              'logs:PutLogEvents'
-            ],
-            Resource: `${this.logGroup.logGroupArn}:*`  // Note the :* suffix for log streams
-          }
-        ]
-      })
-    });
-
     // Create the WAFv2 Web ACL
     this.webAcl = new wafv2.CfnWebACL(this, 'APIGatewayWAF', {
       name: stageConfig.getResourceName('APIGateway-eregs-allow-usa-plus-territories'),
@@ -127,7 +106,6 @@ export class WafConstruct extends Construct {
 
     // Make sure WAF depends on log group
     this.webAcl.node.addDependency(this.logGroup);
-    this.webAcl.node.addDependency(logResourcePolicy);
 
     // Format a clean ARN for WAF logging
     const stack = cdk.Stack.of(this);
@@ -149,7 +127,6 @@ export class WafConstruct extends Construct {
 
     // Add explicit dependencies
     loggingConfig.node.addDependency(this.logGroup);
-    loggingConfig.node.addDependency(logResourcePolicy); // Add dependency on the resource policy
     loggingConfig.node.addDependency(this.webAcl);
 
     // Add resource tags


### PR DESCRIPTION
Resolves #2953

**Description-**

For a few days we have been receiving the following error while attempting to deploy the site stack:
```
Waf/WafLogResourcePolicy (WafWafLogResourcePolicy...) Resource handler returned message: "Resource limit exceeded. (Service: CloudWatchLogs, Status Code: 400, Request ID: ...) (SDK Attempt Count: 1)"
```

The issue does not occur for already deployed stacks when redeployed, and it does not occur in production. The issue was resolved incidentally after manually deleting several old CDK stacks that had failed to delete.

After looking at the stack in CloudFormation, I saw that the resource it was referring to was of type `AWS::Logs::ResourcePolicy`. The [docs for this](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-resourcepolicy.html) state that only 10 policies are permitted per account per region.

Using the AWS CLI, I ran the command `aws logs describe-resource-policies` and saw the following:
```jsonc
{
    "resourcePolicies": [
        {
            "policyName": "AWSLogDeliveryWrite20150319",
            "policyDocument": {
                "Version": "2012-10-17",
                "Statement": [
                    {
                        // ..... statement removed for brevity .....
                    },
                    {
                        "Sid": "AWSLogDeliveryWrite2",
                        "Effect": "Allow",
                        "Principal": {
                            "Service": "delivery.logs.amazonaws.com"
                        },
                        "Action": [
                            "logs:CreateLogStream",
                            "logs:PutLogEvents"
                        ],
                        "Resource": [
                            "..... 45 comma-separated ARNs each representing a (older, no longer in use) PR's WAF ....."
                        ]
                    }
                ]
            },
            "lastUpdatedTime": 1744057817584
        },
        {
            "policyName": "TrustEventsToStoreLogEvents",
            "policyDocument": "... policy removed for brevity ...",
            "lastUpdatedTime": 1723581333131
        },
        {
            "policyName": "cms-eregs-dev-waf-logs-delivery-policy",
            "policyDocument": "... policy removed for brevity ...",
            "lastUpdatedTime": 1742479440446
        },
        {
            "policyName": "cms-eregs-eph-1608-waf-logs-delivery-policy",
            "policyDocument": "... policy removed for brevity ...",
            "lastUpdatedTime": 1743005429676
        },
        {
            "policyName": "cms-eregs-eph-1615-waf-logs-delivery-policy",
            "policyDocument": "... policy removed for brevity ...",
            "lastUpdatedTime": 1743613174386
        },
        {
            "policyName": "cms-eregs-eph-1617-waf-logs-delivery-policy",
            "policyDocument": "... policy removed for brevity ...",
            "lastUpdatedTime": 1744053683030
        },
        {
            "policyName": "cms-eregs-eph-1618-waf-logs-delivery-policy",
            "policyDocument": "... policy removed for brevity ...",
            "lastUpdatedTime": 1744053500067
        },
        {
            "policyName": "cms-eregs-eph-1619-waf-logs-delivery-policy",
            "policyDocument": "... policy removed for brevity ...",
            "lastUpdatedTime": 1744054401507
        }
    ]
}
```

The timing corresponds to the PR that fixed the previous log group issue we encountered, PR #1600, where we suddenly started getting errors like this:
```
The stack named cms-eregs-eph-****-api failed creation, it may need to be manually deleted from the AWS console: ROLLBACK_COMPLETE: Resource handler returned message: "Unable to deliver logs to the configured destination. You might need to grant log delivery permissions for the destination. If you're using S3 as your log destination, you might have exceeded your bucket limit.
```

At the time, we thought that an update to CDK caused this, and manually adding a resource policy to the log group fixed the error. I believe that what really happened is that the first policy, `AWSLogDeliveryWrite20150319`, was having resources added to it with each CDK deployment until it reached the [max policy size of 5,120 characters](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length), at which point no more resources were accepted and we started receiving the vague error that the resource is "unable to deliver logs to the configured destination".

By adding the policy manually, we bypassed the character limit by adding an entirely new policy for each deployment. Eventually, we hit the maximum number of policies (10) and started getting this new error. Deleting some old deployments fixed this error as well, but this alone is a temporary fix. This PR provides a permanent fix.

**This pull request changes...**

- Manually overrode the `AWSLogDeliveryWrite2` sid of the `AWSLogDeliveryWrite20150319` policy to allow putting log events from any source in our account. This protects against hitting the policy character limit.
    - This is not reflected in the PR because these policies can only be manually edited with the AWS CLI.
- Removed the CDK code that adds a new resource policy for each deployment.

**Steps to manually verify this change...**

1. See that this PR was deployed successfully.
2. Merge this PR.
3. Using the AWS CLI, delete all other delivery policies that follow the name scheme `cms-eregs-*-waf-logs-delivery-policy`.
4. Deploy some more PRs.
5. After some time, run `aws logs describe-resource-policies` and see that there are only 2 policies, and that neither of them contain growing resource lists.

