### PR TITLE
[hotfix] Pass github.run_id as environment variable to site lambdas

### DIFF
--- a/.github/workflows/deploy-to-env.yml
+++ b/.github/workflows/deploy-to-env.yml
@@ -95,15 +95,15 @@ jobs:
           pushd cdk-eregs
           npm install
           npm install fs-extra
-          npm install --save-dev @types/fs-extra   
-          STATICASSET_STACK="cms-eregs-${STAGE_NAME}-static-assets"   
+          npm install --save-dev @types/fs-extra
+          STATICASSET_STACK="cms-eregs-${STAGE_NAME}-static-assets"
           npx cdk deploy ${STATICASSET_STACK} \
           -c environment=${ENVIRONMENT} \
           --require-approval never \
           --exclusively \
           --app "npx ts-node bin/static-assets.ts"
           popd
-  
+
   deploy-alternate-sites:
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
@@ -127,11 +127,11 @@ jobs:
         run: |
           pushd cdk-eregs
           npm install
-          
+
           # Get exact stack names
           REDIRECT_STACK="cms-eregs-${STAGE_NAME}-redirect-api"
           MAINTENANCE_STACK="cms-eregs-${STAGE_NAME}-maintenance-api"
-          
+
           npx cdk deploy ${REDIRECT_STACK} ${MAINTENANCE_STACK} \
           -c environment=${ENVIRONMENT} \
           --require-approval never \
@@ -162,9 +162,9 @@ jobs:
         run: |
           pushd cdk-eregs
           npm install
-          
+
           TEXT_EXTRACTOR_STACK="cms-eregs-${STAGE_NAME}-text-extractor"
-          
+
           npx cdk deploy $TEXT_EXTRACTOR_STACK \
           -c environment=${ENVIRONMENT} \
           --require-approval never \
@@ -196,9 +196,9 @@ jobs:
         run: |
           pushd cdk-eregs
           npm install
-          
+
           FR_PARSER_STACK="cms-eregs-${STAGE_NAME}-fr-parser"
-          
+
           npx cdk deploy $FR_PARSER_STACK \
           -c environment=${ENVIRONMENT} \
           --require-approval never \
@@ -230,9 +230,9 @@ jobs:
         run: |
           pushd cdk-eregs
           npm install
-          
+
           ECFR_PARSER_STACK="cms-eregs-${STAGE_NAME}-ecfr-parser"
-          
+
           npx cdk deploy $ECFR_PARSER_STACK \
           -c environment=${ENVIRONMENT} \
           --require-approval never \
@@ -264,22 +264,22 @@ jobs:
         run: |
           pushd cdk-eregs
           npm install
-          
+
           PARSER_LAUNCHER_STACK="cms-eregs-${STAGE_NAME}-parser-launcher"
-          
+
           npx cdk deploy $PARSER_LAUNCHER_STACK \
           -c environment=${ENVIRONMENT} \
           --require-approval never \
           --exclusively \
           --app "npx ts-node bin/docker-lambdas.ts"
-          popd          
+          popd
 
   deploy-site:
     needs: [deploy-static-assets, deploy-text-extractor]
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}
     outputs:
-      api_url: ${{ steps.get-api-url.outputs.api_url }}  
+      api_url: ${{ steps.get-api-url.outputs.api_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -297,12 +297,13 @@ jobs:
           STAGE_NAME: ${{ inputs.stage_name }}
           ENVIRONMENT: ${{ inputs.environment }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           pushd cdk-eregs
           npm install
-          
+
           API_STACK="cms-eregs-${STAGE_NAME}-api"
-          
+
           npx cdk deploy $API_STACK \
           -c environment=${ENVIRONMENT} \
           -c buildId="${GITHUB_RUN_ID}" \
@@ -356,7 +357,7 @@ jobs:
           body: |
             ✨ See the Django Site deployed at: ${{ env.SITE_URL }} ✨
           reactions: "+1"
- 
+
   test-cypress:
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-22.04

--- a/cdk-eregs/lib/stacks/api-stack.ts
+++ b/cdk-eregs/lib/stacks/api-stack.ts
@@ -92,7 +92,7 @@ class SecurityGroupHandler {
                 );
             }
         }
-  
+
         // For non-ephemeral environments, create new security group
         const serverlessSG = new ec2.SecurityGroup(scope, 'ServerlessSecurityGroup', {
             vpc,
@@ -280,7 +280,7 @@ export class BackendStack extends cdk.Stack {
             EUA_FEATUREFLAG: ssmParams.euaFeatureFlag,
             AWS_STORAGE_BUCKET_NAME: storageBucket.bucketName,
             TEXT_EXTRACTOR_QUEUE_URL: textExtractorQueue.queueUrl,
-            DEPLOY_NUMBER: process.env.RUN_ID || '',
+            DEPLOY_NUMBER: buildId,
             HTTP_AUTH_SECRET: SECRET_NAMES.HTTP_CREDENTIALS,
             DJANGO_SECRET: SECRET_NAMES.DJANGO_CREDENTIALS,
             READER_SECRET: SECRET_NAMES.READER_CREDENTIALS,
@@ -289,7 +289,7 @@ export class BackendStack extends cdk.Stack {
         // ================================
         // LOG GROUPS
         // ================================
-        const createLogGroup = (name: string): logs.LogGroup => 
+        const createLogGroup = (name: string): logs.LogGroup =>
             new logs.LogGroup(this, `${name}LogGroup`, {
                 logGroupName: stageConfig.aws.lambda(name),
                 retention: logs.RetentionDays.ONE_MONTH,


### PR DESCRIPTION
Resolves #n/a

**Description-**

@PhilR8 noted that the `DEPLOY_NUMBER` variable used to invalidate caches (like this: `<script src="{% static '/bundles/eregs-main.iife.js' %}?{{ DEPLOY_NUMBER }}"></script>`) is blank and so doesn't work. This is an oversight from our CDK transition.

**This pull request changes...**

- Use `buildId` CDK context variable to construct the `DEPLOY_NUMBER` environment variable.
- Populate the Github Actions step environment variable `GITHUB_RUN_ID` with `${{ github.run_id }}` like before with Serverless.
- Unrelated: VS Code auto-fixed some lines with extra spaces. 

**Steps to manually verify this change...**

1. Go to the homepage of the experimental deploy and view page source.
2. Check that the stylesheets and JS files linked all have a `?<deploy_number>` after them.
3. If more validation is desired: push a commit to this PR and confirm that the number changes.

