### PR TITLE
[hotfix] Fix for FR parser bug: field required for section child_id

### DIFF
--- a/solution/backend/resources/serializers/citations.py
+++ b/solution/backend/resources/serializers/citations.py
@@ -50,10 +50,10 @@ class SubpartWithChildrenSerializer(SubpartSerializer):
     children = SectionSerializer(many=True)
 
 
-class SectionCreateSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Section
-        fields = "__all__"
+class SectionCreateSerializer(serializers.Serializer):
+    title = serializers.CharField()
+    part = serializers.CharField()
+    section_id = serializers.IntegerField()
 
 
 class SectionRangeCreateSerializer(serializers.Serializer):


### PR DESCRIPTION
Resolves #n/a

**Description-**

Because the `SectionCreateSerializer` was a `ModelSerializer` with a `Meta` class referencing all fields, the FR parser was failing because the [recently added](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1658) `child_id` field is not included in the request from the parser.

Since this field is set on save anyway, we can simply ignore it by defining the serializer as a `serializers.Serializer` and then manually defining the fields, like we do with many other serializers already.

**This pull request changes...**

- `SectionCreateSerializer` switched from a subclass of `ModelSerializer` to `Serializer`.
- Manually defined relevant fields in the new serializer.

**Steps to manually verify this change...**

I will manually run the FR parser for this PR, so to verify you can log into the admin panel for this ephemeral deploy and go to Federal Register Links. Then note the most recent entries that were previously not uploading.

