### PR TITLE
[fix] Update aws-cdk-lib to 2.192.0 to attempt to fix deploy issue

### DIFF
--- a/cdk-eregs/package-lock.json
+++ b/cdk-eregs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-ssm": "~3.759.0",
-        "aws-cdk-lib": "~2.186.0",
+        "aws-cdk-lib": "~2.192.0",
         "constructs": "^10.4.1",
         "fs-extra": "^11.2.0",
         "path": "^0.12.7",
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.228",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.228.tgz",
-      "integrity": "sha512-ToZPI+dEz2BKj//kD2V8oXAvpeBFec5w6tXxIQh/U2iiMLcaUVZw4sxR820jF2GDArZY2D/alVkcSkId0J6rtA=="
+      "version": "2.2.233",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.233.tgz",
+      "integrity": "sha512-OH5ZN1F/0wwOUwzVUSvE0/syUOi44H9the6IG16anlSptfeQ1fvduJazZAKRuJLtautPbiqxllyOrtWh6LhX8A=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
@@ -60,9 +60,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "40.7.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz",
-      "integrity": "sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==",
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -2916,9 +2916,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.186.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.186.0.tgz",
-      "integrity": "sha512-y/DD4h8CbhwGyPTpoHELATavZe5FWcy1xSuLlReOd3+cCRZ9rAzVSFdPB8kSJUD4nBPrIeGkW1u8ItUOhms17w==",
+      "version": "2.192.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.192.0.tgz",
+      "integrity": "sha512-Y9BAlr9a4QsEsamKc2cOGzX8DpVSOh94wsrMSGRXT0bZaqmixhhmT7WYCrT1KX4MU3gYk3OiwY2BbNyWaNE8Fg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2932,11 +2932,10 @@
         "yaml",
         "mime-types"
       ],
-      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.227",
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^40.7.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.0",
@@ -6108,7 +6107,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/cdk-eregs/package.json
+++ b/cdk-eregs/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-ssm": "~3.759.0",
-    "aws-cdk-lib": "~2.186.0",
+    "aws-cdk-lib": "~2.192.0",
     "constructs": "^10.4.1",
     "fs-extra": "^11.2.0",
     "path": "^0.12.7",


### PR DESCRIPTION
Resolves #n/a

**Description-**

Deployments have been randomly failing since updating AWS CDK minor versions in a recent PR. Error is:
```
DeployStaticAssets/CustomResource/Default (DeployStaticAssetsCustomResource900BFA47) Received response status [FAILED] from custom resource. Message returned: Command '['/opt/awscli/aws', 's3', 'sync', '--delete', '/tmp/tmpbjjqwbd4/contents', 's3://cms-eregs-eph-1640-site-assets/']' died with <Signals.SIGKILL: 9>. 
```

We are attempting to update to a newer minor version to see if that fixes it before troubleshooting any further.

**This pull request changes...**

- In package.json, update aws-cdk-lib to 2.192.0

**Steps to manually verify this change...**

1. Be sure PR deploys successfully (in other words, the update doesn't break anything).
2. Approve and deploy this PR.
3. See if random failures stop occurring.

