### PR TITLE
EREGCSC-2979 — add cypress intercepts to handle flaky jump to tests

### DIFF
--- a/solution/ui/e2e/cypress/e2e/custom-login-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/custom-login-page.cy.js
@@ -4,6 +4,7 @@ describe("custom login page", { scrollBehavior: "center" }, () => {
         cy.intercept("/**", (req) => {
             req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
         });
+        cy.intercept("**/v3/title/42/parts").as("title42parts");
     });
 
     it("custom-login-page - does not render an anchor for header Sign In link when on login page", () => {
@@ -42,12 +43,14 @@ describe("custom login page", { scrollBehavior: "center" }, () => {
     it("custom-login-page - jumps to a regulation Part using the jump-to select", () => {
         cy.viewport("macbook-15");
         cy.visit("/login");
+        cy.wait("@title42parts");
         cy.jumpToRegulationPart({ title: "45", part: "95" });
     });
 
     it("custom-login-page - jumps to a regulation Part section using the section number text input", () => {
         cy.viewport("macbook-15");
         cy.visit("/login");
+        cy.wait("@title42parts");
         cy.jumpToRegulationPartSection({
             title: "42",
             part: "433",

--- a/solution/ui/e2e/cypress/e2e/error-page.cy.js
+++ b/solution/ui/e2e/cypress/e2e/error-page.cy.js
@@ -4,6 +4,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
         cy.intercept("/**", (req) => {
             req.headers["x-automated-test"] = Cypress.env("DEPLOYING");
         });
+        cy.intercept("**/v3/title/42/parts").as("title42parts");
     });
 
     it("loads as a 404 page when server returns a 404 error", () => {
@@ -30,6 +31,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
             .its("status")
             .should("equal", 404);
         cy.visit("/404", { failOnStatusCode: false });
+        cy.wait("@title42parts");
         cy.jumpToRegulationPart({ title: "45", part: "95" });
     });
 
@@ -39,6 +41,7 @@ describe("Error page", { scrollBehavior: "center" }, () => {
             .its("status")
             .should("equal", 404);
         cy.visit("/404", { failOnStatusCode: false });
+        cy.wait("@title42parts");
         cy.jumpToRegulationPartSection({
             title: "42",
             part: "433",

--- a/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
+++ b/solution/ui/e2e/cypress/e2e/homepage.spec.cy.js
@@ -16,6 +16,7 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
         cy.intercept("**/v3/resources/public/links?page=1&page_size=7**", {
             fixture: "recent-guidance.json",
         }).as("recentGuidance");
+        cy.intercept("**/v3/title/42/parts").as("title42parts");
     });
 
     it("loads the homepage", () => {
@@ -246,6 +247,7 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
     it("Does not include Part 75 when Title 45 is selected in Jump To", () => {
         cy.viewport("macbook-15");
         cy.visit("/");
+        cy.wait("@title42parts");
         cy.get("#jumpToTitle").select("45");
         cy.get("#jumpToPart").then(($select) => {
             const options = $select.find("option");
@@ -257,12 +259,14 @@ describe("Homepage", { scrollBehavior: "center" }, () => {
     it("jumps to a regulation Part using the jump-to select", () => {
         cy.viewport("macbook-15");
         cy.visit("/");
+        cy.wait("@title42parts");
         cy.jumpToRegulationPart({ title: "45", part: "95" });
     });
 
     it("jumps to a regulation Part section using the section number text input", () => {
         cy.viewport("macbook-15");
         cy.visit("/");
+        cy.wait("@title42parts");
         cy.jumpToRegulationPartSection({
             title: "42",
             part: "433",


### PR DESCRIPTION
Resolves [EREGCSC-2979](https://jiraent.cms.gov/browse/EREGCSC-2979)

**Description**

We recently refactored the loading/disabled states for the Jump To form in the site header.  This has caused some Cypress end to end tests to become flaky, as the tests are expecting to interact with an element that is still disabled when loading data needed to populate a dropdown list in the form.  

In our Cypress configuration, we allow up to two retries (three tries total) before a test fails and moves on to the next test.  This has historically been enough to ensure that the end to end tests don't fail due to random flakiness; if a test fails, it almost always would pass on the first retry.

However, since the Jump To form refactor mentioned above, Cypress tests that interact with the Jump To form have become much flakier, often needing to use all three tries to pass, and sometimes still failing after three attempts.  This is a new and unacceptable level of flakiness that needs to be addressed.

To improve the tests to remove flakiness, we have a few options:

- Intercept the API calls used to populate form fields and use a fixture containing mock data, which would result in instantaneous population of the form dropdowns and would prevent any disabled/loading states
- Intercept the API calls used to populate form fields and wait for these API calls to return successfully before continuing to the next step of the test.

We employ both options in our end to end test suites.  In this case, we'd like to continue to use live data, as there exists a test that validates that 45 CFR Part 75 is not available to be selected.  As such, this PR will continue to request live data to populate the form elements, but will add intercepts that [allow us to spy on and wait for specific requests to respond](https://docs.cypress.io/api/commands/wait#Wait-for-a-specific-request-to-respond).

**This pull request changes:**

- Adds names intercepts that allow us to spy on specific API requests for data used in the header Jump To form.
   - specifically: spying on `/v3/title/42/parts` as `@title42parts` and `/v3/title/45/parts` as `@title45parts`
- Adds explicit `wait` commands that will not move onto the next test command until the above API requests have been returned successfully

**Steps to manually verify this change:**

1. All tests pass
2. Re-run cypress test suite a few times, either locally or here on Github in the "Deploy Experimental" action
3. View the cypress test logs and validate that no Jump To tests have needed to be retried

