### PR TITLE
Improve backup/restore scripts and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,39 +124,39 @@ To use our Okta identity provider on an experimental (ephemeral) deployment, see
 
 # Development tips
 
-## Export and import data
+## Backing up and restoring the database
 
-To update local data with the most recent version of production, you need access to the production database and pg_dump. You can also use these instructions to update dev or val data with fresh data from production.
+The scripts `backup_db.sh`, `restore_remote_db.sh`, and `restore_local_db.sh` can be used for the following purposes:
+* Copying the prod DB to val and prod for more accurate testing.
+* Copying an RDS database to your local environment.
+* Restoring one or more databases from a previously taken backup without using RDS Snapshots.
 
-1. You must have the correct version of PostgreSQL installed locally on your machine (see [prerequisites](#prerequisites) for version number). Local PostgreSQL server must be turned **off**.
-2. Ensure you have [AWS CLI](#https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) installed locally on your machine.
-3. Connect to the VPN. 
-4. Create a backup of the database you intend to restore using pg_dump. Execute the following command:
+You must have the correct version of PostgreSQL installed locally on your machine (see [prerequisites](#prerequisites) for version number). To prevent connection conflicts, the local PostgreSQL server must be turned **off**. You also need the AWS CLI installed and configured with your short-term access keys from Cloudtamer. Additionally, be sure to run `export AWS_REGION=<your region>`. To access RDS and Cloudtamer, you must be connected to the VPN.
 
-   - `pg_dump -U <DB_USER> -h <DB_HOST> -p <DB_PORT> <DB_NAME> > <name_you_want_your_backupfile_to_be>`
-   - It is recommended that you put these backups in a folder that is hidden from `git`.  We suggest creating a folder in the root of the project named `db_backup` and dumping all of your backups into it.  This directory name is safe to use, as it has already been added to the project's `.gitignore`.
+### Creating a backup
 
-> [!NOTE]
-> restore_db.sh also performs a backup of the database you intend to restore. However, as a precautionary measure, it's advisable to create a separate backup of your database.)
-5. Sign in to the Cloudtamer CMS portal (cloudtamer.cms.gov) to retrieve your short-term access keys.
-6. Paste the access keys into your terminal. This will enable you to use AWS CLI commands.
-7. Run the script by executing ./scripts/backup_db.sh from your terminal.
-8. Once the backup process is finished, you'll find a copy of the backup file in the directory where the command was executed.
+1. Run `mkdir -p db_backup; cd db_backup` from the eRegs root directory. This creates a `db_backup` directory which is already hidden from Git.
+2. Run `../scripts/backup_db.sh` to start the backup process.
+3. Specify the environment you wish to backup. (`dev`, `val`, `prod`, etc.)
+4. Wait for the script to fetch the database parameters and perform the backup.
 
-   - The file will be named in the following format: `<db host name>_<name of your db>_<date>.sql`.
+When done, the backup file will be named `<DB host>_<name of DB>_<date>.sql`.
 
-9. With the backup file ready, proceed to restore the database by running the script `./scripts/restore_db.sh`.
+### Restoring from a backup file to RDS
 
-   - local database name: `localhost`
-   - local port: `5432`
+1. From the `db_backup` directory, run `../scripts/restore_remote_db.sh`.
+2. Enter the relative path to the SQL backup file created above.
+3. Specify the environment you wish to restore. (`dev`, `val`, `prod`, `eph-*`, etc.)
+4. Wait for the script to fetch the database parameters, create a backup of the remote DB, and perform the restore. This will take a while.
 
-10. Upon running the restoration script, you'll receive a prompt indicating that the existing database will be replaced. If you're certain, type yes.
+Note that specifying `prod` as an environment will prompt for confirmation. Be absolutely sure that the backup that you have taken is valid and the file you specify is the correct one. However, this script will take a backup of the remote DB first before restoring from the specified file. If an error occurs, this new backup can be used for recovery. If this fails, a restore from an RDS Snapshot will be required.
 
-11. Follow the subsequent prompts, providing the necessary credentials. When prompted for the backup file, enter the name of the file generated during the backup process.
+### Restoring from a backup file to local PostgreSQL
 
-12. Before the database is restored, a backup is created of the db that is being restored. The file will be named in the following format: `<db host name>_<name of your db>_<date>.sql`. 
-
-   - Visit the local website and ensure that the data has been copied. 
+1. From the `db_backup` directory, run `../scripts/restore_local_db.sh`.
+2. Enter the relative path to the SQL backup file created above.
+3. Enter the password to the local database.
+4. Wait for the script to restore the local database from the file. This may take a few minutes.
 
 ## Add a new model
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ To use our Okta identity provider on an experimental (ephemeral) deployment, see
 ## Backing up and restoring the database
 
 The scripts `backup_db.sh`, `restore_remote_db.sh`, and `restore_local_db.sh` can be used for the following purposes:
-* Copying the prod DB to val and prod for more accurate testing.
+
+* Copying the prod DB to dev and val for more accurate testing.
 * Copying an RDS database to your local environment.
 * Restoring one or more databases from a previously taken backup without using RDS Snapshots.
 
@@ -156,7 +157,7 @@ Note that specifying `prod` as an environment will prompt for confirmation. Be a
 1. From the `db_backup` directory, run `../scripts/restore_local_db.sh`.
 2. Enter the relative path to the SQL backup file created above.
 3. Enter the password to the local database.
-4. Wait for the script to restore the local database from the file. This may take a few minutes.
+4. Wait for the script to restore the local database from the file. This may take a few minutes.d
 
 ## Add a new model
 

--- a/scripts/restore_local_db.sh
+++ b/scripts/restore_local_db.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+read -p "Enter the path to the backup file you want to restore: " RESTORE_FILE
+if [ ! -f "$RESTORE_FILE" ]; then
+    echo "Backup file not found! Please check the path and try again."
+    exit 1
+fi
+
+DB_HOST=localhost
+DB_NAME=eregs
+DB_USER=eregsuser
+DB_PORT=5432
+read -p "Enter the database password: " DB_PASSWORD
+
+echo "Dropping database $DB_NAME on $DB_HOST now..."
+# Drop existing database
+# we use postgres as the database name as the given database is in use.
+PGPASSWORD=$DB_PASSWORD psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d postgres -c "DROP DATABASE IF EXISTS ${DB_NAME} WITH ( FORCE );"
+
+echo "Creating new database..."
+# Create new database
+PGPASSWORD=$DB_PASSWORD psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d postgres -c "CREATE DATABASE ${DB_NAME};"
+
+echo "Restoring data from backup file ${RESTORE_FILE}"
+# Restore data from a backup file. (this is a different file than existing db backup file)
+# restore the data with an existing backup file.
+PGPASSWORD=$DB_PASSWORD psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d ${DB_NAME} < $RESTORE_FILE
+echo "Database restore completed successfully."

--- a/scripts/restore_local_db.sh
+++ b/scripts/restore_local_db.sh
@@ -26,4 +26,5 @@ echo "Restoring data from backup file ${RESTORE_FILE}"
 # Restore data from a backup file. (this is a different file than existing db backup file)
 # restore the data with an existing backup file.
 PGPASSWORD=$DB_PASSWORD psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d ${DB_NAME} < $RESTORE_FILE
+
 echo "Database restore completed successfully."

--- a/scripts/restore_remote_db.sh
+++ b/scripts/restore_remote_db.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+
 # This script deletes the database and then restores it from backup.
 # Before running this script make a backup of the data you want to restore with pg_dump.
 # This script does make a backup of the data it's restoring but its recommended to backup that data as well.
@@ -69,4 +70,5 @@ echo "Restoring data from backup file ${RESTORE_FILE}"
 # Restore data from a backup file. (this is a different file than existing db backup file)
 # restore the data with an existing backup file.
 PGPASSWORD=$DB_PASSWORD psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d ${DB_NAME} < $RESTORE_FILE
+
 echo "Database restore completed successfully."


### PR DESCRIPTION
Resolves #n/a

**Description-**

Database restore script was recently rewritten to take advantage of the AWS CLI more instead of relying on user inputs. Forgot to consider localhost use, so needed to add a new script and reflect the new script usage in the docs. Also, needed to update the CDK documentation.

**This pull request changes...**

- Moved `restore_db.sh` to `restore_remove_db.sh`.
- Added `restore_local_db.sh` that bypasses AWS CLI and hardcodes certain values, only asking for a file and password.
- Updated main README.md to reflect new steps for DB backup/restore.
- Updated CDK README.md for better readability.

**Steps to manually verify this change...**

n/a, all scripts already tested. Feel free to read the README changes and see if they make sense.

