### PR TITLE
[HOTFIX] Handle null value before attempting to iterate using flatMap

### DIFF
--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -648,12 +648,16 @@ const getCurrentSectionFromHash = (windowHash) => {
  * @param {Array<object>} sectionList - array of Table of Contents objects from getSubpartTOC
  * @returns {Array<string>} - array of section identifier numbers as strings
  */
-const getSectionsRecursive = (tocPartsList) =>
-    tocPartsList.flatMap((tocPart) => {
+const getSectionsRecursive = (tocPartsList) => {
+    if (!tocPartsList || !Array.isArray(tocPartsList)) {
+        return [];
+    }
+    return tocPartsList.flatMap((tocPart) => {
         if (tocPart.type !== "section")
             return getSectionsRecursive(tocPart.children);
         return tocPart.identifier[1];
     });
+};
 
 const getFieldVal = ({ item, fieldName }) => {
     if (item?.resource) {


### PR DESCRIPTION
Resolves `prod` bug

**Description**

For certain parts of the regs, the right sidebar in the reader view will not populate with public documents even if the documents exist and should be displayed.

Here's an example of the error on `prod`:

/42/441/Subpart-F/2024-10-02/

The following error appears in the devtools console:

```
TypeError: Cannot read properties of null (reading 'flatMap')
```

It's likely that whatever method is calling `flatMap` (which in this case is `getSectionsRecursive`) is not handling null values properly.  Consequently, the right sidebar public resources component is crashing.  

These null values are likely due to the two "default" empty categories that are displayed but do not have any results: "Implementation Resources" and "Oversight Reports".  If these default categories are not empty, there is no issue.  If at least one default category is empty, the entire component crashes.

**This pull request changes:**

- Adds early return as guard against iterating over `null` value that will not crash the right sidebar component

**Steps to manually verify this change:**

1. Green check marks
2. Visit [42 CFR 441 Subpart F on the ephemeral deployment](https://6opqqvupl0.execute-api.us-east-1.amazonaws.com/eph-1690/42/441/Subpart-F/2024-10-02/) and validate that public resources are appearing in the right sidebar and there is no longer an error in the devtools console
   - compare to the [same Subpart on another ephemeral deployment](https://lxe9zu4ee5.execute-api.us-east-1.amazonaws.com/eph-1687/42/441/Subpart-F/2024-10-02/) and note the error in the console

