### PR TITLE
EREGCSC-2976 Fix vulnerability in redirect lambda

### DIFF
--- a/solution/backend/redirect_lambda.py
+++ b/solution/backend/redirect_lambda.py
@@ -1,13 +1,10 @@
 import os
-from urllib.parse import urljoin
 
 
 def handler(event, context):
-    original_path = event['path']
-
     # Not using "get" because we want to fail if the environment variable is not set
     new_domain = os.environ["CUSTOM_URL"]
-    redirect_url = urljoin(f"https://{new_domain}", original_path)
+    redirect_url = f"https://{new_domain}"
 
     response = {
         'statusCode': 302,


### PR DESCRIPTION
Remove ability to redirect to non-root paths which introduced an open redirect vulnerability. Now the lambda will _always_ redirect to the homepage. This will force users to update bookmarks, but the pilot domain has been deprecated for some time already.

Resolves #

**Description-**

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change

