### PR TITLE
EREGCSC-2813 Add and enable pgvector extension

### DIFF
--- a/.github/workflows/test-django.yml
+++ b/.github/workflows/test-django.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
     services:
       postgres:
-        image: postgres
+        image: pgvector/pgvector:pg15  # Use the same image as in docker-compose.yml
         env:
           POSTGRES_HOST: localhost
           POSTGRES_DB: eregs

--- a/solution/backend/content_search/migrations/0007_enable_pgvector.py
+++ b/solution/backend/content_search/migrations/0007_enable_pgvector.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+from pgvector.django import VectorExtension
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('content_search', '0006_populate_date_field'),
+    ]
+
+    operations = [
+        VectorExtension(),
+    ]

--- a/solution/backend/requirements.txt
+++ b/solution/backend/requirements.txt
@@ -28,3 +28,4 @@ djangorestframework_simplejwt
 olefile
 sqlparse>=0.5.0 # not directly required, pinned by Snyk to avoid a vulnerability
 natsort==8.4.0
+pgvector==0.4.1

--- a/solution/docker-compose.yml
+++ b/solution/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
     name: eregs
 services:
   db:
-    image: postgres:15.2
+    image: pgvector/pgvector:pg15
     environment:
       POSTGRES_USER: eregsuser
       POSTGRES_PASSWORD: sgere


### PR DESCRIPTION
Resolves #2813

**Description-**

To enable the rest of our planned hybrid semantic search work, we first need to enable pgvector and pgvector-python.

**This pull request changes...**

- Add pgvector-python requirement.
- Add pgvector enable migration to content-search app.
- Switch local database Docker container to use version of Postgres containing pgvector extension.

**Steps to manually verify this change...**

Validate the site continues to work as expected. No changes to behavior are expected at this time.

