### PR TITLE
EREGCSC-2886 Update eCFR/FR parsers to Amazon Linux 2023

### DIFF
--- a/solution/parser/ecfr-parser/Dockerfile
+++ b/solution/parser/ecfr-parser/Dockerfile
@@ -1,7 +1,7 @@
-FROM public.ecr.aws/lambda/provided:al2 as build
+FROM public.ecr.aws/lambda/provided:al2023 as build
 
 # install compiler
-RUN yum install -y golang
+RUN dnf install -y golang
 RUN go env -w GOPROXY=direct
 
 # build parser
@@ -11,6 +11,6 @@ RUN go mod download
 RUN go build -tags lambda.norpc -o /main
 
 # copy artifacts to a clean image
-FROM public.ecr.aws/lambda/provided:al2
+FROM public.ecr.aws/lambda/provided:al2023
 COPY --from=build /main /main
 ENTRYPOINT [ "/main" ]

--- a/solution/parser/fr-parser/Dockerfile
+++ b/solution/parser/fr-parser/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/lambda/provided:al2023 as build
 
 # install compiler
-RUN yum install -y golang
+RUN dnf install -y golang
 RUN go env -w GOPROXY=direct
 
 # build parser

--- a/solution/parser/fr-parser/Dockerfile
+++ b/solution/parser/fr-parser/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/provided:al2 as build
+FROM public.ecr.aws/lambda/provided:al2023 as build
 
 # install compiler
 RUN yum install -y golang
@@ -11,6 +11,6 @@ RUN go mod download
 RUN go build -tags lambda.norpc -o /main
 
 # copy artifacts to a clean image
-FROM public.ecr.aws/lambda/provided:al2
+FROM public.ecr.aws/lambda/provided:al2023
 COPY --from=build /main /main
 ENTRYPOINT [ "/main" ]


### PR DESCRIPTION
Resolves #2886

**Description-**

Amazon Linux 2 is outdated and deprecated and so we need to switch to Amazon Linux 2023 to continue to be supported. The only place we are directly using Amazon Linux images is in the eCFR/FR parsers.

**This pull request changes...**

- eCFR and FR parsers switched to al2023 from al2.

**Steps to manually verify this change...**

1. Green checks indicate successful Docker build and deploy.
2. Check the CloudWatch logs for the eCFR and FR parser for this PR (go to CloudWatch -> search for 2886 -> select logs for parsers).
3. Verify logs show that the parsers are successfully running.

