### PR TITLE
[bugfix] Fix bug on category admin list view: invalid prefetch

### DIFF
--- a/solution/backend/resources/admin/categories.py
+++ b/solution/backend/resources/admin/categories.py
@@ -3,6 +3,7 @@ from django.db.models import Prefetch
 
 from common.admin import CustomAdminMixin
 from resources.models import (
+    AbstractCategory,
     InternalCategory,
     InternalSubCategory,
     PublicCategory,
@@ -39,7 +40,7 @@ class PublicSubCategoryAdmin(AbstractCategoryAdmin):
             super()
             .get_queryset(request)
             .prefetch_related(
-                Prefetch("parent", PublicCategory.objects.all()),
+                Prefetch("parent", AbstractCategory.objects.select_subclasses()),
             )
         )
 
@@ -69,6 +70,6 @@ class InternalSubCategoryAdmin(AbstractCategoryAdmin):
             super()
             .get_queryset(request)
             .prefetch_related(
-                Prefetch("parent", InternalCategory.objects.all()),
+                Prefetch("parent", AbstractCategory.objects.select_subclasses()),
             )
         )


### PR DESCRIPTION
Resolves #n/a

**Description-**

A 500 error is occurring on the public and internal subcategory admin panel list views. It's because we're prefetching parent categories for the list display, but we were specifying the models to prefetch as `InternalCategory` and `PublicCategory` instead of the abstract class.

**This pull request changes...**

- `InternalCategory.objects.all()` and `PublicCategory.objects.all()` in prefetch calls replaced with `AbstractCategory.objects.select_subclasses()`.

**Steps to manually verify this change...**

1. Go to the admin panel and click on public subcategory, make sure the page loads and parent categories are displaying properly.
2. Go to internal subcategory, make sure the page loads and parent categories are displaying properly.

