### PR TITLE
EREGCSC-2960 Changed some deploy job labels for readability/accuracy

### DIFF
--- a/.github/workflows/deploy-to-env.yml
+++ b/.github/workflows/deploy-to-env.yml
@@ -104,7 +104,7 @@ jobs:
           --app "npx ts-node bin/static-assets.ts"
           popd
   
-  deploy-zip-lambdas:
+  deploy-alternate-sites:
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
     steps:
@@ -173,7 +173,7 @@ jobs:
           popd
 
   deploy-fr-parser:
-    needs: [deploy-site-lambdas]
+    needs: [deploy-site]
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
     steps:
@@ -207,7 +207,7 @@ jobs:
           popd
 
   deploy-ecfr-parser:
-    needs: [deploy-site-lambdas]
+    needs: [deploy-site]
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
     steps:
@@ -274,7 +274,7 @@ jobs:
           --app "npx ts-node bin/docker-lambdas.ts"
           popd          
 
-  deploy-site-lambdas:
+  deploy-site:
     needs: [deploy-static-assets, deploy-text-extractor]
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
@@ -340,17 +340,17 @@ jobs:
           cat $GITHUB_OUTPUT
           popd
 
-  notify:
+  add-pr-comment:
     if: ${{ inputs.pr_number != '' }}
     permissions:
       pull-requests: write
     runs-on: ubuntu-22.04
-    needs: deploy-site-lambdas
+    needs: deploy-site
     steps:
       - name: Create deployment comment
         uses: peter-evans/create-or-update-comment@v4
         env:
-          SITE_URL: ${{ needs.deploy-site-lambdas.outputs.api_url }}
+          SITE_URL: ${{ needs.deploy-site.outputs.api_url }}
         with:
           issue-number: ${{ inputs.pr_number }}
           body: |
@@ -360,7 +360,7 @@ jobs:
   test-cypress:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-22.04
-    needs: deploy-site-lambdas
+    needs: deploy-site
     steps:
       # Checkout the code
       - name: Checkout
@@ -396,7 +396,7 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           working-directory: solution/ui/e2e
-          config: baseUrl=${{ needs.deploy-site-lambdas.outputs.api_url }}
+          config: baseUrl=${{ needs.deploy-site.outputs.api_url }}
         env:
           CYPRESS_DEPLOYING: true
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  deploy-to-dev:
+  dev-deploy:
     uses: ./.github/workflows/deploy-to-env.yml
     with:
       environment: dev
@@ -24,8 +24,8 @@ jobs:
     secrets:
       AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
 
-  deploy-to-val:
-    needs: deploy-to-dev
+  val-deploy:
+    needs: dev-deploy
     uses: ./.github/workflows/deploy-to-env.yml
     with:
       environment: val
@@ -35,14 +35,14 @@ jobs:
       AWS_OIDC_ROLE_TO_ASSUME: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
 
   wait-for-approval:
-    needs: deploy-to-val
+    needs: val-deploy
     runs-on: ubuntu-latest
     environment: approval
     steps:
       - name: Wait for approval
         run: echo "Waiting for approval to proceed to production deployment"
 
-  deploy-to-prod:
+  prod-deploy:
     needs: wait-for-approval
     uses: ./.github/workflows/deploy-to-env.yml
     with:


### PR DESCRIPTION
Resolves #2960

**Description-**

One of the goals of implementing reusable workflows was to enhance at-a-glance readability of the site deployment action. For the most part, it did accomplish that, but there were some minor issues such as the fact that the action "deploy-to-dev", for example, would be often shortened to something like "de... / job-name" where "de" is short for "deploy" instead of "dev".

**This pull request changes...**

- deploy-to-* replaced with *-deploy. (Shortened versions in the diagram should show "d...", "v...", "p..." which will more clearly indicate which jobs are for which environment.)
- notify replaced with add-pr-comment.
- deploy-zip-lambdas replaced with deploy-alternate-sites.
- deploy-site-lambdas replaced with deploy-site.

**Steps to manually verify this change...**

1. Check out the experimental deploy workflow, all labels should be consistent and accurate.
2. Approve and merge, deploy to prod.
3. Review deploy diagram, all labels should be consistent, accurate, and more readable than before.

