### PR TITLE
EREGCSC-2977 - Show related subjects in sidebars

### DIFF
--- a/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
+++ b/solution/ui/regulations/css/scss/partials/_supplemental_content.scss
@@ -164,6 +164,14 @@
         text-decoration: none;
         font-size: var(--font-size-sm);
     }
+
+    .supplemental-content-subjects-toggle {
+        color: $primary_link_color;
+        cursor: pointer;
+        font-size: var(--font-size-xs);
+        text-decoration: none;
+        display: inline-block;
+    }
 }
 
 .internal-docs__container {

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentList.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentList.vue
@@ -43,6 +43,7 @@ const showMoreNeeded = computed(() => contentCount.value > props.limit);
             :url="content.url"
             :doc-type="content.type ?? 'external'"
             :file-name="content.file_name"
+            :subjects="content.subjects"
         />
         <collapse-button
             v-if="showMoreNeeded"
@@ -78,6 +79,7 @@ const showMoreNeeded = computed(() => contentCount.value > props.limit);
                 :uid="content.uid"
                 :url="content.url"
                 :doc-type="content.type ?? 'external'"
+                :subjects="content.subjects"
                 :file-name="content.file_name"
             />
             <collapse-button

--- a/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentObject.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/SupplementalContentObject.vue
@@ -1,5 +1,7 @@
 <script setup>
 import { DOCUMENT_TYPES_MAP, getFileTypeButton, getLinkDomainFileTypeEl, getLinkDomainString } from "utilities/utils";
+import { ref } from "vue";
+import SubjectChips from "../../../eregs-vite/src/components/subjects/SubjectChips.vue";
 
 defineProps({
     name: {
@@ -38,6 +40,11 @@ defineProps({
     },
     fileName: {
         type: String,
+        required: false,
+        default: undefined,
+    },
+    subjects: {
+        type: Array,
         required: false,
         default: undefined,
     },
@@ -97,6 +104,9 @@ const getLinkClasses = (docType, description) => {
                 docType === "internal_link") && isBlank(description),
     };
 };
+
+const showSubjects = ref(false);
+const hasSubjects = (subjects) => Array.isArray(subjects) && subjects.length > 0;
 </script>
 
 <template>
@@ -129,5 +139,24 @@ const getLinkClasses = (docType, description) => {
                 />
             </div>
         </a>
+        <div v-if="hasSubjects(subjects)" class="supplemental-content-subjects">
+            <a
+                href="#"
+                class="supplemental-content-subjects-toggle"
+                @click.prevent="showSubjects = !showSubjects"
+            >
+                <span v-if="!showSubjects">
+                    Show Related Subjects
+                    <i class="fa fa-chevron-down" />
+                </span>
+                <span v-else>
+                    Hide Related Subjects
+                    <i class="fa fa-chevron-up" />
+                </span>
+            </a>
+            <div v-if="showSubjects" class="supplemental-content-subjectchips">
+                <SubjectChips :subjects="subjects" />
+            </div>
+        </div>
     </div>
 </template>


### PR DESCRIPTION
Resolves #[EREGCSC-2977](https://jiraent.cms.gov/browse/EREGCSC-2977)

**Description-**

This is a prototype version of showing related subjects in regulation sidebars, for design discussion.

**This pull request changes...**

Adds "Show Related Subjects" and "Hide Related Subjects" to regulation page sidebars, so we can see what this looks like with real data. Limitations:

- Does not include nice animation for expand/collapse
- Subjects are not clickable

Does not apply to Federal Register documents.

**Steps to manually verify this change...**

Go to a regulation page and look at the sidebar.