### PR TITLE
[hotfix] Remove unnecessary space in bs4 get_text() call

### DIFF
--- a/solution/text-extractor/extractors/markup.py
+++ b/solution/text-extractor/extractors/markup.py
@@ -49,7 +49,7 @@ class MarkupExtractor(Extractor):
         # Fallback 1: Look for content in a <main> tag first
         try:
             logger.info("Fallback 1: Attempting to extract text from <main> tag.")
-            return soup.find("main").get_text(" ")
+            return soup.find("main").get_text()
         except Exception:
             # If the <main> tag is not found or fails to extract text, fallback to other methods
             logger.warning("Failed to extract text from <main> tag.")
@@ -58,14 +58,14 @@ class MarkupExtractor(Extractor):
         try:
             logger.info("Fallback 2: Attempting to extract text from <article> or <section> tags.")
             candidates = soup.find_all(["article", "section"], recursive=True) or None
-            return " ".join(candidate.get_text(" ") or "" for candidate in candidates).strip()
+            return " ".join(candidate.get_text() or "" for candidate in candidates).strip()
         except Exception:
             logger.warning("Failed to extract text from <article> or <section> tags.")
 
         # Fallback 3: use the page's entire body
         logger.info("Fallback 3: Attempting to extract text from the entire <body> tag.")
         body = soup.body or soup
-        return body.get_text(" ")
+        return body.get_text()
 
     # Extract text from uscode.house.gov pages
     def _extract_from_uscode_house_gov(self, soup: BeautifulSoup) -> str:
@@ -73,21 +73,21 @@ class MarkupExtractor(Extractor):
         content = soup.find("div", id="docViewer")
         for i in content.find_all("div", class_="jumpTo"):  # Remove "jump to" links
             i.decompose()
-        return content.get_text(" ")
+        return content.get_text()
 
     # Extract text from gao.gov pages
     def _extract_from_gao_gov(self, soup: BeautifulSoup) -> str:
         # GAO.gov pages have the main content in a <div id="block-gao-uswds-content">
         content = soup.find("div", id="block-gao-uswds-content")
-        return content.get_text(" ")
+        return content.get_text()
 
     # Extract text from cmsgov.github.io pages
     def _extract_from_cmsgov_github_io(self, soup: BeautifulSoup) -> str:
         # cmsgov.github.io pages have the main content in an <article> tag
         content = soup.find("article", id="content")
-        return content.get_text(" ")
+        return content.get_text()
 
     def _extract_from_cms_gov(self, soup: BeautifulSoup) -> str:
         # Some cms.gov pages have the main content in a <div id="block-cms-evo-content">
         content = soup.find("div", id="block-cms-evo-content")
-        return content.get_text(" ")
+        return content.get_text()

--- a/solution/text-extractor/extractors/tests/fixtures/htm/expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/htm/expected.txt
@@ -1,4 +1,4 @@
 
- Hello world! 
- abc 
- this is a link 
+Hello world!
+abc
+this is a link

--- a/solution/text-extractor/extractors/tests/fixtures/html/article_section_tag_test_expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/html/article_section_tag_test_expected.txt
@@ -1,16 +1,16 @@
-Content Section 
- This section contains important information. 
+Content Section
+This section contains important information.
+
+Item 1
+Item 2
+Item 3
+
  
- Item 1 
- Item 2 
- Item 3 
+Article Section
+This section is wrapped in an article tag.
  
+Another Section
+This section is wrapped in a section tag.
  
- Article Section 
- This section is wrapped in an article tag. 
- 
- Another Section 
- This section is wrapped in a section tag. 
- 
- Another Article Section 
- This section is also wrapped in an article tag.
+Another Article Section
+This section is also wrapped in an article tag.

--- a/solution/text-extractor/extractors/tests/fixtures/html/cms.gov_expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/html/cms.gov_expected.txt
@@ -1,13 +1,13 @@
 
- CMS.gov Sample Page 
- This is a sample page for testing the text extraction functionality. 
- It contains various elements that should be processed correctly. 
- 
- Content Section 
- This section contains important information. 
- 
- Item 1 
- Item 2 
- Item 3 
- 
- 
+CMS.gov Sample Page
+This is a sample page for testing the text extraction functionality.
+It contains various elements that should be processed correctly.
+
+Content Section
+This section contains important information.
+
+Item 1
+Item 2
+Item 3
+
+

--- a/solution/text-extractor/extractors/tests/fixtures/html/cmsgov.github.io_expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/html/cmsgov.github.io_expected.txt
@@ -1,25 +1,25 @@
 
- Streamlined Modular Certification Frequently Asked Questions (FAQs) 
- CMS prepared this set of FAQs to inform states and the public about the Streamlined Modular Certification (SMC) process and requirements. The official  SMC Guidance  is available at  Medicaid.gov  and is the primary source of information on the SMC process and requirements. Other helpful information is available in the MES Certification Repository, and State Officers are available to answer your questions. Questions may also be submitted via the Medicaid Enterprise System mailbox at  MES@cms.hhs.gov . 
- 
- Overview of SMC 
- What States Must Know about the SMC Process 
- Outcomes and Metrics 
- Conditions for Enhanced Funding 
- Intake Form 
- Certification 
- Reporting Requirements 
- Metrics 
- 
- 
- Overview of SMC 
- Q1: What is SMC? 
- A: Streamlined Modular Certification (SMC) is the process for certifying discrete Medicaid information technology (IT) systems. State Medicaid Agencies use these IT systems and modules, known as Medicaid Enterprise Systems (MES), to manage, monitor, and administer their Medicaid program. The SMC framework promotes reduced burden and increased flexibility for states while ensuring states meet federal requirements (and state-specific outcomes) for systems and modules. 
- SMC contains the following certification elements: 
- 
- Conditions for Enhanced Funding that require ongoing state compliance. 
- CMS-required outcomes are based on statutory or regulatory requirements to promote the efficient, economical, and effective administration of the state’s Medicaid program. 
- State-specific outcomes that reflect the unique circumstances, characteristics, or program priorities that the state’s IT project will directly address while ensuring benefit to the state’s Medicaid program. 
- Metrics to provide evidence about whether the outcomes are achieved continuously. 
- Required artifacts are required for certification. These are documents that demonstrate the progression of a state’s IT project. 
- 
+Streamlined Modular Certification Frequently Asked Questions (FAQs)
+CMS prepared this set of FAQs to inform states and the public about the Streamlined Modular Certification (SMC) process and requirements. The official SMC Guidance is available at Medicaid.gov and is the primary source of information on the SMC process and requirements. Other helpful information is available in the MES Certification Repository, and State Officers are available to answer your questions. Questions may also be submitted via the Medicaid Enterprise System mailbox at MES@cms.hhs.gov.
+
+Overview of SMC
+What States Must Know about the SMC Process
+Outcomes and Metrics
+Conditions for Enhanced Funding
+Intake Form
+Certification
+Reporting Requirements
+Metrics
+
+
+Overview of SMC
+Q1: What is SMC?
+A: Streamlined Modular Certification (SMC) is the process for certifying discrete Medicaid information technology (IT) systems. State Medicaid Agencies use these IT systems and modules, known as Medicaid Enterprise Systems (MES), to manage, monitor, and administer their Medicaid program. The SMC framework promotes reduced burden and increased flexibility for states while ensuring states meet federal requirements (and state-specific outcomes) for systems and modules.
+SMC contains the following certification elements:
+
+Conditions for Enhanced Funding that require ongoing state compliance.
+CMS-required outcomes are based on statutory or regulatory requirements to promote the efficient, economical, and effective administration of the state’s Medicaid program.
+State-specific outcomes that reflect the unique circumstances, characteristics, or program priorities that the state’s IT project will directly address while ensuring benefit to the state’s Medicaid program.
+Metrics to provide evidence about whether the outcomes are achieved continuously.
+Required artifacts are required for certification. These are documents that demonstrate the progression of a state’s IT project.
+

--- a/solution/text-extractor/extractors/tests/fixtures/html/expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/html/expected.txt
@@ -1,5 +1,5 @@
 
- Hello world! 
- abc 
- this is a link 
- 
+Hello world!
+abc
+this is a link
+

--- a/solution/text-extractor/extractors/tests/fixtures/html/gao.gov_expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/html/gao.gov_expected.txt
@@ -1,3 +1,3 @@
 
- Sample GAO.gov Report Title 
- This is a sample paragraph from a GAO.gov report. It provides an overview of the report's findings and recommendations. 
+Sample GAO.gov Report Title
+This is a sample paragraph from a GAO.gov report. It provides an overview of the report's findings and recommendations.

--- a/solution/text-extractor/extractors/tests/fixtures/html/low-confidence_expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/html/low-confidence_expected.txt
@@ -1,153 +1,153 @@
 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
-   
- Hospital-Acquired Conditions (Present on Admission Indicator)
-     	 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
-   
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
-   
- Hospital-Acquired Conditions (Present on Admission Indicator) 
- 
- 
- 
- 
-   
- 
- On February 8, 2006, the President signed the Deficit Reduction Act (DRA) of 2005. Section 5001(c) of DRA requires the Secretary to identify conditions that are: (a) high cost or high volume or both, (b) result in the assignment of a case to a DRG that has a higher payment when present as a secondary diagnosis, and (c) could reasonably have been prevented through the application of evidence-based guidelines. Section 5001(c) provides that CMS can revise the list of conditions from time to time, as long as it contains at least two conditions. The statute is available in the  Statute/Regulations/Program Instructions  section, accessible through the navigation menu at left. 
- CMS also required hospitals to report present on admission information for both principal and secondary diagnoses when submitting claims for discharges on or after October 1, 2007. 
- For discharges occurring on or after October 1, 2008, hospitals will not receive additional payment for cases in which one of the selected conditions was not present on admission. That is, the case would be paid as though the secondary diagnosis were not present. 
-   
- 
- 
- 
- 
- 
-   
- 
- Downloads 
- 
- 
- 
- Hospital-Acquired Conditions–Present on Admission: Examination of Spillover Effects and Unintended Consequences--September 2012 (PDF) 
- 
- 
- 
- 
- Accuracy of Coding in the Hospital-Acquired Conditions-Present on Admission Program--June 2012 (PDF) 
- 
- 
- 
- 
- Readmissions Due to Hospital-Acquired Conditions (HACs): Multivariate Modeling and Under-coding Analyses--September 2012 (PDF) 
- 
- 
- 
- 
- Examination of the Accuracy of Coding Pressure Ulcer Stages--April 2012 (PDF) 
- 
- 
- 
- 
- Update on State Government Tracking of Health Care-Acquired Conditions and a Four-State In-Depth Review--June 2012 (PDF) 
- 
- 
- 
- 
- Evidence-based Guidelines for Selected and Previously Considered Hospital-Acquired Conditions Report--June 2015 (ZIP) 
- 
- 
- 
- 
- Incremental Updated Cost Report – Updated May 2012 (ZIP) 
- 
- 
- 
- 
- Evidence Based Guidelines Report for Selected and Candidate Hospital-Acquired Conditions--January 2010 (PDF) 
- 
- 
- 
- 
- Evidenced-based Guidelines for Selected and Previously Considered Hospital-Acquired Conditions Report-2016 (PDF) 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- Page Last Modified: 
- 09/06/2023 04:51 PM 
- 
- 
- Help with File Formats and Plug-Ins 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+Hospital-Acquired Conditions (Present on Admission Indicator)
+     	
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+Hospital-Acquired Conditions (Present on Admission Indicator)
+
+
+
+
+ 
+
+On February 8, 2006, the President signed the Deficit Reduction Act (DRA) of 2005. Section 5001(c) of DRA requires the Secretary to identify conditions that are: (a) high cost or high volume or both, (b) result in the assignment of a case to a DRG that has a higher payment when present as a secondary diagnosis, and (c) could reasonably have been prevented through the application of evidence-based guidelines. Section 5001(c) provides that CMS can revise the list of conditions from time to time, as long as it contains at least two conditions. The statute is available in the Statute/Regulations/Program Instructions section, accessible through the navigation menu at left.
+CMS also required hospitals to report present on admission information for both principal and secondary diagnoses when submitting claims for discharges on or after October 1, 2007.
+For discharges occurring on or after October 1, 2008, hospitals will not receive additional payment for cases in which one of the selected conditions was not present on admission. That is, the case would be paid as though the secondary diagnosis were not present.
+ 
+
+
+
+
+
+ 
+
+Downloads
+
+
+
+Hospital-Acquired Conditions–Present on Admission: Examination of Spillover Effects and Unintended Consequences--September 2012 (PDF)
+
+
+
+
+Accuracy of Coding in the Hospital-Acquired Conditions-Present on Admission Program--June 2012 (PDF)
+
+
+
+
+Readmissions Due to Hospital-Acquired Conditions (HACs): Multivariate Modeling and Under-coding Analyses--September 2012 (PDF)
+
+
+
+
+Examination of the Accuracy of Coding Pressure Ulcer Stages--April 2012 (PDF)
+
+
+
+
+Update on State Government Tracking of Health Care-Acquired Conditions and a Four-State In-Depth Review--June 2012 (PDF)
+
+
+
+
+Evidence-based Guidelines for Selected and Previously Considered Hospital-Acquired Conditions Report--June 2015 (ZIP)
+
+
+
+
+Incremental Updated Cost Report – Updated May 2012 (ZIP)
+
+
+
+
+Evidence Based Guidelines Report for Selected and Candidate Hospital-Acquired Conditions--January 2010 (PDF)
+
+
+
+
+Evidenced-based Guidelines for Selected and Previously Considered Hospital-Acquired Conditions Report-2016 (PDF)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Page Last Modified:
+09/06/2023 04:51 PM
+
+
+Help with File Formats and Plug-Ins
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/solution/text-extractor/extractors/tests/fixtures/html/main_tag_test_expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/html/main_tag_test_expected.txt
@@ -1,13 +1,13 @@
 
- A Sample Page 
- This is a sample page for testing the text extraction functionality. 
- It contains various elements that should be processed correctly. 
- 
- Content Section 
- This section contains important information. 
- 
- Item 1 
- Item 2 
- Item 3 
- 
- 
+A Sample Page
+This is a sample page for testing the text extraction functionality.
+It contains various elements that should be processed correctly.
+
+Content Section
+This section contains important information.
+
+Item 1
+Item 2
+Item 3
+
+

--- a/solution/text-extractor/extractors/tests/fixtures/html/uscode.house.gov_expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/html/uscode.house.gov_expected.txt
@@ -1,53 +1,53 @@
 
- 
- 
- 42 USC 1396w-5 : Addressing health care disparities 
- Text contains those laws in effect on June 29, 2025 
- 
- 
- 
- From Title 42-THE PUBLIC HEALTH AND WELFARE CHAPTER 7-SOCIAL SECURITY SUBCHAPTER XIX-GRANTS TO STATES FOR MEDICAL ASSISTANCE PROGRAMS 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- §1396w–5. Addressing health care disparities 
- 
- 
- 
- (a) Evaluating data collection approaches 
- The Secretary shall evaluate approaches for the collection of data under this subchapter and subchapter XXI, to be performed in conjunction with existing quality reporting requirements and programs under this subchapter and subchapter XXI, that allow for the ongoing, accurate, and timely collection and evaluation of data on disparities in health care services and performance on the basis of race, ethnicity, sex, primary language, and disability status. In conducting such evaluation, the Secretary shall consider the following objectives: 
- 
- (1) Protecting patient privacy. 
- 
- (2) Minimizing the administrative burdens of data collection and reporting on States, providers, and health plans participating under this subchapter or subchapter XXI. 
- 
- (3) Improving program data under this subchapter and subchapter XXI on race, ethnicity, sex, primary language, and disability status. 
- 
- (b) Reports to Congress 
- 
- (1) Report on evaluation 
- Not later than 18 months after March 23, 2010, the Secretary shall submit to Congress a report on the evaluation conducted under subsection (a). Such report shall, taking into consideration the results of such evaluation- 
- 
- (A) identify approaches (including defining methodologies) for identifying and collecting and evaluating data on health care disparities on the basis of race, ethnicity, sex, primary language, and disability status for the programs under this subchapter and subchapter XXI; and 
- 
- (B) include recommendations on the most effective strategies and approaches to reporting HEDIS quality measures as required under  section 1395w–22(e)(3) of this title  and other nationally recognized quality performance measures, as appropriate, on such bases. 
- 
- (2) Reports on data analyses 
- Not later than 4 years after March 23, 2010, and 4 years thereafter, the Secretary shall submit to Congress a report that includes recommendations for improving the identification of health care disparities for beneficiaries under this subchapter and under subchapter XXI based on analyses of the data collected under subsection (c). 
- 
- (c) Implementing effective approaches 
- Not later than 24 months after March 23, 2010, the Secretary shall implement the approaches identified in the report submitted under subsection (b)(1) for the ongoing, accurate, and timely collection and evaluation of data on health care disparities on the basis of race, ethnicity, sex, primary language, and disability status. 
- 
- 
- 
- (Aug. 14, 1935, ch. 531, title XIX, §1946, as added  
- Pub. L. 111–148,  title IV, §4302(b)(2), Mar. 23, 2010,  124 Stat. 581 
- .) 
- 
- 
+
+
+42 USC 1396w-5: Addressing health care disparities
+Text contains those laws in effect on June 29, 2025
+
+
+
+From Title 42-THE PUBLIC HEALTH AND WELFARECHAPTER 7-SOCIAL SECURITYSUBCHAPTER XIX-GRANTS TO STATES FOR MEDICAL ASSISTANCE PROGRAMS
+
+
+
+
+
+
+
+
+
+§1396w–5. Addressing health care disparities
+
+
+
+(a) Evaluating data collection approaches
+The Secretary shall evaluate approaches for the collection of data under this subchapter and subchapter XXI, to be performed in conjunction with existing quality reporting requirements and programs under this subchapter and subchapter XXI, that allow for the ongoing, accurate, and timely collection and evaluation of data on disparities in health care services and performance on the basis of race, ethnicity, sex, primary language, and disability status. In conducting such evaluation, the Secretary shall consider the following objectives:
+
+(1) Protecting patient privacy.
+
+(2) Minimizing the administrative burdens of data collection and reporting on States, providers, and health plans participating under this subchapter or subchapter XXI.
+
+(3) Improving program data under this subchapter and subchapter XXI on race, ethnicity, sex, primary language, and disability status.
+
+(b) Reports to Congress
+
+(1) Report on evaluation
+Not later than 18 months after March 23, 2010, the Secretary shall submit to Congress a report on the evaluation conducted under subsection (a). Such report shall, taking into consideration the results of such evaluation-
+
+(A) identify approaches (including defining methodologies) for identifying and collecting and evaluating data on health care disparities on the basis of race, ethnicity, sex, primary language, and disability status for the programs under this subchapter and subchapter XXI; and
+
+(B) include recommendations on the most effective strategies and approaches to reporting HEDIS quality measures as required under section 1395w–22(e)(3) of this title and other nationally recognized quality performance measures, as appropriate, on such bases.
+
+(2) Reports on data analyses
+Not later than 4 years after March 23, 2010, and 4 years thereafter, the Secretary shall submit to Congress a report that includes recommendations for improving the identification of health care disparities for beneficiaries under this subchapter and under subchapter XXI based on analyses of the data collected under subsection (c).
+
+(c) Implementing effective approaches
+Not later than 24 months after March 23, 2010, the Secretary shall implement the approaches identified in the report submitted under subsection (b)(1) for the ongoing, accurate, and timely collection and evaluation of data on health care disparities on the basis of race, ethnicity, sex, primary language, and disability status.
+
+
+
+(Aug. 14, 1935, ch. 531, title XIX, §1946, as added 
+Pub. L. 111–148, title IV, §4302(b)(2), Mar. 23, 2010, 124 Stat. 581
+.)
+
+

--- a/solution/text-extractor/extractors/tests/fixtures/xhtml/expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/xhtml/expected.txt
@@ -1,2 +1,2 @@
 
- Welcome to XHTML 
+Welcome to XHTML

--- a/solution/text-extractor/extractors/tests/fixtures/xml/expected.txt
+++ b/solution/text-extractor/extractors/tests/fixtures/xml/expected.txt
@@ -1,33 +1,33 @@
 
- 
- 
- Belgian Waffles 
- $5.95 
- Two of our famous Belgian Waffles with plenty of real maple syrup 
- 650 
- 
- 
- Strawberry Belgian Waffles 
- $7.95 
- Light Belgian waffles covered with strawberries and whipped cream 
- 900 
- 
- 
- Berry-Berry Belgian Waffles 
- $8.95 
- Light Belgian waffles covered with an assortment of fresh berries and whipped cream 
- 900 
- 
- 
- French Toast 
- $4.50 
- Thick slices made from our homemade sourdough bread 
- 600 
- 
- 
- Homestyle Breakfast 
- $6.95 
- Two eggs, bacon or sausage, toast, and our ever-popular hash browns 
- 950 
- 
- 
+
+
+Belgian Waffles
+$5.95
+Two of our famous Belgian Waffles with plenty of real maple syrup
+650
+
+
+Strawberry Belgian Waffles
+$7.95
+Light Belgian waffles covered with strawberries and whipped cream
+900
+
+
+Berry-Berry Belgian Waffles
+$8.95
+Light Belgian waffles covered with an assortment of fresh berries and whipped cream
+900
+
+
+French Toast
+$4.50
+Thick slices made from our homemade sourdough bread
+600
+
+
+Homestyle Breakfast
+$6.95
+Two eggs, bacon or sausage, toast, and our ever-popular hash browns
+950
+
+


### PR DESCRIPTION
This was added by mistake and caused extraction errors of this type: "Hello <span>W</span>orld!" becomes "Hello W orld!"

Resolves #

**Description-**

**This pull request changes...**

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change

