### PR TITLE
EREGCSC-2654-B Fix dependency on wait-for-approval step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo "Waiting for approval to proceed to production deployment"
 
   deploy-to-prod:
-    needs: deploy-to-val
+    needs: wait-for-approval
     uses: ./.github/workflows/deploy-to-env.yml
     with:
       environment: prod


### PR DESCRIPTION
Resolves #2654

**Description-**

In the previous PR I forgot to set the prod deployment process to depend on the "wait-for-approval" job, instead it is still relying on the val deploy. This is not currently an issue because environment protection has not yet been disabled for the prod environment, but before we can do that we need to ensure that the wait for approval step works properly.

**This pull request changes...**

- Prod deploy depends on "wait-for-approval" job instead of on val deploy.

**Steps to manually verify this change...**

1. Approve and deploy
2. See in the prod deploy graph that the prod deploy won't attempt to start until after the "wait-for-approval" job is complete.

