### PR TITLE
EREGCSC-2955 Fix for SecurityHub finding: CloudFront must use custom SSL

### DIFF
--- a/cdk-eregs/lib/stacks/static-assets-stack.ts
+++ b/cdk-eregs/lib/stacks/static-assets-stack.ts
@@ -148,12 +148,12 @@ export class StaticAssetsStack extends cdk.Stack {
         };
 
         // Add certificate and domain configuration if certificate is available
-        if (props.certificateArn) {
+        if (certificateArn) {
             // Create certificate reference
             const certificate = acm.Certificate.fromCertificateArn(
                 this, 
                 'Certificate', 
-                props.certificateArn
+                certificateArn
             );
       
             // Include certificate in initial props


### PR DESCRIPTION
Resolves #2955

**Description-**

Received SecurityHub finding in prod stating that CloudFront distributions must use a custom SSL cert. This appears to be because the CDK code was creating a local var `certificateArn`, and if `props.certificateArn` is not set, the local var is set to the value of the param from Parameter Store. However, later when creating the distribution, the local var is not used, and instead `props.certificateArn` is used.

**This pull request changes...**

- When setting CloudFront properties, use local var `certificateArn` instead of `props.certificateArn`

**Steps to manually verify this change...**

Dev and val do not use the custom SSL cert, this is only needed in prod. So:

1. Make sure this PR deploys successfully.
2. Approve and deploy through to prod. 
3. Log into the prod AWS account and visit CloudFront.
4. Go to the only distribution listed there, and under "Settings" click "Edit".
5. Under "Custom SSL certificate - optional", verify the dropdown box has the custom cert selected. Close without saving.

