### PR TITLE
EREGCSC-2986 Update database version to 15.12 in CDK

### DIFF
--- a/cdk-eregs/lib/constructs/database-construct.ts
+++ b/cdk-eregs/lib/constructs/database-construct.ts
@@ -53,7 +53,7 @@ export class DatabaseConstruct extends Construct {
             'SecurityToolsSG',
             ssm.StringParameter.valueForStringParameter(this, '/eregulations/db/groups/cmscloud_security_tools')
         );
-    
+
         this.dbSecurityGroup.addIngressRule(
             serverlessSecurityGroup,
             ec2.Port.tcp(3306),
@@ -116,7 +116,7 @@ export class DatabaseConstruct extends Construct {
         // Create the database cluster
         this.cluster = new rds.DatabaseCluster(this, 'Database', {
             engine: rds.DatabaseClusterEngine.auroraPostgres({
-                version: rds.AuroraPostgresEngineVersion.VER_15_8,
+                version: rds.AuroraPostgresEngineVersion.VER_15_12,
             }),
             vpc,
             vpcSubnets: selectedSubnets,


### PR DESCRIPTION
Resolves #2986

**Description-**

We updated the database version from 15.8 to 15.12 recently via the AWS Console, but did not update the version in our CDK config.

**This pull request changes...**

- CDK now references version 15.12 which matches our current database configuration.

**Steps to manually verify this change...**

No validation needed, just verify that this PR deploys successfully.

