### PR TITLE
EREGCSC-2613 -- Citation link

### DIFF
--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 
 from cmcs_regulations.utils.api_exceptions import BadRequest
 from cmcs_regulations.utils.pagination import ViewSetPagination
+from regulations.utils import LinkConversionsMixin
 from resources.models import (
     AbstractCategory,
     AbstractCitation,
@@ -102,7 +103,7 @@ class ContentSearchPagination(ViewSetPagination):
         ),
     ] + ViewSetPagination.QUERY_PARAMETERS,
 )
-class ContentSearchViewSet(viewsets.ReadOnlyModelViewSet):
+class ContentSearchViewSet(LinkConversionsMixin, viewsets.ReadOnlyModelViewSet):
     model = ContentIndex
     serializer_class = ContentSearchSerializer
     pagination_class = ContentSearchPagination

--- a/solution/backend/content_search/views.py
+++ b/solution/backend/content_search/views.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 
 from cmcs_regulations.utils.api_exceptions import BadRequest
 from cmcs_regulations.utils.pagination import ViewSetPagination
-from regulations.utils import LinkConversionsMixin
+from regulations.utils import LinkConfigMixin, LinkConversionsMixin
 from resources.models import (
     AbstractCategory,
     AbstractCitation,
@@ -103,7 +103,7 @@ class ContentSearchPagination(ViewSetPagination):
         ),
     ] + ViewSetPagination.QUERY_PARAMETERS,
 )
-class ContentSearchViewSet(LinkConversionsMixin, viewsets.ReadOnlyModelViewSet):
+class ContentSearchViewSet(LinkConfigMixin, LinkConversionsMixin, viewsets.ReadOnlyModelViewSet):
     model = ContentIndex
     serializer_class = ContentSearchSerializer
     pagination_class = ContentSearchPagination

--- a/solution/backend/regulations/templatetags/link_statutes.py
+++ b/solution/backend/regulations/templatetags/link_statutes.py
@@ -1,13 +1,13 @@
 from functools import partial
 
+from django import template
+
 from regulations.utils import (
     STATUTE_REF_REGEX,
     USC_REF_REGEX,
     replace_sections,
     replace_usc_citations,
 )
-
-from django import template
 
 register = template.Library()
 

--- a/solution/backend/regulations/templatetags/link_statutes.py
+++ b/solution/backend/regulations/templatetags/link_statutes.py
@@ -1,148 +1,15 @@
-import re
 from functools import partial
+
+from regulations.utils import (
+    STATUTE_REF_REGEX,
+    USC_REF_REGEX,
+    replace_sections,
+    replace_usc_citations,
+)
 
 from django import template
 
-from common.patterns import (
-    AND_OR_PATTERN,
-    DASH_PATTERN,
-    DASH_REGEX,
-    LINKED_PARAGRAPH_REGEX,
-    PARAGRAPH_EXTRACT_REGEX,
-    PARAGRAPH_PATTERN,
-    USC_CFR_IGNORE_PATTERN,
-)
-
 register = template.Library()
-
-
-USCODE_LINK_FORMAT = '<a target="_blank" rel="noopener noreferrer" class="external" href="https://uscode.house.gov/view.xhtml'\
-                     '?req=granuleid:USC-prelim-title{}-section{}&num=0&edition=prelim{}">{}</a>'
-USCODE_SUBSTRUCT_FORMAT = "#substructure-location_{}"
-
-NUMBER_PATTERN = r"[0-9]+"
-
-# Extracts the section ID only, for example "1902-1G" and its variations.
-SECTION_ID_PATTERN = rf"\d+[a-z]*(?:(?:{DASH_PATTERN})+[a-z0-9]+)?"
-
-# Matches individual sections, for example "1902(a)(2) and (b)(1)" and its variations.
-SECTION_PATTERN = rf"{SECTION_ID_PATTERN}(?:{AND_OR_PATTERN}{PARAGRAPH_PATTERN})*"
-
-# Matches entire statute references, including one or more sections and an optional Act.
-# For example, "Sections 1902(a)(2) and (b)(1) and 1903(b) of the Social Security Act" and its variations.
-# Will also match "Section 1902" if the section is contained within the DEFAULT_ACT. See tests for more complete examples.
-STATUTE_REF_PATTERN = rf"(?:\bsec(?:tions?|t?s?)?|§|&#xA7;)\.?\s*((?:{SECTION_PATTERN}{AND_OR_PATTERN})+)"\
-                      r"(?:\s*of\s*the\s*([a-z0-9\s]*?(?=\bact\b)))?"
-
-# Regex's are precompiled to improve page load time.
-SECTION_ID_REGEX = re.compile(rf"({SECTION_ID_PATTERN})", re.IGNORECASE)
-SECTION_REGEX = re.compile(rf"({SECTION_PATTERN})", re.IGNORECASE)
-STATUTE_REF_REGEX = re.compile(STATUTE_REF_PATTERN, re.IGNORECASE)
-NUMBER_REGEX = re.compile(NUMBER_PATTERN, re.IGNORECASE)
-
-# The act to use if none is specified, for example "section 1902 of the act" defaults to this.
-DEFAULT_ACT = "Social Security Act"
-
-
-# This takes a section identifier and tries to determine if a dash within it is part of the ID, or marking continuity.
-# We assume that all section IDs start with a number. So we can extract the numeric parts and, if B >= A, we can conclude that
-# it's continuity, e.g. "section 1000A-1003B" means "1000A through 1003B", versus "1000A-1G" where "1G" is part of the ID.
-# Returns ("A", "-B") if it's continuation, or ("A", "") otherwise. Raises ValueError if section starts without a number.
-def split_citation(citation):
-    dash = DASH_REGEX.search(citation)
-    if not dash:
-        return citation, ""
-    # First part of a citation is always numeric, so compare numeric parts to determine continuity
-    split = DASH_REGEX.split(citation, maxsplit=1)
-    a, b = [NUMBER_REGEX.match(i) for i in split]
-    if not a:
-        raise ValueError
-    if not b or int(b.group()) < int(a.group()):
-        return citation, ""
-    return split[0], dash.group() + split[1]
-
-
-# Returns a list containing the first paragraph chain in a section ref.
-# For example, if the section text is "Section 1902(a)(1)(C) and (b)(2)", this will return ["a", "1", "C"].
-def extract_paragraphs(section_text):
-    linked_paragraphs = LINKED_PARAGRAPH_REGEX.search(section_text)  # extract the first paragraph chain (e.g. (a)(1)(c)...)
-    return PARAGRAPH_EXTRACT_REGEX.findall(linked_paragraphs.group()) if linked_paragraphs else None
-
-
-# This function is run by re.sub() to replace individual section refs with links.
-# "act" and "link_conversions" must be passed in via a partial function.
-def replace_section(section, act, link_conversions, exceptions):
-    section_text = section.group()
-    try:
-        citation, remainder = split_citation(section_text)
-    except ValueError:
-        return section_text
-    if DASH_REGEX.sub("-", citation) in exceptions:
-        return section_text
-    section = DASH_REGEX.sub("-", SECTION_ID_REGEX.match(citation).group())  # extract section
-    # only link if section exists within the relevant act
-    if act in link_conversions and section in link_conversions[act]:
-        paragraphs = extract_paragraphs(section_text)
-        conversion = link_conversions[act][section]
-        return USCODE_LINK_FORMAT.format(
-            conversion["title"],
-            DASH_REGEX.sub("-", conversion["usc"]),
-            USCODE_SUBSTRUCT_FORMAT.format("_".join(paragraphs)) if paragraphs else "",
-            citation,
-        ) + remainder
-    return section_text
-
-
-# This middleman re.sub() function is run when an entire statute ref is matched. It performs another substition on individual
-# sections within the ref. It is needed to enforce refs starting with "section" but possibly containing more than one section.
-# "link_conversions" and "do_not_link" must be passed in via a partial function.
-def replace_sections(match, link_conversions, exceptions):
-    act = match.group(2)
-    act = f"{act.strip()} Act" if act else DEFAULT_ACT  # if no act is specified, default to DEFAULT_ACT
-    return SECTION_REGEX.sub(
-        partial(replace_section, act=act, link_conversions=link_conversions, exceptions=exceptions.get(act, [])),
-        match.group(),
-    )
-
-
-# This pattern matches USC citations such as "42 U.S.C. 1901(a)", "42 U.S.C. 1901(a) or (b)",
-# "42 U.S.C. 1901(a) and 1902(b)" and more variations, similar to STATUTE_REF_PATTERN.
-# Negative lookahead ensures "42 U.S.C. 1234 and 41 U.S.C. 4567" doesn't register "1234" and "41" as two sections in one ref.
-USC_REF_PATTERN = rf"(\d+)\s*u.?\s*s.?\s*c.?\s*((?:{SECTION_PATTERN}{AND_OR_PATTERN}(?!{USC_CFR_IGNORE_PATTERN}))+)"
-USC_REF_REGEX = re.compile(USC_REF_PATTERN, re.IGNORECASE)
-
-
-# Replaces individual USC refs with links, to be run by re.sub().
-# "title" must be passed in via a partial function.
-def replace_usc_citation(match, title, exceptions):
-    citation_text = match.group()
-    try:
-        citation, remainder = split_citation(citation_text)
-    except ValueError:
-        return citation_text
-    if DASH_REGEX.sub("-", citation) in exceptions:
-        return citation_text
-    section = SECTION_ID_REGEX.match(citation).group()
-    paragraphs = extract_paragraphs(citation)
-    return USCODE_LINK_FORMAT.format(
-        title,
-        DASH_REGEX.sub("-", section),
-        USCODE_SUBSTRUCT_FORMAT.format("_".join(paragraphs)) if paragraphs else "",
-        citation,
-    ) + remainder
-
-
-# Matches entire USC citations to account for "and", "or" scenarios.
-def replace_usc_citations(match, exceptions):
-    title = match.group(1)
-    section = match.group(2)
-    return match.group().replace(
-        section,
-        SECTION_REGEX.sub(
-            partial(replace_usc_citation, title=title, exceptions=exceptions.get(title, [])),
-            section,
-        )
-    )
 
 
 @register.simple_tag

--- a/solution/backend/regulations/tests/test_link_statutes.py
+++ b/solution/backend/regulations/tests/test_link_statutes.py
@@ -27,6 +27,7 @@ class ReplaceCitationTests(TestCase):
             '6409</a>'
         )
         self.assertEqual(result, expected_link)
+
     def test_replace_usc_citation_generate_url_only_true(self):
         match = MagicMock()
         match.group.side_effect = ["6409"]
@@ -45,8 +46,7 @@ class ReplaceCitationTests(TestCase):
             }
         }
         result = replace_section(
-            match, act =
-                "Social Security Act", link_conversions=link_conversions_mock, exceptions=[], generate_url_only=False
+            match, act="Social Security Act", link_conversions=link_conversions_mock, exceptions=[], generate_url_only=False
         )
         expected_link = (
             '<a target="_blank" rel="noopener noreferrer" class="external" '
@@ -64,8 +64,8 @@ class ReplaceCitationTests(TestCase):
             }
         }
         result = replace_section(
-            match, act =
-                "Social Security Act", link_conversions=link_conversions_mock, exceptions=self.exceptions, generate_url_only=True
+            match,
+            act="Social Security Act", link_conversions=link_conversions_mock, exceptions=self.exceptions, generate_url_only=True
         )
         expected_link = (
             "https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1302&num=0&edition=prelim"

--- a/solution/backend/regulations/tests/test_link_statutes.py
+++ b/solution/backend/regulations/tests/test_link_statutes.py
@@ -1,0 +1,73 @@
+# File: test_link_statutes.py
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from regulations.utils.link_statutes import replace_section, replace_usc_citation
+
+
+class ReplaceCitationTests(TestCase):
+    def setUp(self):
+        # Common setup for tests
+        self.maxDiff = None  # To see full diff in case of failure
+        self.exceptions = {"42": ["1901"]}
+        self.link_conversions = {
+            "Social Security Act": {
+                "1902": {"title": "42", "usc": "1902"}
+            }
+        }
+
+    def test_replace_usc_citation_generate_url_only_false(self):
+        match = MagicMock()
+        match.group.side_effect = ["6409"]
+        result = replace_usc_citation(match, title="42", exceptions=self.exceptions, generate_url_only=False)
+        expected_link = (
+            '<a target="_blank" rel="noopener noreferrer" class="external" '
+            'href="https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section6409&num=0&edition=prelim">'
+            '6409</a>'
+        )
+        self.assertEqual(result, expected_link)
+    def test_replace_usc_citation_generate_url_only_true(self):
+        match = MagicMock()
+        match.group.side_effect = ["6409"]
+        result = replace_usc_citation(match, title="42", exceptions=self.exceptions, generate_url_only=True)
+        expected_link = (
+            "https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section6409&num=0&edition=prelim"
+        )
+        self.assertEqual(result, expected_link)
+
+    def test_replace_section_generate_url_only_false(self):
+        match = MagicMock()
+        match.group.side_effect = ["1102"]
+        link_conversions_mock = {
+            "Social Security Act": {
+                "1102": {"title": "42", "usc": "1302"}
+            }
+        }
+        result = replace_section(
+            match, act =
+                "Social Security Act", link_conversions=link_conversions_mock, exceptions=[], generate_url_only=False
+        )
+        expected_link = (
+            '<a target="_blank" rel="noopener noreferrer" class="external" '
+            'href="https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1302&num=0&edition=prelim">'
+            '1102</a>'
+        )
+        self.assertEqual(result, expected_link)
+
+    def test_replace_section_generate_url_only_true(self):
+        match = MagicMock()
+        match.group.side_effect = ["1102"]
+        link_conversions_mock = {
+            "Social Security Act": {
+                "1102": {"title": "42", "usc": "1302"}
+            }
+        }
+        result = replace_section(
+            match, act =
+                "Social Security Act", link_conversions=link_conversions_mock, exceptions=self.exceptions, generate_url_only=True
+        )
+        expected_link = (
+            "https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1302&num=0&edition=prelim"
+        )
+        self.assertEqual(result, expected_link)

--- a/solution/backend/regulations/tests/test_link_statutes.py
+++ b/solution/backend/regulations/tests/test_link_statutes.py
@@ -16,6 +16,39 @@ class ReplaceCitationTests(TestCase):
             }
         }
 
+    def test_replace_usc_citation_exception_url_only_false(self):
+        match = MagicMock()
+        match.group.side_effect = ["6409"]
+        mock_usc_ref_exceptions = {"26": ["6409"]}
+        mock_title = "26"
+        mock_exceptions = mock_usc_ref_exceptions.get(mock_title, [])
+        result = replace_usc_citation(
+            match, title=mock_title, exceptions=mock_exceptions, generate_url_only=False
+        )
+        self.assertEqual(result, "6409")
+
+    def test_replace_usc_citation_exception_url_only_true(self):
+        match = MagicMock()
+        match.group.side_effect = ["6409"]
+        mock_usc_ref_exceptions = {"26": ["6409"]}
+        mock_title = "26"
+        mock_exceptions = mock_usc_ref_exceptions.get(mock_title, [])
+        result = replace_usc_citation(
+            match, title=mock_title, exceptions=mock_exceptions, generate_url_only=True
+        )
+        self.assertEqual(result, "")
+
+    def test_replace_usc_citation_generate_url_only_false(self):
+        match = MagicMock()
+        match.group.side_effect = ["6409"]
+        result = replace_usc_citation(match, title="42", exceptions={}, generate_url_only=False)
+        expected_link = (
+            '<a target="_blank" rel="noopener noreferrer" class="external" '
+            'href="https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section6409&num=0&edition=prelim">'
+            '6409</a>'
+        )
+        self.assertEqual(result, expected_link)
+
     def test_replace_usc_citation_generate_url_only_true(self):
         match = MagicMock()
         match.group.side_effect = ["6409"]
@@ -25,7 +58,18 @@ class ReplaceCitationTests(TestCase):
         )
         self.assertEqual(result, expected_link)
 
-    def test_replace_section_exception(self):
+    def test_replace_section_exception_url_only_false(self):
+        match = MagicMock()
+        match.group.side_effect = ["1102"]
+        mock_act = "Social Security Act"
+        mock_statute_ref_exceptions = {"Social Security Act": ["1102"]}
+        mock_exceptions = mock_statute_ref_exceptions.get(mock_act, [])
+        result = replace_section(
+            match, act=mock_act, link_conversions=self.link_conversions, exceptions=mock_exceptions, generate_url_only=False
+        )
+        self.assertEqual(result, "1102")
+
+    def test_replace_section_exception_url_only_true(self):
         match = MagicMock()
         match.group.side_effect = ["1102"]
         mock_act = "Social Security Act"

--- a/solution/backend/regulations/tests/test_link_statutes.py
+++ b/solution/backend/regulations/tests/test_link_statutes.py
@@ -10,43 +10,37 @@ class ReplaceCitationTests(TestCase):
     def setUp(self):
         # Common setup for tests
         self.maxDiff = None  # To see full diff in case of failure
-        self.exceptions = {"42": ["1901"]}
         self.link_conversions = {
             "Social Security Act": {
-                "1902": {"title": "42", "usc": "1902"}
+                "1102": {"title": "42", "usc": "1302"}
             }
         }
-
-    def test_replace_usc_citation_generate_url_only_false(self):
-        match = MagicMock()
-        match.group.side_effect = ["6409"]
-        result = replace_usc_citation(match, title="42", exceptions=self.exceptions, generate_url_only=False)
-        expected_link = (
-            '<a target="_blank" rel="noopener noreferrer" class="external" '
-            'href="https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section6409&num=0&edition=prelim">'
-            '6409</a>'
-        )
-        self.assertEqual(result, expected_link)
 
     def test_replace_usc_citation_generate_url_only_true(self):
         match = MagicMock()
         match.group.side_effect = ["6409"]
-        result = replace_usc_citation(match, title="42", exceptions=self.exceptions, generate_url_only=True)
+        result = replace_usc_citation(match, title="42", exceptions={}, generate_url_only=True)
         expected_link = (
             "https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section6409&num=0&edition=prelim"
         )
         self.assertEqual(result, expected_link)
 
+    def test_replace_section_exception(self):
+        match = MagicMock()
+        match.group.side_effect = ["1102"]
+        mock_act = "Social Security Act"
+        mock_statute_ref_exceptions = {"Social Security Act": ["1102"]}
+        mock_exceptions = mock_statute_ref_exceptions.get(mock_act, [])
+        result = replace_section(
+            match, act=mock_act, link_conversions=self.link_conversions, exceptions=mock_exceptions, generate_url_only=True
+        )
+        self.assertEqual(result, "")
+
     def test_replace_section_generate_url_only_false(self):
         match = MagicMock()
         match.group.side_effect = ["1102"]
-        link_conversions_mock = {
-            "Social Security Act": {
-                "1102": {"title": "42", "usc": "1302"}
-            }
-        }
         result = replace_section(
-            match, act="Social Security Act", link_conversions=link_conversions_mock, exceptions=[], generate_url_only=False
+            match, act="Social Security Act", link_conversions=self.link_conversions, exceptions={}, generate_url_only=False
         )
         expected_link = (
             '<a target="_blank" rel="noopener noreferrer" class="external" '
@@ -58,14 +52,9 @@ class ReplaceCitationTests(TestCase):
     def test_replace_section_generate_url_only_true(self):
         match = MagicMock()
         match.group.side_effect = ["1102"]
-        link_conversions_mock = {
-            "Social Security Act": {
-                "1102": {"title": "42", "usc": "1302"}
-            }
-        }
         result = replace_section(
             match,
-            act="Social Security Act", link_conversions=link_conversions_mock, exceptions=self.exceptions, generate_url_only=True
+            act="Social Security Act", link_conversions=self.link_conversions, exceptions={}, generate_url_only=True
         )
         expected_link = (
             "https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-section1302&num=0&edition=prelim"

--- a/solution/backend/regulations/utils/__init__.py
+++ b/solution/backend/regulations/utils/__init__.py
@@ -1,0 +1,1 @@
+from .link_statutes import *  # noqa

--- a/solution/backend/regulations/utils/link_statutes.py
+++ b/solution/backend/regulations/utils/link_statutes.py
@@ -44,7 +44,7 @@ NUMBER_REGEX = re.compile(NUMBER_PATTERN, re.IGNORECASE)
 DEFAULT_ACT = "Social Security Act"
 
 
-# Create a mixin class that adds link conversions to the serializer context.
+# Mixin that adds link conversions to the context
 class LinkConversionsMixin:
     def get_serializer_context(self):
         context = super().get_serializer_context()
@@ -52,7 +52,6 @@ class LinkConversionsMixin:
         return context
 
     def get_link_conversions(self):
-        # This method should be overridden to provide the actual link conversions.
         conversions = {}
         for section, usc, act, title in StatuteLinkConverter.objects.values_list("section", "usc", "act", "title"):
             if act not in conversions:
@@ -64,7 +63,7 @@ class LinkConversionsMixin:
         return conversions
 
 
-# Create a mixin that adds exceptions to the serializer context.
+# Mixin that adds exceptions to the context
 class LinkConfigMixin:
     def get_serializer_context(self):
         context = super().get_serializer_context()
@@ -72,8 +71,6 @@ class LinkConfigMixin:
         return context
 
     def get_link_config(self):
-        # This method should be overridden to provide the actual exceptions.
-
         statute_link_config = StatuteLinkConfiguration.get_solo()
         reg_link_config = RegulationLinkConfiguration.get_solo()
         return {

--- a/solution/backend/regulations/utils/link_statutes.py
+++ b/solution/backend/regulations/utils/link_statutes.py
@@ -1,12 +1,6 @@
 import re
 from functools import partial
 
-
-from regulations.models import (
-    StatuteLinkConverter,
-)
-
-
 from common.patterns import (
     AND_OR_PATTERN,
     DASH_PATTERN,
@@ -15,6 +9,9 @@ from common.patterns import (
     PARAGRAPH_EXTRACT_REGEX,
     PARAGRAPH_PATTERN,
     USC_CFR_IGNORE_PATTERN,
+)
+from regulations.models import (
+    StatuteLinkConverter,
 )
 
 USCODE_LINK_FORMAT = '<a target="_blank" rel="noopener noreferrer" class="external" href="https://uscode.house.gov/view.xhtml'\
@@ -63,7 +60,6 @@ class LinkConversionsMixin:
                 "usc": usc,
             }
         return conversions
-
 
 
 # This takes a section identifier and tries to determine if a dash within it is part of the ID, or marking continuity.

--- a/solution/backend/regulations/utils/link_statutes.py
+++ b/solution/backend/regulations/utils/link_statutes.py
@@ -63,6 +63,7 @@ class LinkConversionsMixin:
             }
         return conversions
 
+
 # Create a mixin that adds exceptions to the serializer context.
 class LinkConfigMixin:
     def get_serializer_context(self):

--- a/solution/backend/regulations/utils/link_statutes.py
+++ b/solution/backend/regulations/utils/link_statutes.py
@@ -1,0 +1,140 @@
+import re
+from functools import partial
+
+from common.patterns import (
+    AND_OR_PATTERN,
+    DASH_PATTERN,
+    DASH_REGEX,
+    LINKED_PARAGRAPH_REGEX,
+    PARAGRAPH_EXTRACT_REGEX,
+    PARAGRAPH_PATTERN,
+    USC_CFR_IGNORE_PATTERN,
+)
+
+USCODE_LINK_FORMAT = '<a target="_blank" rel="noopener noreferrer" class="external" href="https://uscode.house.gov/view.xhtml'\
+                     '?req=granuleid:USC-prelim-title{}-section{}&num=0&edition=prelim{}">{}</a>'
+USCODE_SUBSTRUCT_FORMAT = "#substructure-location_{}"
+
+NUMBER_PATTERN = r"[0-9]+"
+
+# Extracts the section ID only, for example "1902-1G" and its variations.
+SECTION_ID_PATTERN = rf"\d+[a-z]*(?:(?:{DASH_PATTERN})+[a-z0-9]+)?"
+
+# Matches individual sections, for example "1902(a)(2) and (b)(1)" and its variations.
+SECTION_PATTERN = rf"{SECTION_ID_PATTERN}(?:{AND_OR_PATTERN}{PARAGRAPH_PATTERN})*"
+
+# Matches entire statute references, including one or more sections and an optional Act.
+# For example, "Sections 1902(a)(2) and (b)(1) and 1903(b) of the Social Security Act" and its variations.
+# Will also match "Section 1902" if the section is contained within the DEFAULT_ACT. See tests for more complete examples.
+STATUTE_REF_PATTERN = rf"(?:\bsec(?:tions?|t?s?)?|§|&#xA7;)\.?\s*((?:{SECTION_PATTERN}{AND_OR_PATTERN})+)"\
+                      r"(?:\s*of\s*the\s*([a-z0-9\s]*?(?=\bact\b)))?"
+
+# Regex's are precompiled to improve page load time.
+SECTION_ID_REGEX = re.compile(rf"({SECTION_ID_PATTERN})", re.IGNORECASE)
+SECTION_REGEX = re.compile(rf"({SECTION_PATTERN})", re.IGNORECASE)
+STATUTE_REF_REGEX = re.compile(STATUTE_REF_PATTERN, re.IGNORECASE)
+NUMBER_REGEX = re.compile(NUMBER_PATTERN, re.IGNORECASE)
+
+# The act to use if none is specified, for example "section 1902 of the act" defaults to this.
+DEFAULT_ACT = "Social Security Act"
+
+
+# This takes a section identifier and tries to determine if a dash within it is part of the ID, or marking continuity.
+# We assume that all section IDs start with a number. So we can extract the numeric parts and, if B >= A, we can conclude that
+# it's continuity, e.g. "section 1000A-1003B" means "1000A through 1003B", versus "1000A-1G" where "1G" is part of the ID.
+# Returns ("A", "-B") if it's continuation, or ("A", "") otherwise. Raises ValueError if section starts without a number.
+def split_citation(citation):
+    dash = DASH_REGEX.search(citation)
+    if not dash:
+        return citation, ""
+    # First part of a citation is always numeric, so compare numeric parts to determine continuity
+    split = DASH_REGEX.split(citation, maxsplit=1)
+    a, b = [NUMBER_REGEX.match(i) for i in split]
+    if not a:
+        raise ValueError
+    if not b or int(b.group()) < int(a.group()):
+        return citation, ""
+    return split[0], dash.group() + split[1]
+
+
+# Returns a list containing the first paragraph chain in a section ref.
+# For example, if the section text is "Section 1902(a)(1)(C) and (b)(2)", this will return ["a", "1", "C"].
+def extract_paragraphs(section_text):
+    linked_paragraphs = LINKED_PARAGRAPH_REGEX.search(section_text)  # extract the first paragraph chain (e.g. (a)(1)(c)...)
+    return PARAGRAPH_EXTRACT_REGEX.findall(linked_paragraphs.group()) if linked_paragraphs else None
+
+
+# This function is run by re.sub() to replace individual section refs with links.
+# "act" and "link_conversions" must be passed in via a partial function.
+def replace_section(section, act, link_conversions, exceptions):
+    section_text = section.group()
+    try:
+        citation, remainder = split_citation(section_text)
+    except ValueError:
+        return section_text
+    if DASH_REGEX.sub("-", citation) in exceptions:
+        return section_text
+    section = DASH_REGEX.sub("-", SECTION_ID_REGEX.match(citation).group())  # extract section
+    # only link if section exists within the relevant act
+    if act in link_conversions and section in link_conversions[act]:
+        paragraphs = extract_paragraphs(section_text)
+        conversion = link_conversions[act][section]
+        return USCODE_LINK_FORMAT.format(
+            conversion["title"],
+            DASH_REGEX.sub("-", conversion["usc"]),
+            USCODE_SUBSTRUCT_FORMAT.format("_".join(paragraphs)) if paragraphs else "",
+            citation,
+        ) + remainder
+    return section_text
+
+
+# This middleman re.sub() function is run when an entire statute ref is matched. It performs another substition on individual
+# sections within the ref. It is needed to enforce refs starting with "section" but possibly containing more than one section.
+# "link_conversions" and "do_not_link" must be passed in via a partial function.
+def replace_sections(match, link_conversions, exceptions):
+    act = match.group(2)
+    act = f"{act.strip()} Act" if act else DEFAULT_ACT  # if no act is specified, default to DEFAULT_ACT
+    return SECTION_REGEX.sub(
+        partial(replace_section, act=act, link_conversions=link_conversions, exceptions=exceptions.get(act, [])),
+        match.group(),
+    )
+
+
+# This pattern matches USC citations such as "42 U.S.C. 1901(a)", "42 U.S.C. 1901(a) or (b)",
+# "42 U.S.C. 1901(a) and 1902(b)" and more variations, similar to STATUTE_REF_PATTERN.
+# Negative lookahead ensures "42 U.S.C. 1234 and 41 U.S.C. 4567" doesn't register "1234" and "41" as two sections in one ref.
+USC_REF_PATTERN = rf"(\d+)\s*u.?\s*s.?\s*c.?\s*((?:{SECTION_PATTERN}{AND_OR_PATTERN}(?!{USC_CFR_IGNORE_PATTERN}))+)"
+USC_REF_REGEX = re.compile(USC_REF_PATTERN, re.IGNORECASE)
+
+
+# Replaces individual USC refs with links, to be run by re.sub().
+# "title" must be passed in via a partial function.
+def replace_usc_citation(match, title, exceptions):
+    citation_text = match.group()
+    try:
+        citation, remainder = split_citation(citation_text)
+    except ValueError:
+        return citation_text
+    if DASH_REGEX.sub("-", citation) in exceptions:
+        return citation_text
+    section = SECTION_ID_REGEX.match(citation).group()
+    paragraphs = extract_paragraphs(citation)
+    return USCODE_LINK_FORMAT.format(
+        title,
+        DASH_REGEX.sub("-", section),
+        USCODE_SUBSTRUCT_FORMAT.format("_".join(paragraphs)) if paragraphs else "",
+        citation,
+    ) + remainder
+
+
+# Matches entire USC citations to account for "and", "or" scenarios.
+def replace_usc_citations(match, exceptions):
+    title = match.group(1)
+    section = match.group(2)
+    return match.group().replace(
+        section,
+        SECTION_REGEX.sub(
+            partial(replace_usc_citation, title=title, exceptions=exceptions.get(title, [])),
+            section,
+        )
+    )

--- a/solution/backend/regulations/utils/link_statutes.py
+++ b/solution/backend/regulations/utils/link_statutes.py
@@ -135,7 +135,7 @@ USC_REF_REGEX = re.compile(USC_REF_PATTERN, re.IGNORECASE)
 
 # Replaces individual USC refs with links, to be run by re.sub().
 # "title" must be passed in via a partial function.
-def replace_usc_citation(match, title, exceptions):
+def replace_usc_citation(match, title, exceptions, generate_url_only=False):
     citation_text = match.group()
     try:
         citation, remainder = split_citation(citation_text)
@@ -145,12 +145,15 @@ def replace_usc_citation(match, title, exceptions):
         return citation_text
     section = SECTION_ID_REGEX.match(citation).group()
     paragraphs = extract_paragraphs(citation)
-    return USCODE_LINK_FORMAT.format(
+    link = USCODE_LINK_FORMAT.format(
         title,
         DASH_REGEX.sub("-", section),
         USCODE_SUBSTRUCT_FORMAT.format("_".join(paragraphs)) if paragraphs else "",
         citation,
-    ) + remainder
+    )
+    if not generate_url_only:
+        return USCODE_ANCHOR_FORMAT.format(link, citation) + remainder
+    return link
 
 
 # Matches entire USC citations to account for "and", "or" scenarios.

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -15,8 +15,8 @@ from regcore.models import Part
 from regulations.models import (
     RegulationLinkConfiguration,
     StatuteLinkConfiguration,
-    StatuteLinkConverter,
 )
+from regulations.utils import LinkConversionsMixin
 from regulations.views.errors import NotInSubpart
 from regulations.views.mixins import CitationContextMixin
 from regulations.views.utils import find_subpart
@@ -26,7 +26,7 @@ from resources.models import (
 )
 
 
-class ReaderView(CitationContextMixin, TemplateView):
+class ReaderView(CitationContextMixin, LinkConversionsMixin, TemplateView):
 
     template_name = 'regulations/reader.html'
 
@@ -64,15 +64,6 @@ class ReaderView(CitationContextMixin, TemplateView):
         for location in locations:
             resource_count[location.display_name] = location.num_locations
 
-        conversions = {}
-        for section, usc, act, title in StatuteLinkConverter.objects.values_list("section", "usc", "act", "title"):
-            if act not in conversions:
-                conversions[act] = {}
-            conversions[act][section] = {
-                "title": title,
-                "usc": usc,
-            }
-
         statute_link_config = StatuteLinkConfiguration.get_solo()
         reg_link_config = RegulationLinkConfiguration.get_solo()
 
@@ -101,7 +92,7 @@ class ReaderView(CitationContextMixin, TemplateView):
             'view_type':    self.get_view_type(),
             'categories':   categories,
             'resource_count': resource_count,
-            'link_conversions': conversions,
+            'link_conversions': self.get_link_conversions(),
             'link_config': link_config,
             'is_user_authenticated': is_user_authenticated,
             'user': user,

--- a/solution/backend/regulations/views/reader.py
+++ b/solution/backend/regulations/views/reader.py
@@ -12,11 +12,7 @@ from django.views.generic.base import (
 )
 
 from regcore.models import Part
-from regulations.models import (
-    RegulationLinkConfiguration,
-    StatuteLinkConfiguration,
-)
-from regulations.utils import LinkConversionsMixin
+from regulations.utils import LinkConfigMixin, LinkConversionsMixin
 from regulations.views.errors import NotInSubpart
 from regulations.views.mixins import CitationContextMixin
 from regulations.views.utils import find_subpart
@@ -26,7 +22,7 @@ from resources.models import (
 )
 
 
-class ReaderView(CitationContextMixin, LinkConversionsMixin, TemplateView):
+class ReaderView(CitationContextMixin, LinkConfigMixin, LinkConversionsMixin, TemplateView):
 
     template_name = 'regulations/reader.html'
 
@@ -64,18 +60,6 @@ class ReaderView(CitationContextMixin, LinkConversionsMixin, TemplateView):
         for location in locations:
             resource_count[location.display_name] = location.num_locations
 
-        statute_link_config = StatuteLinkConfiguration.get_solo()
-        reg_link_config = RegulationLinkConfiguration.get_solo()
-
-        link_config = {
-            "link_statute_refs": statute_link_config.link_statute_refs,
-            "link_usc_refs": statute_link_config.link_usc_refs,
-            "statute_ref_exceptions": statute_link_config.statute_ref_exceptions_dict,
-            "usc_ref_exceptions": statute_link_config.usc_ref_exceptions_dict,
-            "link_cfr_refs": reg_link_config.link_cfr_refs,
-            "cfr_ref_exceptions": reg_link_config.cfr_ref_exceptions_dict,
-        }
-
         user = self.request.user
         is_user_authenticated = user.is_authenticated
 
@@ -93,7 +77,7 @@ class ReaderView(CitationContextMixin, LinkConversionsMixin, TemplateView):
             'categories':   categories,
             'resource_count': resource_count,
             'link_conversions': self.get_link_conversions(),
-            'link_config': link_config,
+            'link_config': self.get_link_config(),
             'is_user_authenticated': is_user_authenticated,
             'user': user,
         }

--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -79,6 +79,8 @@ class ActCitationSerializer(serializers.Serializer):
 
     def get_url(self, obj):
         conversions = self.context.get("link_conversions")
+        if not conversions:
+            return None
         if obj["act"] and obj["section"]:
             return SECTION_REGEX.sub(
                 partial(

--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -1,12 +1,12 @@
 from functools import partial
 
-from regulations.utils.link_statutes import replace_usc_citation
 from rest_framework import serializers
 
 from regulations.utils import (
     SECTION_REGEX,
     replace_section,
 )
+from regulations.utils.link_statutes import replace_usc_citation
 from resources.models import (
     Section,
     Subpart,

--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -82,7 +82,7 @@ class ActCitationSerializer(serializers.Serializer):
         conversions = self.context.get("link_conversions")
         link_config = self.context.get("link_config")
         statute_ref_exceptions = link_config["statute_ref_exceptions"]
-        if conversions and obj["act"] and obj["section"]:
+        if conversions and link_config["link_statute_refs"] and obj["act"] and obj["section"]:
             return SECTION_REGEX.sub(
                 partial(
                     replace_section,
@@ -103,7 +103,7 @@ class UscCitationSerializer(serializers.Serializer):
 
     def get_url(self, obj):
         link_config = self.context.get("link_config")
-        if obj["title"] and obj["section"]:
+        if link_config["link_usc_refs"] and obj["title"] and obj["section"]:
             return SECTION_REGEX.sub(
                 partial(
                     replace_usc_citation,

--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -81,7 +81,13 @@ class ActCitationSerializer(serializers.Serializer):
         conversions = self.context.get("link_conversions")
         if obj["act"] and obj["section"]:
             return SECTION_REGEX.sub(
-                partial(replace_section, act=obj["act"], link_conversions=conversions, exceptions=[]),
+                partial(
+                    replace_section,
+                    act=obj["act"],
+                    link_conversions=conversions,
+                    exceptions=[],
+                    generate_url_only=True
+                ),
                 obj["section"]
             )
         return None

--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -79,9 +79,7 @@ class ActCitationSerializer(serializers.Serializer):
 
     def get_url(self, obj):
         conversions = self.context.get("link_conversions")
-        if not conversions:
-            return None
-        if obj["act"] and obj["section"]:
+        if conversions and obj["act"] and obj["section"]:
             return SECTION_REGEX.sub(
                 partial(
                     replace_section,

--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -69,6 +69,12 @@ MetaCitationSerializer = ProxySerializerWrapper(
 class ActCitationSerializer(serializers.Serializer):
     act = serializers.CharField()
     section = serializers.CharField()
+    url = serializers.SerializerMethodField()
+
+    def get_url(self, obj):
+        if obj.act and obj.section:
+            return f"/api/v1/citations/act/{obj.act}/{obj.section}/"
+        return None
 
 
 class UscCitationSerializer(serializers.Serializer):

--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -1,5 +1,4 @@
 from functools import partial
-from os import stat
 
 from rest_framework import serializers
 

--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -1,5 +1,11 @@
+from functools import partial
+
 from rest_framework import serializers
 
+from regulations.utils import (
+    SECTION_REGEX,
+    replace_section,
+)
 from resources.models import (
     Section,
     Subpart,
@@ -72,8 +78,12 @@ class ActCitationSerializer(serializers.Serializer):
     url = serializers.SerializerMethodField()
 
     def get_url(self, obj):
-        if obj.act and obj.section:
-            return f"/api/v1/citations/act/{obj.act}/{obj.section}/"
+        conversions = self.context.get("link_conversions")
+        if obj["act"] and obj["section"]:
+            return SECTION_REGEX.sub(
+                partial(replace_section, act=obj["act"], link_conversions=conversions, exceptions=[]),
+                obj["section"]
+            )
         return None
 
 

--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from regulations.utils.link_statutes import replace_usc_citation
 from rest_framework import serializers
 
 from regulations.utils import (
@@ -96,3 +97,17 @@ class ActCitationSerializer(serializers.Serializer):
 class UscCitationSerializer(serializers.Serializer):
     title = serializers.CharField()
     section = serializers.CharField()
+    url = serializers.SerializerMethodField()
+
+    def get_url(self, obj):
+        if obj["title"] and obj["section"]:
+            return SECTION_REGEX.sub(
+                partial(
+                    replace_usc_citation,
+                    title=obj["title"],
+                    exceptions=[],
+                    generate_url_only=True
+                ),
+                obj["section"]
+            )
+        return None

--- a/solution/backend/resources/serializers/resources.py
+++ b/solution/backend/resources/serializers/resources.py
@@ -191,7 +191,7 @@ class ResourceSerializer(serializers.Serializer):
     @extend_schema_field(serializers.ListField(child=serializers.DictField()))
     def get_related_resources(self, obj):
         if self.context.get("show_related", False):
-            return AbstractResourceSerializer(instance=obj.related_resources, many=True).data
+            return AbstractResourceSerializer(instance=obj.related_resources, context=self.context, many=True).data
         return None
 
 

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -10,7 +10,7 @@ from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnl
 
 from cmcs_regulations.utils import ViewSetPagination
 from common.auth import SettingsAuthentication
-from regulations.utils import LinkConversionsMixin
+from regulations.utils import LinkConfigMixin, LinkConversionsMixin
 from resources.models import (
     AbstractCategory,
     AbstractCitation,
@@ -103,7 +103,7 @@ RESOURCE_ENDPOINT_PARAMETERS = [
 ] + ViewSetPagination.QUERY_PARAMETERS
 
 
-class ResourceViewSet(LinkConversionsMixin, viewsets.ModelViewSet):
+class ResourceViewSet(LinkConfigMixin, LinkConversionsMixin, viewsets.ModelViewSet):
     pagination_class = ResourceCountPagination
     serializer_class = AbstractResourceSerializer
     model = AbstractResource

--- a/solution/backend/resources/views/resources.py
+++ b/solution/backend/resources/views/resources.py
@@ -10,6 +10,7 @@ from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnl
 
 from cmcs_regulations.utils import ViewSetPagination
 from common.auth import SettingsAuthentication
+from regulations.utils import LinkConversionsMixin
 from resources.models import (
     AbstractCategory,
     AbstractCitation,
@@ -102,7 +103,7 @@ RESOURCE_ENDPOINT_PARAMETERS = [
 ] + ViewSetPagination.QUERY_PARAMETERS
 
 
-class ResourceViewSet(viewsets.ModelViewSet):
+class ResourceViewSet(LinkConversionsMixin, viewsets.ModelViewSet):
     pagination_class = ResourceCountPagination
     serializer_class = AbstractResourceSerializer
     model = AbstractResource
@@ -121,7 +122,9 @@ class ResourceViewSet(viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     def get_serializer_context(self):
-        return {"show_related": string_to_bool(self.request.GET.get("group_resources"), True)}
+        context = super().get_serializer_context()
+        context["show_related"] = string_to_bool(self.request.GET.get("group_resources"), True)
+        return context
 
     def get_queryset(self):
         citations = self.request.GET.getlist("citations")


### PR DESCRIPTION
Resolves [EREGCSC-2613](https://jiraent.cms.gov/browse/EREGCSC-2613)

**Description**

In "show related citations", statute sections are linked if possible.

**This pull request changes:**

- Moves `act` and `usc` link logic from `link_statutes` template tags file to its own file in `solution/backend/regulations/utils/link_statutes.py`
   - adds `generate_url_only` boolean flag to replace_section` and `replace_usc_citation` methods that when true will return only a URL and not a fully formed anchor element
- Moves Link Conversions and Link Config logic out of `solution/backend/regulations/views/reader.py` and into `utils/link_statutes.py` as mixins
- Imports mixins to `content_search`, `resources`, and `reader` views to add `link_conversions` and `link_config` to view context
- Propagates context to serializers and uses `replace_section` and `replace_usc_citation` utility methods to add `url` field to `act_citations` and `usc_citations` items in citations serializer
   - Ensures that exceptions are respected
- Adds pytest unit tests to assert that `generate_url_only` flag works as expected

**Steps to manually verify this change:**

1. Green check marks
2. Visit [ephemeral deployment](https://w5ithwwiz6.execute-api.us-east-1.amazonaws.com/eph-1681) and log in
3. Ensure that Act and U.S.C. links still render as expected in the reader view (example: [42 CFR Part 433, Subpart A](https://w5ithwwiz6.execute-api.us-east-1.amazonaws.com/eph-1681/42/433/Subpart-A/2024-11-19/))
4. Visit the Search page and execute a sample search (example: [COVID FAQ](https://w5ithwwiz6.execute-api.us-east-1.amazonaws.com/eph-1681/search/?q=COVID+FAQ))
   - Expand "Show Related Citations" and ensure that SSA and U.S.C. links exist where expected and link to the correct places
5. Visit the Subjects page and ensure that "Show Related Citations" has SSA and U.S.C. links exist where expected and link to the correct places (example: [COVID-19](https://w5ithwwiz6.execute-api.us-east-1.amazonaws.com/eph-1681/subjects/?subjects=152))
6. Visit the [admin panel](https://w5ithwwiz6.execute-api.us-east-1.amazonaws.com/eph-1681/admin/) and test that Statute Link Configuration works as expected
   - Uncheck "Link Statute Refs" and ensure that no SSA links are rendered in related citations on Search and Subjects page
   - Uncheck "Link U.S.C. Refs" and ensure that no U.S.C. links are rendered in related citations on Search and Subjects page
   - Re-check all Link Refs boxes and add individual Statute Ref Link Exceptions and U.S.C. Ref Link Exceptions and ensure that those new exceptions are not rendered as links
   - Delete those new exceptions and ensure that those refs are once again rendered as links
   - Assert that this behavior still exists in the reader view

