### PR TITLE
EREGCSC-2958 -- Display subject descriptions on subject pages

### DIFF
--- a/solution/backend/regulations/templates/regulations/partials/node_types/Division.html
+++ b/solution/backend/regulations/templates/regulations/partials/node_types/Division.html
@@ -1,1 +1,1 @@
-<table-component table_markup="{{node.content}}"></table-component>
+<table-component table-markup="{{node.content}}"></table-component>

--- a/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/subjects.spec.cy.js
@@ -166,9 +166,11 @@ describe("Find by Subjects", () => {
             .should("have.text", "Managed Care")
             .click({ force: true });
         cy.get(".doc-type__toggle fieldset").should("not.exist");
-        cy.get(".subject__heading")
+        cy.get(".subject__heading h1")
             .should("exist")
             .and("have.text", "Managed Care");
+        cy.get("span[data-testid=selected-subject-description]")
+            .should("have.text", "Managed Care Description")
         cy.url().should("include", "/subjects?subjects=63");
     });
 
@@ -266,9 +268,11 @@ describe("Find by Subjects", () => {
             .should("have.text", "Access to Services(1)")
             .click({ force: true });
         cy.url().should("include", "/subjects?subjects=3");
-        cy.get(".subject__heading")
+        cy.get(".subject__heading h1")
             .should("exist")
             .and("have.text", "Access to Services");
+        cy.get("span[data-testid=selected-subject-description]")
+            .should("have.text", "Access to Services Description")
         cy.get("search-results__heading").should("not.exist");
         cy.get(".search-results-count").should(
             "have.text",
@@ -292,39 +296,45 @@ describe("Find by Subjects", () => {
         });
         cy.url().should("include", "/subjects?subjects=1");
         cy.get(`button[data-testid=remove-subject-1]`).should("exist");
-        cy.get(".subject__heading span")
+        cy.get(".subject__heading h1 span")
             .eq(0)
             .should("have.text", "Cures Act")
             .and("have.class", "subj-heading__span--bold");
-        cy.get(".subject__heading span")
+        cy.get(".subject__heading h1 span")
             .eq(1)
             .should("have.text", "21st Century Cures Act")
             .and("not.have.class", "subj-heading__span--bold");
+        cy.get("span[data-testid=selected-subject-description]")
+            .should("have.text", "Cures Act Description")
 
         cy.get(`button[data-testid=add-subject-2]`).click({
             force: true,
         });
         cy.url().should("include", "/subjects?subjects=2");
         cy.get(`button[data-testid=remove-subject-2]`).should("exist");
-        cy.get(".subject__heading span")
+        cy.get(".subject__heading h1 span")
             .eq(0)
             .should("have.text", "ABP")
             .and("have.class", "subj-heading__span--bold");
-        cy.get(".subject__heading span")
+        cy.get(".subject__heading h1 span")
             .eq(1)
             .should("have.text", "Alternative Benefit Plan")
             .and("not.have.class", "subj-heading__span--bold");
+        cy.get("span[data-testid=selected-subject-description]")
+            .should("not.exist");
 
         cy.get(`button[data-testid=add-subject-3]`).click({
             force: true,
         });
         cy.url().should("include", "/subjects?subjects=3");
         cy.get(`button[data-testid=remove-subject-3]`).should("exist");
-        cy.get(".subject__heading span")
+        cy.get(".subject__heading h1 span")
             .eq(0)
             .should("have.text", "Access to Services")
             .and("have.class", "subj-heading__span--bold");
-        cy.get(".subject__heading span").eq(1).should("not.exist");
+        cy.get(".subject__heading h1 span").eq(1).should("not.exist");
+        cy.get("span[data-testid=selected-subject-description]")
+            .should("have.text", "Access to Services Description")
 
         cy.go("back");
         cy.url().should("include", "/subjects?subjects=2");

--- a/solution/ui/e2e/cypress/fixtures/subjects.json
+++ b/solution/ui/e2e/cypress/fixtures/subjects.json
@@ -17,7 +17,7 @@
       "full_name": "Access to Services",
       "short_name": "",
       "abbreviation": "",
-      "description": "",
+      "description": "Access to Services Description",
       "public_resources": 1,
       "internal_resources": 0
     },
@@ -215,7 +215,7 @@
       "full_name": "21st Century Cures Act",
       "short_name": "",
       "abbreviation": "Cures Act",
-      "description": "",
+      "description": "Cures Act Description",
       "public_resources": 1,
       "internal_resources": 0
     },
@@ -566,7 +566,7 @@
       "full_name": "Managed Care",
       "short_name": "",
       "abbreviation": "",
-      "description": "",
+      "description": "Managed Care Description",
       "public_resources": 0,
       "internal_resources": 0
     },

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentCategory.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentCategory.vue
@@ -29,7 +29,7 @@ const props = defineProps({
         required: false,
         default: false,
     },
-    supplemental_content: {
+    supplemental_content: { // eslint-disable-line vue/prop-name-casing
         type: Array,
         required: false,
         default: undefined,

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentList.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentList.vue
@@ -6,7 +6,7 @@ import CollapseButton from "./CollapseButton.vue";
 import Collapsible from "./Collapsible.vue";
 
 const props = defineProps({
-    supplemental_content: {
+    supplemental_content: { // eslint-disable-line vue/prop-name-casing
         type: Array,
         required: true,
     },

--- a/solution/ui/regulations/eregs-component-lib/src/components/TableComponent.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/TableComponent.vue
@@ -2,13 +2,13 @@
 import { computed } from 'vue';
 
 const props = defineProps({
-    table_markup: {
+    tableMarkup: {
         type: String,
         required: true,
     },
 });
 
-const table = computed(() => props.table_markup);
+const table = computed(() => props.tableMarkup);
 </script>
 
 <template>

--- a/solution/ui/regulations/eregs-vite/src/components/navigation/NavBtn.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/navigation/NavBtn.vue
@@ -4,12 +4,10 @@ import { computed } from "vue";
 const props = defineProps({
     direction: {
         type: String,
-        required: true,
         default: "forward",
     },
     label: {
         type: String,
-        required: true,
         default: "Loading...",
     },
     isDisabled: {

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -251,6 +251,7 @@ const getDocSubjects = async () => {
 };
 
 const selectedSubjectParts = ref([]);
+const selectedSubjectDescription = ref("");
 
 const setSelectedSubjectParts = () => {
     if (selectedParams.paramsArray.length) {
@@ -261,9 +262,11 @@ const setSelectedSubjectParts = () => {
                     selectedParams.paramsArray[0].id
             )[0];
             selectedSubjectParts.value = getSubjectNameParts(selectedSubject);
+            selectedSubjectDescription.value = selectedSubject.description ?? "";
         }
     } else {
         selectedSubjectParts.value = [];
+        selectedSubjectDescription.value = "";
     }
 };
 
@@ -430,6 +433,12 @@ getDocSubjects();
                             <SelectedSubjectHeading
                                 :selected-subject-parts="selectedSubjectParts"
                             />
+                            <span
+                                v-if="selectedSubjectDescription"
+                                data-testid="selected-subject-description"
+                            >
+                                {{ selectedSubjectDescription }}
+                            </span>
                         </div>
                         <div class="subject__filters--row">
                             <DocumentTypeSelector v-if="isAuthenticated" />


### PR DESCRIPTION
Resolves [EREGCSC-2958](https://jiraent.cms.gov/browse/EREGCSC-2958)

**Description**

If a selected subject has a description field, display it on the Subjects page under the subject name at the top of the page.

**This pull request changes:**

- Conditionally renders `span` under `<SelectedSubjectHeading />` on `/subjects` page if selected subject has a `desc` field with non-zero-length string
- Adds Cypress e2e tests and fixtures to assert that subject descriptions are rendered if they exist and not rendered if they don't exist
- Fixes four eslint warnings that need to be cleaned up

**Steps to manually verify this change:**

1. Green check marks
2. Visit [ephemeral deployment's Subjects page](https://nb8hiudky9.execute-api.us-east-1.amazonaws.com/eph-1659/subjects/)
3. Click around Subjects page and ensure that Subject descriptions are displayed in a `<span>` at the top of the page under the `h1` element containing subject name
4. View ["Files Changed" tab](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1659/files) here in this Pull Request and ensure that there are no linting annotations listed at the bottom of the page
   - Visit [ESLint Github Action](https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/runs/14885342220) to confirm; compare to another [unfixed ESLint Github Action](https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/runs/14885016208)

