### PR TITLE
EREGCSC-2247 Enable providing resource statute citation info to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ You can run `make` to learn about other available tasks. For example:
 
 `make local.clean` will remove the local environment completely, useful when you want to start fresh.
 
+You may also need [Docker compose commands](https://docs.docker.com/compose/). For example:
+
+If you add or update Python dependencies, you may need to rebuild the site: `docker compose up -d --build regulations`
+
+In general, `make local` will run any migrations that need to run, but if you need to run migrations on their own: `docker compose exec regulations python manage.py migrate`
+
 ## Run tests
 
 #### Testing setup

--- a/solution/backend/common/fields.py
+++ b/solution/backend/common/fields.py
@@ -159,7 +159,8 @@ def _ref_field_pre_save_hook(value, schema):
 
     # Standardize dashes in the reference field
     for i in value:
-        i[keys[1]] = DASH_REGEX.sub("-", i[keys[1]])
+        i[keys[0]] = i[keys[0]].strip()
+        i[keys[1]] = DASH_REGEX.sub("-", i[keys[1]].strip())
 
     # Return the sorted list of references
     return sorted(value, key=lambda x: (x[keys[0]], x[keys[1]]))

--- a/solution/backend/common/fields.py
+++ b/solution/backend/common/fields.py
@@ -3,13 +3,12 @@ import datetime
 import re
 from functools import partial
 
-from natsort import natsorted
-
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
 from django_jsonform.models.fields import JSONField
 from drf_spectacular.utils import OpenApiTypes, extend_schema_field
+from natsort import natsorted
 from rest_framework import serializers
 
 from .patterns import DASH_REGEX

--- a/solution/backend/common/fields.py
+++ b/solution/backend/common/fields.py
@@ -154,15 +154,15 @@ CFR_REF_SCHEMA = {
 
 
 def _ref_field_pre_save_hook(value, schema):
-    # Get names of keys in the schema
+    # Get names of keys from the schema
     keys = list(schema["items"]["keys"].keys())
 
-    # Standardize dashes in the reference field
+    # Standardize dashes in the reference field and strip whitespace
     for i in value:
         i[keys[0]] = i[keys[0]].strip()
         i[keys[1]] = DASH_REGEX.sub("-", i[keys[1]].strip())
 
-    # Return the sorted list of references
+    # Return the alphabetically sorted list of references
     return sorted(value, key=lambda x: (x[keys[0]], x[keys[1]]))
 
 

--- a/solution/backend/common/fields.py
+++ b/solution/backend/common/fields.py
@@ -153,18 +153,24 @@ CFR_REF_SCHEMA = {
 }
 
 
-def _convert_dashes(exceptions, key):
-    for i in exceptions:
-        i[key] = DASH_REGEX.sub("-", i[key])
-    return exceptions
+def _ref_field_pre_save_hook(value, schema):
+    # Get names of keys in the schema
+    keys = list(schema["items"]["keys"].keys())
+
+    # Standardize dashes in the reference field
+    for i in value:
+        i[keys[1]] = DASH_REGEX.sub("-", i[keys[1]])
+
+    # Return the sorted list of references
+    return sorted(value, key=lambda x: (x[keys[0]], x[keys[1]]))
 
 
 class _ReferenceField(JSONField):
-    def __init__(self, schema, key, *args, **kwargs):
+    def __init__(self, schema, *args, **kwargs):
         kwargs = {**kwargs, **{
             "default": list,
             "blank": True,
-            "pre_save_hook": partial(_convert_dashes, key=key),
+            "pre_save_hook": partial(_ref_field_pre_save_hook, schema=schema),
             "schema": schema,
         }}
         super().__init__(*args, **kwargs)
@@ -172,17 +178,17 @@ class _ReferenceField(JSONField):
 
 class StatuteRefField(_ReferenceField):
     def __init__(self, *args, **kwargs):
-        super().__init__(STATUTE_REF_SCHEMA, "section", *args, **kwargs)
+        super().__init__(STATUTE_REF_SCHEMA, *args, **kwargs)
 
 
 class UscRefField(_ReferenceField):
     def __init__(self, *args, **kwargs):
-        super().__init__(USC_REF_SCHEMA, "section", *args, **kwargs)
+        super().__init__(USC_REF_SCHEMA, *args, **kwargs)
 
 
 class CfrRefField(_ReferenceField):
     def __init__(self, *args, **kwargs):
-        super().__init__(CFR_REF_SCHEMA, "reference", *args, **kwargs)
+        super().__init__(CFR_REF_SCHEMA, *args, **kwargs)
 
 
 # Retrieves automatically generated search headlines

--- a/solution/backend/common/fields.py
+++ b/solution/backend/common/fields.py
@@ -3,6 +3,8 @@ import datetime
 import re
 from functools import partial
 
+from natsort import natsorted
+
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
@@ -162,8 +164,8 @@ def _ref_field_pre_save_hook(value, schema):
         i[keys[0]] = i[keys[0]].strip()
         i[keys[1]] = DASH_REGEX.sub("-", i[keys[1]].strip())
 
-    # Return the alphabetically sorted list of references
-    return sorted(value, key=lambda x: (x[keys[0]], x[keys[1]]))
+    # Return the naturally sorted list of references
+    return natsorted(value, key=lambda x: (x[keys[0]], x[keys[1]]))
 
 
 class _ReferenceField(JSONField):

--- a/solution/backend/requirements.txt
+++ b/solution/backend/requirements.txt
@@ -27,3 +27,4 @@ pytest-cov
 djangorestframework_simplejwt
 olefile
 sqlparse>=0.5.0 # not directly required, pinned by Snyk to avoid a vulnerability
+natsort==8.4.0

--- a/solution/backend/resources/migrations/0008_update_ref_field_sort.py
+++ b/solution/backend/resources/migrations/0008_update_ref_field_sort.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models, transaction
+from django.db.models import Q
+
+
+def update_ref_field_sort(apps, schema_editor):
+    # Resave all Resource objects to trigger the pre-save hook for the ref fields
+    AbstractResource = apps.get_model("resources", "AbstractResource")
+    q_filter = Q(usc_citations__isnull=False) | Q(act_citations__isnull=False)
+    pk = -1  # Start with the lowest pk to ensure we process all resources
+
+    while True:
+        with transaction.atomic():            
+            # Process 100 resources at a time to avoid a statement timeout while maintaining atomicity
+            resources = AbstractResource.objects.filter(Q(pk__gt=pk) & q_filter).order_by("pk")[:100]
+
+            if not resources:
+                break
+
+            for resource in resources:
+                pk = resource.pk
+                resource.save()
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ('resources', '0007_create_citation_sort_field'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_ref_field_sort, reverse_code=migrations.RunPython.noop),
+    ]

--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -64,3 +64,13 @@ MetaCitationSerializer = ProxySerializerWrapper(
         SubpartSerializer,
     ],
 )
+
+
+class ActCitationSerializer(serializers.Serializer):
+    act = serializers.CharField()
+    section = serializers.CharField()
+
+
+class UscCitationSerializer(serializers.Serializer):
+    title = serializers.CharField()
+    section = serializers.CharField()

--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -20,10 +20,10 @@ from resources.models import (
 from .categories import AbstractCategorySerializer
 from .citations import (
     AbstractCitationSerializer,
+    ActCitationSerializer,
     SectionCreateSerializer,
     SectionRangeCreateSerializer,
     UscCitationSerializer,
-    ActCitationSerializer,
 )
 from .polymorphic import (
     PolymorphicSerializer,

--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -22,6 +22,8 @@ from .citations import (
     AbstractCitationSerializer,
     SectionCreateSerializer,
     SectionRangeCreateSerializer,
+    UscCitationSerializer,
+    ActCitationSerializer,
 )
 from .polymorphic import (
     PolymorphicSerializer,
@@ -177,6 +179,8 @@ class ResourceSerializer(serializers.Serializer):
     approved = serializers.BooleanField()
     category = AbstractCategorySerializer()
     cfr_citations = AbstractCitationSerializer(many=True)
+    act_citations = ActCitationSerializer(many=True)
+    usc_citations = UscCitationSerializer(many=True)
     subjects = SubjectSerializer(many=True)
     document_id = serializers.CharField()
     title = serializers.CharField()

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -129,9 +129,11 @@ class ResourceViewSet(viewsets.ModelViewSet):
         subjects = self.request.GET.getlist("subjects")
         group_resources = string_to_bool(self.request.GET.get("group_resources"), True)
 
-        category_prefetch = AbstractCategory.objects.select_subclasses()
         citation_prefetch = AbstractCitation.objects.select_subclasses()
         subject_prefetch = Subject.objects.all()
+        category_prefetch = AbstractCategory.objects.select_subclasses().prefetch_related(
+            Prefetch("parent", AbstractCategory.objects.select_subclasses()),
+        )
 
         query = self.model.objects.filter(approved=True).order_by(F("date").desc(nulls_last=True)).prefetch_related(
             Prefetch("category", category_prefetch),


### PR DESCRIPTION
Resolves #2247

**Description-**

In order to enable related (non-CFR) citations to show on the frontend, we need to provide that in the API response wherever resources are serialized. In addition, the citations need to be sorted alphabetically.

**This pull request changes...**

- Add dependency on `natsort` to provide the `natsorted()` function which replaces Python's built-in `sorted()` function.
    - This is needed because alphabetical sorting is incorrect when inconsistent-length numbers are in the strings. For example, `sorted(["1", "2", "3", "10"])` would become `["1", "10", "2", "3"]`. Natsort resolves this.
- Add natural sorting (and whitespace removal) to the pre-save hook for custom reference fields (+unit test).
- Add Resources app migration to re-save all resources to utilize the new pre-save hook behavior.
- Add serializers for USC and Act citations.
- Use new serializers in the Resource serializer to enable these citations to show in `/v3/resources` and `/v3/content-search`.
- Unrelated quick fix for resource category prefetching: add prefetching for prefetched subcategory parents.

**Steps to manually verify this change...**

1. Verify green checks (deploy & migrate succeeded.)
2. Check `/v3/resources` API endpoint and search for "usc_citations" and "act_citations", see that the response includes these fields and some items have one or both of these fields populated (and for those that do, that they are in alphabetical order).
3. Do the same as step 2 for `/v3/content-search/?q=test`.