### PR TITLE
EREGCSC-2969 - Manual in navigation + jump to statute

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+        {
+            "type": "npm",
+            "script": "eslint",
+            "problemMatcher": [],
+            "label": "npm: eslint",
+            "detail": "eslint"
+        }
+    ]
+}

--- a/solution/backend/regulations/templates/regulations/manual.html
+++ b/solution/backend/regulations/templates/regulations/manual.html
@@ -25,6 +25,7 @@
     data-home-url="{% url 'homepage' %}"
     data-host="{{ host }}"
     data-is-authenticated="{{ user.is_authenticated }}"
+    data-manual-url="{% url 'manual' %}"
     data-search-url="{% url 'search' %}"
     data-statutes-url="{% url 'statutes' %}"
     data-subjects-url="{% url 'subjects' %}"

--- a/solution/backend/regulations/templates/regulations/search.html
+++ b/solution/backend/regulations/templates/regulations/search.html
@@ -20,6 +20,7 @@
     data-home-url="{% url 'homepage' %}"
     data-host="{{ host }}"
     data-is-authenticated="{{ user.is_authenticated }}"
+    data-manual-url="{% url 'manual' %}"
     data-search-url="{% url 'search' %}"
     data-statutes-url="{% url 'statutes' %}"
     data-subjects-url="{% url 'subjects' %}"

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load string_formatters %}
 
-{% block title_prefix %}Statute Reference | {% endblock %}
+{% block title_prefix %}Social Security Act | {% endblock %}
 
 {% block outside_vue %}
     {{ site_config|json_script:"site_config" }}

--- a/solution/backend/regulations/templates/regulations/statute.html
+++ b/solution/backend/regulations/templates/regulations/statute.html
@@ -25,7 +25,9 @@
     data-home-url="{% url 'homepage' %}"
     data-host="{{ host }}"
     data-is-authenticated="{{ user.is_authenticated }}"
+    data-manual-url="{% url 'manual' %}"
     data-search-url="{% url 'search' %}"
+    data-statutes-url="{% url 'statutes' %}"
     data-subjects-url="{% url 'subjects' %}"
     data-username="{{ user.username }}"
 ></div>

--- a/solution/backend/regulations/templates/regulations/subjects.html
+++ b/solution/backend/regulations/templates/regulations/subjects.html
@@ -21,6 +21,7 @@
     data-home-url="{% url 'homepage' %}"
     data-host="{{ host }}"
     data-is-authenticated="{{ is_authenticated }}"
+    data-manual-url="{% url 'manual' %}"
     data-search-url="{% url 'search' %}"
     data-statutes-url="{% url 'statutes' %}"
     data-subjects-url="{% url 'subjects' %}"

--- a/solution/ui/regulations/css/scss/partials/_statutes.scss
+++ b/solution/ui/regulations/css/scss/partials/_statutes.scss
@@ -15,10 +15,9 @@
     .statute__container {
         @include eds-gutters;
 
-        .content {
+        .statute-table-section {
             display: flex;
             flex-direction: row;
-            padding-top: 10px;
             padding-left: 10px;
             padding-bottom: 30px;
             border: 1px solid $table_border_color;
@@ -243,4 +242,23 @@
             }
         }
     }
+}
+
+.citation-link-box {
+    display: flex;
+    gap: var(--spacer-1, 0.5rem);
+    align-items: center;
+    margin-bottom: var(--spacer-3, 1.5rem);
+}
+
+.citation-input {
+    width: 450px;
+    padding: 0.5rem;
+    border: 1px solid $border_color;
+    border-radius: 4px;
+    font-size: 1rem;
+}
+#citation-button {
+    font-weight: 700;
+    height: 2.5rem;
 }

--- a/solution/ui/regulations/css/scss/partials/_statutes.scss
+++ b/solution/ui/regulations/css/scss/partials/_statutes.scss
@@ -18,16 +18,18 @@
         .content {
             display: flex;
             flex-direction: row;
-            padding-top: 30px;
+            padding-top: 10px;
+            padding-left: 10px;
             padding-bottom: 30px;
+            border: 1px solid $table_border_color;
+            border-radius: 4px;
 
             @include custom-max(calc((calc($eds-width-md - 1px)) / 1px)) {
                 flex-direction: column;
             }
 
             .content__selector {
-                flex: 0 0 200px;
-                margin-right: 25px;
+                flex: 0 0 120px;
 
                 h3 {
                     font-size: 1.5rem;
@@ -55,6 +57,7 @@
                     }
                 }
 
+
                 .titles-list__link {
                     text-decoration: none;
                     transition: none;
@@ -76,18 +79,19 @@
 
                     &.acts__list {
                         padding-left: 0;
+                        margin-top: 3.5rem;
                     }
 
                     &.titles__list {
                         margin: 0;
+                        padding-left: 0;
+                        font-size: 1.2rem;
                     }
                 }
             }
 
             .table__parent {
                 padding: 0.75rem;
-                border: 1px solid $table_border_color;
-                border-radius: 4px;
                 width: 100%;
 
                 &.loading {

--- a/solution/ui/regulations/css/scss/partials/_statutes.scss
+++ b/solution/ui/regulations/css/scss/partials/_statutes.scss
@@ -20,8 +20,6 @@
             flex-direction: row;
             padding-left: 10px;
             padding-bottom: 30px;
-            border: 1px solid $table_border_color;
-            border-radius: 4px;
 
             @include custom-max(calc((calc($eds-width-md - 1px)) / 1px)) {
                 flex-direction: column;
@@ -78,7 +76,6 @@
 
                     &.acts__list {
                         padding-left: 0;
-                        margin-top: 3.5rem;
                     }
 
                     &.titles__list {
@@ -248,7 +245,42 @@
     display: flex;
     gap: var(--spacer-1, 0.5rem);
     align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+// Styles for the citation help toggle and help text
+.citation-help-toggle-container {
+    margin-top: 0;
     margin-bottom: var(--spacer-3, 1.5rem);
+    padding-left: 2px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    .collapsible-title {
+        color: $primary_link_color;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        background: none;
+        border: none;
+        padding: 0;
+        margin-bottom: 0.25rem;
+        text-decoration: none;
+        transition: color 0.2s;
+
+        &:hover,
+        &:focus {
+            color: $primary_link_hover;
+        }
+    }
+
+    .citation-help-text {
+        font-size: 0.95rem;
+        background: $lightest_blue;
+        padding: 0rem 1rem 1rem;
+        border-radius: 4px;
+    }
 }
 
 .citation-input {

--- a/solution/ui/regulations/css/scss/partials/_statutes.scss
+++ b/solution/ui/regulations/css/scss/partials/_statutes.scss
@@ -20,7 +20,6 @@
             flex-direction: row;
             padding-left: 10px;
             padding-bottom: 30px;
-
             @include custom-max(calc((calc($eds-width-md - 1px)) / 1px)) {
                 flex-direction: column;
             }
@@ -252,12 +251,10 @@
     }
 }
 .citation-help-toggle-container {
-    margin-top: 0;
-    margin-bottom: var(--spacer-3, 1.5rem);
-    padding-left: 2px;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    margin-bottom: .5rem;
 
     .collapsible-title {
         color: $primary_link_color;

--- a/solution/ui/regulations/css/scss/partials/_statutes.scss
+++ b/solution/ui/regulations/css/scss/partials/_statutes.scss
@@ -245,10 +245,12 @@
     display: flex;
     gap: var(--spacer-1, 0.5rem);
     align-items: center;
-    margin-bottom: 0.5rem;
-}
+    margin-bottom: 1rem;
 
-// Styles for the citation help toggle and help text
+    label {
+        font-weight: 700;
+    }
+}
 .citation-help-toggle-container {
     margin-top: 0;
     margin-bottom: var(--spacer-3, 1.5rem);
@@ -284,7 +286,14 @@
 }
 
 .citation-input {
-    width: 450px;
+    width: 200px;
+    padding: 0.5rem;
+    border: 1px solid $border_color;
+    border-radius: 4px;
+    font-size: 1rem;
+}
+.citation-input-short {
+    width: 50px;
     padding: 0.5rem;
     border: 1px solid $border_color;
     border-radius: 4px;

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.vue
@@ -34,14 +34,15 @@ const isTitleActive = ({ act, title }) =>
             :key="`${key}-${i}`"
             class="acts-list__item"
         >
-            <h4
+            <!--<h4
                 class="acts-item__heading"
                 :class="{
                     'acts-item__heading--active': isActActive({ act: key }),
                 }"
             >
                 {{ value.name }}
-            </h4>
+            </h4>-->
+            <h4>View Title</h4>
             <ul class="titles__list">
                 <li
                     v-for="(title, j) in value.titles"

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.vue
@@ -41,7 +41,7 @@ const isTitleActive = ({ act, title }) =>
             >
                 {{ value.name }}
             </h4>-->
-            <h4>View Title</h4>
+            <h4>Included Titles</h4>
             <ul class="titles__list">
                 <li
                     v-for="(title, j) in value.titles"

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/StatuteSelector.vue
@@ -22,7 +22,6 @@ const props = defineProps({
     },
 });
 
-const isActActive = ({ act }) => act === props.selectedAct;
 const isTitleActive = ({ act, title }) =>
     act === props.selectedAct && title === props.selectedTitle;
 </script>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/TableCaption.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/TableCaption.vue
@@ -1,10 +1,10 @@
 <template>
     <div class="table__caption">
-        This table shows sections of <a
+        List of sections of <a
             target="_blank"
             rel="noopener noreferrer"
             class="external"
             href="https://uscode.house.gov/view.xhtml?req=granuleid%3AUSC-prelim-title42-chapter7&amp;saved=%7CZ3JhbnVsZWlkOlVTQy1wcmVsaW0tdGl0bGU0Mi1jaGFwdGVyNy1mcm9udA%3D%3D%7C%7C%7C0%7Cfalse%7Cprelim&amp;edition=prelim"
-        >42 U.S.C. Chapter 7 (Social Security)</a> enacted by the Social Security Act.
+        >42 U.S.C. Chapter 7</a> enacted by the Social Security Act.
     </div>
 </template>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/TableCaption.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/TableCaption.vue
@@ -5,30 +5,6 @@
             rel="noopener noreferrer"
             class="external"
             href="https://uscode.house.gov/view.xhtml?req=granuleid%3AUSC-prelim-title42-chapter7&amp;saved=%7CZ3JhbnVsZWlkOlVTQy1wcmVsaW0tdGl0bGU0Mi1jaGFwdGVyNy1mcm9udA%3D%3D%7C%7C%7C0%7Cfalse%7Cprelim&amp;edition=prelim"
-        >42 U.S.C. Chapter 7 (Social Security)</a> enacted by the Social Security Act. Learn about these sources:
-        <a
-            href="https://uscode.house.gov/"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="external"
-        >US Code House.gov</a>,
-        <a
-            href="https://www.govinfo.gov/app/collection/comps/"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="external"
-        >Statute Compilation</a>,
-        <a
-            href="https://www.govinfo.gov/app/collection/uscode"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="external"
-        >US Code Annual</a>,
-        <a
-            href="https://www.ssa.gov/OP_Home/ssact/ssact.htm"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="external"
-        >SSA.gov Compilation</a>.
+        >42 U.S.C. Chapter 7 (Social Security)</a> enacted by the Social Security Act.
     </div>
 </template>

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
@@ -42,7 +42,7 @@ const ssaSchema = [
             primary: true,
         },
         body: {
-            title: (statute) => `SSA Section ${statute.section}`,
+            title: (statute) => `Section ${statute.section}`,
             label: (statute) => `${statute.title} U.S.C. ${statute.usc}`,
             name: (statute) => `${statute.name}`,
             primary: true,

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/schemas/tableSchemas.js
@@ -57,6 +57,7 @@ const ssaSchema = [
                 (columnDates) =>
                     getDateLabel(columnDates?.us_code_house_gov ?? {}),
             ],
+            learnMoreUrl: "https://uscode.house.gov/",
         },
         body: {
             url: (statute) => houseGovUrl(statute),
@@ -74,6 +75,7 @@ const ssaSchema = [
                 (columnDates) =>
                     getDateLabel(columnDates?.statute_compilation ?? {}),
             ],
+            learnMoreUrl: "https://www.govinfo.gov/app/collection/comps/",
         },
         body: {
             url: (statute) => statuteCompilationUrl(statute),
@@ -91,6 +93,7 @@ const ssaSchema = [
                 (columnDates) =>
                     getDateLabel(columnDates?.us_code_annual ?? {}),
             ],
+            learnMoreUrl: "https://www.govinfo.gov/app/collection/uscode",
         },
         body: {
             url: (statute) => usCodeUrl(statute),
@@ -108,6 +111,7 @@ const ssaSchema = [
                 (columnDates) =>
                     getDateLabel(columnDates?.ssa_gov_compilation ?? {}),
             ],
+            learnMoreUrl: "https://www.ssa.gov/OP_Home/ssact/ssact.htm",
         },
         body: {
             url: (statute) => ssaGovUrl(statute),

--- a/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.vue
+++ b/solution/ui/regulations/eregs-component-lib/src/components/shared-components/Statutes/table-elements/HeaderCell.vue
@@ -28,7 +28,20 @@ const props = defineProps({
         }"
     >
         <div class="cell__title">
-            {{ props.cellData.title }}
+            <template v-if="cellData.learnMoreUrl">
+                <a
+                    :href="cellData.learnMoreUrl"
+                    class="cell__learn-more"
+                    target="_blank"
+                    rel="noopener"
+                    style="color: #fff; text-decoration: underline;"
+                >
+                    {{ props.cellData.title }}
+                </a>
+            </template>
+            <template v-else>
+                {{ props.cellData.title }}
+            </template>
         </div>
         <template v-if="cellData.subtitles">
             <div

--- a/solution/ui/regulations/eregs-vite/src/components/header/HeaderLinks.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/header/HeaderLinks.vue
@@ -22,7 +22,7 @@ defineEmits(["link-clicked"]);
 const links = [
     {
         name: "statutes",
-        label: "Access Statute Citations",
+        label: "Social Security Act",
         active: window.location.pathname.includes("statutes"),
         href: props.statutesUrl,
     },

--- a/solution/ui/regulations/eregs-vite/src/components/header/HeaderLinks.vue
+++ b/solution/ui/regulations/eregs-vite/src/components/header/HeaderLinks.vue
@@ -11,6 +11,10 @@ const props = defineProps({
         type: String,
         required: true,
     },
+    manualUrl: {
+        type: String,
+        required: true,
+    },
     subjectsUrl: {
         type: String,
         required: true,
@@ -25,6 +29,12 @@ const links = [
         label: "Social Security Act",
         active: window.location.pathname.includes("statutes"),
         href: props.statutesUrl,
+    },
+    {
+        name: "manual",
+        label: "State Medicaid Manual",
+        active: window.location.pathname.includes("manual"),
+        href: props.manualUrl,
     },
     {
         name: "subjects",

--- a/solution/ui/regulations/eregs-vite/src/views/Manual.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Manual.vue
@@ -22,6 +22,7 @@ const apiUrl = inject("apiUrl");
 const customLoginUrl = inject("customLoginUrl");
 const homeUrl = inject("homeUrl");
 const isAuthenticated = inject("isAuthenticated");
+const manualUrl = inject("manualUrl");
 const searchUrl = inject("searchUrl");
 const statutesUrl = inject("statutesUrl");
 const subjectsUrl = inject("subjectsUrl");
@@ -72,7 +73,11 @@ const executeSearch = (payload) => {
                     <JumpTo :api-url="apiUrl" :home-url="homeUrl" />
                 </template>
                 <template #links>
-                    <HeaderLinks :statutes-url="statutesUrl" :subjects-url="subjectsUrl" />
+                    <HeaderLinks
+                        :statutes-url="statutesUrl"
+                        :manual-url="manualUrl"
+                        :subjects-url="subjectsUrl"
+                    />
                 </template>
                 <template #search>
                     <HeaderSearch :search-url="searchUrl" />

--- a/solution/ui/regulations/eregs-vite/src/views/Manual.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Manual.vue
@@ -106,34 +106,7 @@ const executeSearch = (payload) => {
             <Banner title="State Medicaid Manual" />
             <div id="main-content" class="manual__container">
                 <div class="">
-                    <p class="manual-page-description">
-                        This table provides links to
-                        <a
-                            class="external"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            href="https://www.cms.gov/Regulations-and-Guidance/Guidance/Manuals/Paper-Based-Manuals-Items/CMS021927"
-                        >
-                            zipped Word documents from the CMS website</a>,
-                        which is the most current and complete version of the manual,
-                        along with links to convenient
-                        <a
-                            class="external"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            href="https://web.archive.org/web/20041212094406/http://www.cms.hhs.gov/manuals/45_smm/pub45toc.asp"
-                        >
-                            web pages</a>
-                        and
-                        <a
-                            class="external"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            href="https://web.archive.org/web/20050204151206/http://www.cms.hhs.gov:80/manuals/pub45pdf/smmtoc.asp"
-                        >
-                            PDFs</a>
-                        from archived copies of the CMS website.
-                    </p>
+                    <h2>Search</h2>
                     <section class="search__container">
                         <div v-if="isAuthenticated" class="search-input__div">
                             <FetchItemsContainer
@@ -169,6 +142,35 @@ const executeSearch = (payload) => {
                             </template>
                         </SignInCTA>
                     </section>
+                    <h2>Table of Contents</h2>
+                    <p class="manual-page-description">
+                        This table provides links to
+                        <a
+                            class="external"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href="https://www.cms.gov/Regulations-and-Guidance/Guidance/Manuals/Paper-Based-Manuals-Items/CMS021927"
+                        >
+                            zipped Word documents from the CMS website</a>,
+                        which is the most current and complete version of the manual,
+                        along with links to convenient
+                        <a
+                            class="external"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href="https://web.archive.org/web/20041212094406/http://www.cms.hhs.gov/manuals/45_smm/pub45toc.asp"
+                        >
+                            web pages</a>
+                        and
+                        <a
+                            class="external"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href="https://web.archive.org/web/20050204151206/http://www.cms.hhs.gov:80/manuals/pub45pdf/smmtoc.asp"
+                        >
+                            PDFs</a>
+                        from archived copies of the CMS website.
+                    </p>
                     <section class="table__parent">
                         <table id="manualTable">
                             <thead>

--- a/solution/ui/regulations/eregs-vite/src/views/Search.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Search.vue
@@ -33,9 +33,9 @@ const accessUrl = inject("accessUrl");
 const adminUrl = inject("adminUrl");
 const apiUrl = inject("apiUrl");
 const customLoginUrl = inject("customLoginUrl");
-const hasEditableJobCode = inject("hasEditableJobCode");
 const homeUrl = inject("homeUrl");
 const isAuthenticated = inject("isAuthenticated");
+const manualUrl = inject("manualUrl");
 const searchUrl = inject("searchUrl");
 const statutesUrl = inject("statutesUrl");
 const subjectsUrl = inject("subjectsUrl");
@@ -248,6 +248,7 @@ getDocsOnLoad();
                 <template #links>
                     <HeaderLinks
                         :statutes-url="statutesUrl"
+                        :manual-url="manualUrl"
                         :subjects-url="subjectsUrl"
                     />
                 </template>

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -125,10 +125,11 @@ getActTitles();
 getStatutesArray();
 
 const citationInput = ref("");
-const handleGetCitationLink = () => {
-    // For now, just log the value. Replace with actual logic as needed.
-    console.info("Citation input:", citationInput.value);
-};
+const showCitationHelp = ref(false);
+
+function toggleCitationHelp() {
+    showCitationHelp.value = !showCitationHelp.value;
+}
 </script>
 
 <template>
@@ -168,22 +169,51 @@ const handleGetCitationLink = () => {
             <Banner title="Social Security Act" />
             <div id="main-content" class="statute__container">
                 <div class="content">
-                    <!-- Citation input/button always at the top -->
+                    <h2>Look Up Statute Text</h2>
                     <div class="citation-link-box">
                         <input
                             v-model="citationInput"
                             type="text"
                             class="citation-input"
                             placeholder="Enter citation, e.g., 1902(a)(74) or 42 U.S.C. 1396a(a)(74)"
-                        />
+                        >
                         <input
                             id="citation-button"
                             class="btn default-btn"
                             type="submit"
-                            value="Get Link to Citation"
+                            value="Go"
                         >
                     </div>
-                    <!-- Statute selector and table grouped together -->
+                    <div class="citation-help-toggle-container">
+                        <button
+                            type="button"
+                            class="collapsible-title"
+                            :aria-expanded="showCitationHelp.toString()"
+                            @click="toggleCitationHelp"
+                            style="background: none; border: none; padding: 0; margin: 0;"
+                        >
+                            <span>{{ showCitationHelp ? 'Hide example formats ▲' : 'Show example formats ▼' }}</span>
+                        </button>
+                        <div v-if="showCitationHelp" class="citation-help-text">
+                            <p><strong>Social Security Act:</strong></p>
+                            <ul>
+                                <li>1945A</li>
+                                <li>1902(a)(74)</li>
+                                <li>1903(m)(2)(A)(x)</li>
+                            </ul>
+                            <p><strong>US Code:</strong></p>
+                            <ul>
+                                <li>42 U.S.C. 1396w-4a</li>
+                                <li>42 U.S.C. 1396(a)(74)</li>
+                                <li>42 U.S.C. 1396b(m)(2)(A)(x)</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <h2>Table of Contents</h2>
+                    <TableCaption
+                        :selected-act="ACT_TYPES[queryParams.act]"
+                        :selected-title="queryParams.title"
+                    />
                     <div class="statute-table-section">
                         <div class="content__selector">
                             <div class="selector__parent">
@@ -205,10 +235,6 @@ const handleGetCitationLink = () => {
                                 class="table__spinner"
                             />
                             <template v-else>
-                                <TableCaption
-                                    :selected-act="ACT_TYPES[queryParams.act]"
-                                    :selected-title="queryParams.title"
-                                />
                                 <StatuteTable
                                     :display-type="isNarrow ? 'list' : 'table'"
                                     :filtered-statutes="statutes.results"

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -172,24 +172,10 @@ function toggleCitationHelp() {
             </HeaderComponent>
         </header>
         <div id="statuteApp" class="statute-view">
-            <Banner title="Social Security Act" />
+            <Banner title="Statute Reference" />
             <div id="main-content" class="statute__container">
                 <div class="content">
                     <h2>Look Up Statute Text</h2>
-                    <div class="citation-link-box">
-                        <input
-                            v-model="citationInput"
-                            type="text"
-                            class="citation-input"
-                            placeholder="Enter citation, e.g., 1902(a)(74) or 42 U.S.C. 1396a(a)(74)"
-                        >
-                        <input
-                            id="citation-button"
-                            class="btn default-btn"
-                            type="submit"
-                            value="Go"
-                        >
-                    </div>
                     <div class="citation-help-toggle-container">
                         <button
                             type="button"
@@ -198,9 +184,16 @@ function toggleCitationHelp() {
                             style="background: none; border: none; padding: 0; margin: 0;"
                             @click="toggleCitationHelp"
                         >
-                            <span>{{ showCitationHelp ? 'Hide example formats ▲' : 'Show example formats ▼' }}</span>
+                            <span>{{ showCitationHelp ? 'Hide examples ▲' : 'Show examples ▼' }}</span>
                         </button>
                         <div v-if="showCitationHelp" class="citation-help-text">
+                            <p>Enter a citation to get a direct link to current text on the
+                                <a
+                                    href="https://uscode.house.gov/"
+                                >
+                                    US Code House.gov</a>
+                                website.
+                            </p>
                             <p><strong>Social Security Act:</strong></p>
                             <ul>
                                 <li>1945A</li>
@@ -215,7 +208,43 @@ function toggleCitationHelp() {
                             </ul>
                         </div>
                     </div>
-                    <h2>Table of Contents</h2>
+                    <div class="citation-link-box">
+                        <label>Social Security Act §</label>
+                        <input
+                            v-model="citationInput"
+                            type="text"
+                            class="citation-input"
+                            placeholder="1903(a)(3)(A)(i)"
+                        >
+                        <input
+                            id="citation-button"
+                            class="btn default-btn"
+                            type="submit"
+                            value="Get Citation Link"
+                        >
+                    </div>
+                    <div class="citation-link-box">
+                        <input
+                            v-model="citationInput"
+                            type="text"
+                            class="citation-input-short"
+                            placeholder="42"
+                        >
+                        <label>U.S.C.</label>
+                        <input
+                            v-model="citationInput"
+                            type="text"
+                            class="citation-input"
+                            placeholder="1396b(a)(3)(A)(i)"
+                        >
+                        <input
+                            id="citation-button"
+                            class="btn default-btn"
+                            type="submit"
+                            value="Get Citation Link"
+                        >
+                    </div>
+                    <h2>Social Security Act Table of Contents</h2>
                     <TableCaption
                         :selected-act="ACT_TYPES[queryParams.act]"
                         :selected-title="queryParams.title"

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -159,12 +159,11 @@ getStatutesArray();
             </HeaderComponent>
         </header>
         <div id="statuteApp" class="statute-view">
-            <Banner title="Look Up Statute Text" />
+            <Banner title="Social Security Act" />
             <div id="main-content" class="statute__container">
                 <div class="content">
                     <div class="content__selector">
                         <div class="selector__parent">
-                            <h3>Included Statute</h3>
                             <StatuteSelector
                                 v-if="!acts.loading"
                                 :loading="statutes.loading"

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -123,6 +123,12 @@ onUnmounted(() => window.removeEventListener("resize", onWidthChange));
 // On load
 getActTitles();
 getStatutesArray();
+
+const citationInput = ref("");
+const handleGetCitationLink = () => {
+    // For now, just log the value. Replace with actual logic as needed.
+    console.info("Citation input:", citationInput.value);
+};
 </script>
 
 <template>
@@ -162,36 +168,54 @@ getStatutesArray();
             <Banner title="Social Security Act" />
             <div id="main-content" class="statute__container">
                 <div class="content">
-                    <div class="content__selector">
-                        <div class="selector__parent">
-                            <StatuteSelector
-                                v-if="!acts.loading"
-                                :loading="statutes.loading"
-                                :selected-act="queryParams.act"
-                                :selected-title="queryParams.title"
-                                :titles="parsedTitles"
-                            />
-                        </div>
-                    </div>
-                    <div
-                        class="table__parent"
-                        :class="{ loading: statutes.loading }"
-                    >
-                        <SimpleSpinner
-                            v-if="statutes.loading"
-                            class="table__spinner"
+                    <!-- Citation input/button always at the top -->
+                    <div class="citation-link-box">
+                        <input
+                            v-model="citationInput"
+                            type="text"
+                            class="citation-input"
+                            placeholder="Enter citation, e.g., 1902(a)(74) or 42 U.S.C. 1396a(a)(74)"
                         />
-                        <template v-else>
-                            <TableCaption
-                                :selected-act="ACT_TYPES[queryParams.act]"
-                                :selected-title="queryParams.title"
+                        <input
+                            id="citation-button"
+                            class="btn default-btn"
+                            type="submit"
+                            value="Get Link to Citation"
+                        >
+                    </div>
+                    <!-- Statute selector and table grouped together -->
+                    <div class="statute-table-section">
+                        <div class="content__selector">
+                            <div class="selector__parent">
+                                <StatuteSelector
+                                    v-if="!acts.loading"
+                                    :loading="statutes.loading"
+                                    :selected-act="queryParams.act"
+                                    :selected-title="queryParams.title"
+                                    :titles="parsedTitles"
+                                />
+                            </div>
+                        </div>
+                        <div
+                            class="table__parent"
+                            :class="{ loading: statutes.loading }"
+                        >
+                            <SimpleSpinner
+                                v-if="statutes.loading"
+                                class="table__spinner"
                             />
-                            <StatuteTable
-                                :display-type="isNarrow ? 'list' : 'table'"
-                                :filtered-statutes="statutes.results"
-                                table-type="ssa"
-                            />
-                        </template>
+                            <template v-else>
+                                <TableCaption
+                                    :selected-act="ACT_TYPES[queryParams.act]"
+                                    :selected-title="queryParams.title"
+                                />
+                                <StatuteTable
+                                    :display-type="isNarrow ? 'list' : 'table'"
+                                    :filtered-statutes="statutes.results"
+                                    table-type="ssa"
+                                />
+                            </template>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -187,24 +187,27 @@ function toggleCitationHelp() {
                             <span>{{ showCitationHelp ? 'Hide examples ▲' : 'Show examples ▼' }}</span>
                         </button>
                         <div v-if="showCitationHelp" class="citation-help-text">
-                            <p>Enter a citation to get a direct link to current text on the
+                            <p>Get a link to current statute text on the
                                 <a
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="external"
                                     href="https://uscode.house.gov/"
                                 >
                                     US Code House.gov</a>
                                 website.
                             </p>
-                            <p><strong>Social Security Act:</strong></p>
+                            <p>For <strong>Social Security Act</strong> citations, enter the section and optionally the paragraph:</p>
                             <ul>
                                 <li>1945A</li>
-                                <li>1902(a)(74)</li>
+                                <li>1902(k)</li>
                                 <li>1903(m)(2)(A)(x)</li>
                             </ul>
-                            <p><strong>US Code:</strong></p>
+                            <p>Or for <strong>U.S.C.</strong> citations, enter the title (such as 42), then enter the section and optionally the paragraph:</p>
                             <ul>
-                                <li>42 U.S.C. 1396w-4a</li>
-                                <li>42 U.S.C. 1396(a)(74)</li>
-                                <li>42 U.S.C. 1396b(m)(2)(A)(x)</li>
+                                <li>1396w-4a</li>
+                                <li>1396a(k)</li>
+                                <li>1396b(m)(2)(A)(x)</li>
                             </ul>
                         </div>
                     </div>

--- a/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Statutes.vue
@@ -25,7 +25,9 @@ const apiUrl = inject("apiUrl");
 const customLoginUrl = inject("customLoginUrl");
 const homeUrl = inject("homeUrl");
 const isAuthenticated = inject("isAuthenticated");
+const manualUrl = inject("manualUrl");
 const searchUrl = inject("searchUrl");
+const statutesUrl = inject("statutesUrl");
 const subjectsUrl = inject("subjectsUrl");
 const username = inject("username");
 
@@ -140,7 +142,11 @@ function toggleCitationHelp() {
                     <JumpTo :api-url="apiUrl" :home-url="homeUrl" />
                 </template>
                 <template #links>
-                    <HeaderLinks :subjects-url="subjectsUrl" />
+                    <HeaderLinks
+                        :statutes-url="statutesUrl"
+                        :manual-url="manualUrl"
+                        :subjects-url="subjectsUrl"
+                    />
                 </template>
                 <template #search>
                     <HeaderSearch :search-url="searchUrl" />
@@ -189,8 +195,8 @@ function toggleCitationHelp() {
                             type="button"
                             class="collapsible-title"
                             :aria-expanded="showCitationHelp.toString()"
-                            @click="toggleCitationHelp"
                             style="background: none; border: none; padding: 0; margin: 0;"
+                            @click="toggleCitationHelp"
                         >
                             <span>{{ showCitationHelp ? 'Hide example formats ▲' : 'Show example formats ▼' }}</span>
                         </button>

--- a/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
+++ b/solution/ui/regulations/eregs-vite/src/views/Subjects.vue
@@ -42,6 +42,7 @@ const customLoginUrl = inject("customLoginUrl");
 const hasEditableJobCode = inject("hasEditableJobCode");
 const homeUrl = inject("homeUrl");
 const isAuthenticated = inject("isAuthenticated");
+const manualUrl = inject("manualUrl");
 const searchUrl = inject("searchUrl");
 const statutesUrl = inject("statutesUrl");
 const surveyUrl = inject("surveyUrl");
@@ -349,6 +350,7 @@ getDocSubjects();
                 <template #links>
                     <HeaderLinks
                         :statutes-url="statutesUrl"
+                        :manual-url="manualUrl"
                         @link-clicked="resetSubjects"
                     />
                 </template>


### PR DESCRIPTION
Resolves #EREGCSC-2969

**Description-**

This is a prototype for design discussion, showing a concept for improving consistency between the statute and State Medicaid Manual pages. This is not meant to be merged; it can be closed after we come up with refined designs to implement.

**This pull request changes...**

- Adds the "State Medicaid Manual" page to the header navigation and updates the statute page to "Social Security Act" in the header navigation
- Adds subheadings to both pages for navigation items (search and jump-to-statute) vs table of contents
- Adds example of jump-to-statute on the statute page

**Steps to manually verify this change...**

- View experimental branch header navigation
- View State Medicaid Manual page
- View statute page