### PR TITLE
EREGCSC-2910-B fix: increase local statement timeout to fix migration failure

### DIFF
--- a/solution/backend/content_search/migrations/0005_contentindex_date.py
+++ b/solution/backend/content_search/migrations/0005_contentindex_date.py
@@ -3,8 +3,13 @@
 from django.db import migrations, models
 from django.db.models import Q
 
+TIMEOUT_MINUTES = 10
+
 
 def populate_date(apps, schema_editor):
+    # Lessen the likelihood of this migration timing out during the copy operation
+    schema_editor.execute(f"SET LOCAL statement_timeout TO {TIMEOUT_MINUTES * 60000};")
+    
     ContentIndex = apps.get_model('content_search', 'ContentIndex')
     for index in ContentIndex.objects.filter(Q(resource__isnull=False) & ~Q(resource__date="")):
         index.date = index.resource.date


### PR DESCRIPTION
Resolves #2910

**Description-**

Previous migration failed because of a statement timeout.

**This pull request changes...**

- Increase local statement timeout to 10 mins.

**Steps to manually verify this change...**

1. Approve and deploy this PR up to val.
2. Val deploy should succeed.

