### PR TITLE
[Hotfix] Revert dominikh/staticcheck-action from 1.4.0 back to 1.3.0

### DIFF
--- a/.github/workflows/lint-and-test-parsers.yml
+++ b/.github/workflows/lint-and-test-parsers.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '^1.16' # The Go version to download (if necessary) and use.
-  
+
     # set up build cache
     - name: Set up build cache
       uses: actions/cache@v4
@@ -50,7 +50,7 @@ jobs:
         gofmt-path: './solution/parser/${{ matrix.dir }}'
         gofmt-flags: '-l -d'
 
-    - uses: dominikh/staticcheck-action@v1.4.0
+    - uses: dominikh/staticcheck-action@v1.3.0
       with:
         version: "2022.1.3"
         working-directory: "./solution/parser/${{ matrix.dir }}"
@@ -62,7 +62,7 @@ jobs:
         pushd solution/parser/${{ matrix.dir }}
         golint -set_exit_status ./...
         popd
-    
+
     # Run tests and create coverage report
     - name: Run tests
       run: |

--- a/.github/workflows/lint-and-test-parsers.yml
+++ b/.github/workflows/lint-and-test-parsers.yml
@@ -1,6 +1,13 @@
 name: Lint & Unit Test Parsers
 
-on: [ push, pull_request, workflow_dispatch ]
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    paths:
+      - 'solution/parser/**'
+  push:
+    branches:
+      - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/lint-and-test-parsers.yml
+++ b/.github/workflows/lint-and-test-parsers.yml
@@ -1,13 +1,6 @@
 name: Lint & Unit Test Parsers
 
-on:
-  pull_request:
-    types: [ opened, synchronize, reopened ]
-    paths:
-      - 'solution/parser/**'
-  push:
-    branches:
-      - main
+on: [ push, pull_request, workflow_dispatch ]
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
Resolves failing [Lint & Unit Test Parsers action](https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/workflows/lint-and-test-parsers.yml)

**Description**

Dependabot created a [Pull Request to upgrade `dominikh/staticcheck-action` from 1.3.0 to 1.4.0](https://github.com/Enterprise-CMCS/cmcs-eregulations/pull/1728).  The [changelog seemed innocent enough](https://github.com/dominikh/staticcheck-action/compare/v1.3.0...v1.4.0), so we approved the PR and merged it into `main` untested.  

It was untested because this action only runs when golang code is changed or when a PR is merged into `main`, and no golang code was changed in this PR, so this action ran for the first time (and then failed) when the dependabot PR was merged into `main`.

Since the previous version of `dominikh/staticcheck-action` that worked (1.3.0) still works, and the dependabot PR was not created to address any security concerns, we have decided to revert back to the working version (1.3.0) for now.

**This pull request changes:**

- Reverts version of `dominikh/staticcheck-action` from 1.4.0 to 1.3.0.

**Steps to manually verify this change:**

1. See this [Lint & Unit Test Parsers action run](https://github.com/Enterprise-CMCS/cmcs-eregulations/actions/runs/16205112229) and note that the action succeeded
2. Merge this PR into `main` and ensure the action succeeds again

