### PR TITLE
EREGCSC-2974-A Temporarily disable the text extractor

### DIFF
--- a/cdk-eregs/lib/stacks/api-stack.ts
+++ b/cdk-eregs/lib/stacks/api-stack.ts
@@ -209,10 +209,10 @@ export class BackendStack extends cdk.Stack {
         // ================================
         // SQS QUEUE
         // ================================
-        const textExtractorQueue = sqs.Queue.fromQueueAttributes(this, 'ImportedTextExtractorQueue', {
-            queueUrl: cdk.Fn.importValue(stageConfig.getResourceName('text-extractor-queue-url')),
-            queueArn: cdk.Fn.importValue(stageConfig.getResourceName('text-extractor-queue-arn')),
-        });
+        // const textExtractorQueue = sqs.Queue.fromQueueAttributes(this, 'ImportedTextExtractorQueue', {
+        //     queueUrl: cdk.Fn.importValue(stageConfig.getResourceName('text-extractor-queue-url')),
+        //     queueArn: cdk.Fn.importValue(stageConfig.getResourceName('text-extractor-queue-arn')),
+        // });
 
         // ================================
         // SSM PARAMETERS
@@ -279,7 +279,8 @@ export class BackendStack extends cdk.Stack {
             SEARCH_HEADLINE_MAX_FRAGMENTS: ssmParams.searchHeadlineMaxFragments,
             EUA_FEATUREFLAG: ssmParams.euaFeatureFlag,
             AWS_STORAGE_BUCKET_NAME: storageBucket.bucketName,
-            TEXT_EXTRACTOR_QUEUE_URL: textExtractorQueue.queueUrl,
+            //TEXT_EXTRACTOR_QUEUE_URL: textExtractorQueue.queueUrl,
+            TEXT_EXTRACTOR_QUEUE_URL: "",
             DEPLOY_NUMBER: buildId,
             HTTP_AUTH_SECRET: SECRET_NAMES.HTTP_CREDENTIALS,
             DJANGO_SECRET: SECRET_NAMES.DJANGO_CREDENTIALS,
@@ -361,7 +362,8 @@ export class BackendStack extends cdk.Stack {
             securityGroup: serverlessSG,
             environmentVariables,
             storageBucketName: storageBucket.bucketName,
-            queueUrl: textExtractorQueue.queueUrl,
+            //queueUrl: textExtractorQueue.queueUrl,
+            queueUrl: "",
             lambdaConfig: props.lambdaConfig,
             stageConfig,
             vpcSubnets: selectedSubnets,
@@ -373,7 +375,7 @@ export class BackendStack extends cdk.Stack {
         // PERMISSIONS
         // ================================
         storageBucket.grantReadWrite(regSiteLambda);
-        textExtractorQueue.grantSendMessages(regSiteLambda);
+        //textExtractorQueue.grantSendMessages(regSiteLambda);
 
         // DB inspection permissions
         [createDbLambda, dropDbLambda, migrateLambda, createSuLambda].forEach(lambdaFn => {

--- a/cdk-eregs/lib/stacks/api-stack.ts
+++ b/cdk-eregs/lib/stacks/api-stack.ts
@@ -8,7 +8,7 @@ import {
     aws_ec2 as ec2,
     aws_s3 as s3,
     aws_lambda as lambda,
-    aws_sqs as sqs,
+    //aws_sqs as sqs,
     aws_ssm as ssm,
     aws_logs as logs,
     aws_iam as iam,

--- a/cdk-eregs/lib/stacks/text-extract-stack.ts
+++ b/cdk-eregs/lib/stacks/text-extract-stack.ts
@@ -46,7 +46,7 @@ export interface TextExtractorStackProps extends cdk.StackProps {
 
 /**
  * CDK Stack implementation for Text Extractor service.
- *
+ * 
  * This stack creates a serverless text extraction service with the following components:
  * - Docker-based Lambda function for text extraction using AWS managed VPC
  * - SQS Queue with Dead Letter Queue for reliable message processing
@@ -62,13 +62,11 @@ export class TextExtractorStack extends cdk.Stack {
         // SQS QUEUES
         // ================================
         const deadLetterQueue = new sqs.Queue(this, 'DeadLetterQueue', {
-            queueName: stageConfig.getResourceName('text-extractor-dl-queue.fifo'),
-            fifo: true,
+            queueName: stageConfig.getResourceName('text-extractor-dl-queue'),
         });
 
         const queue = new sqs.Queue(this, 'TextExtractorQueue', {
-            queueName: stageConfig.getResourceName('text-extractor-queue.fifo'),
-            fifo: true,
+            queueName: stageConfig.getResourceName('text-extractor-queue'),
             visibilityTimeout: cdk.Duration.seconds(900),
             retentionPeriod: cdk.Duration.days(4),
             deadLetterQueue: {

--- a/cdk-eregs/lib/stacks/text-extract-stack.ts
+++ b/cdk-eregs/lib/stacks/text-extract-stack.ts
@@ -46,7 +46,7 @@ export interface TextExtractorStackProps extends cdk.StackProps {
 
 /**
  * CDK Stack implementation for Text Extractor service.
- * 
+ *
  * This stack creates a serverless text extraction service with the following components:
  * - Docker-based Lambda function for text extraction using AWS managed VPC
  * - SQS Queue with Dead Letter Queue for reliable message processing
@@ -62,11 +62,13 @@ export class TextExtractorStack extends cdk.Stack {
         // SQS QUEUES
         // ================================
         const deadLetterQueue = new sqs.Queue(this, 'DeadLetterQueue', {
-            queueName: stageConfig.getResourceName('text-extractor-dl-queue'),
+            queueName: stageConfig.getResourceName('text-extractor-dl-queue.fifo'),
+            fifo: true,
         });
 
         const queue = new sqs.Queue(this, 'TextExtractorQueue', {
-            queueName: stageConfig.getResourceName('text-extractor-queue'),
+            queueName: stageConfig.getResourceName('text-extractor-queue.fifo'),
+            fifo: true,
             visibilityTimeout: cdk.Duration.seconds(900),
             retentionPeriod: cdk.Duration.days(4),
             deadLetterQueue: {

--- a/solution/backend/resources/utils/aws_utils.py
+++ b/solution/backend/resources/utils/aws_utils.py
@@ -4,7 +4,6 @@ from urllib.parse import urlparse
 import boto3
 import requests
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 
 from resources.models import FederalRegisterLink, ResourcesConfiguration
@@ -57,8 +56,6 @@ def _extract_via_sqs(batch, client):
         "Id": str(i["id"]),
         "MessageBody": json.dumps(i),
     } for i in batch]
-
-    print("hello")
 
     try:
         resp = client.send_message_batch(
@@ -144,7 +141,7 @@ def _should_ignore_robots_txt(resource, allow_list):
 #   - USE_LOCAL_TEXT_EXTRACTOR: if true will use the local dockerized text extractor instead of the AWS client.
 #   - TEXT_EXTRACTOR_QUEUE_URL: if set will use the SQS queue instead of invoking the Lambda directly.
 #   - TEXT_EXTRACTOR_ARN: if the above is not set and this is, will invoke the Lamba directly.
-# If none of these are set, ImproperlyConfigured is raised.
+# If none of these are set, extraction will fail for all resources.
 #
 # Arguments:
 # request: the Django Request object that caused this call to occur.
@@ -205,7 +202,11 @@ def call_text_extractor(request, resources):
         extract_function = _extract_via_lambda
         client = establish_client("lambda")
     else:
-        raise ImproperlyConfigured("The text extractor destination is not configured.")
+        failures += [{
+            "id": i["id"],
+            "reason": "The text extractor destination is not configured.",
+        } for i in requests]
+        requests = []
 
     for batch in [requests[i:i + 10] for i in range(0, len(requests), 10)]:
         success, fail = extract_function(batch, client)

--- a/solution/backend/resources/utils/aws_utils.py
+++ b/solution/backend/resources/utils/aws_utils.py
@@ -58,6 +58,8 @@ def _extract_via_sqs(batch, client):
         "MessageBody": json.dumps(i),
     } for i in batch]
 
+    print("hello")
+
     try:
         resp = client.send_message_batch(
             QueueUrl=settings.TEXT_EXTRACTOR_QUEUE_URL,


### PR DESCRIPTION
Resolves part of #2974

**Description-**

In order to convert the text extractor's SQS queue from standard to FIFO, we can't have the eRegs site depending on the queue via exported URL or ARN. This is because in order to do the switch, AWS must delete the old queue and create a new one in its place. Attempting to do this currently will fail as the deploy process won't allow the deletion of a resource that is depended on by a downstream stack.

**This pull request changes...**

- Temporarily disable the text extractor by removing imports in the CDK API stack.
- Modify the text extractor calling code to properly display an admin panel error in the case where the text extractor's destination URL or ARN is not configured.

**Steps to manually verify this change...**

1. Go to the admin panel -> public links.
2. Select one or more resources and use the action dropdown to attempt to extract text.
3. Observe the red error banner at the top of the page that results. This is expected until the next 2974 PR is deployed.

