### PR TITLE
Make "extract_url" field visible and editable in the admin panel

### DIFF
--- a/solution/backend/resources/admin/internal_resources.py
+++ b/solution/backend/resources/admin/internal_resources.py
@@ -45,7 +45,7 @@ class InternalLinkAdmin(AbstractInternalResourceAdmin):
         }),
         ("Search indexing", {
             "classes": ("collapse",),
-            "fields": ["indexing_status", "detected_file_type", "file_type"],
+            "fields": ["indexing_status", "extract_url", "detected_file_type", "file_type"],
         }),
         ("Document status", {
             "fields": ["approved"],

--- a/solution/backend/resources/admin/public_resources.py
+++ b/solution/backend/resources/admin/public_resources.py
@@ -50,7 +50,7 @@ class PublicLinkAdmin(AbstractPublicResourceAdmin):
         }),
         ("Search indexing", {
             "classes": ("collapse",),
-            "fields": ["indexing_status", "detected_file_type", "file_type", "extract_text"],
+            "fields": ["indexing_status", "extract_url", "detected_file_type", "file_type", "extract_text"],
         }),
         ("Document status", {
             "fields": ["approved"],
@@ -112,7 +112,7 @@ class FederalRegisterLinkAdmin(AbstractPublicResourceAdmin):
         }),
         ("Search indexing", {
             "classes": ("collapse",),
-            "fields": ["indexing_status", "detected_file_type", "file_type"],
+            "fields": ["indexing_status", "extract_url", "detected_file_type", "file_type"],
         }),
         ("Document status", {
             "fields": ["approved"],

--- a/solution/backend/resources/tests/test_robots_txt.py
+++ b/solution/backend/resources/tests/test_robots_txt.py
@@ -4,29 +4,32 @@ from resources.utils.aws_utils import _should_ignore_robots_txt
 
 
 @pytest.mark.parametrize(
-    "url,allow_list,expected",
+    "url,extract_url,allow_list,expected",
     [
         # No allow_list, should not ignore any
-        ("https://example.com", [], False),
-        ("http://sub.example.com/page", [], False),
+        ("https://example.com", "", [], False),
+        ("http://sub.example.com/page", "", [], False),
         # Allow list with domain only
-        ("https://example.com", ["example.com"], True),
-        ("https://other.com", ["example.com"], False),
+        ("https://example.com", "", ["example.com"], True),
+        ("https://other.com", "", ["example.com"], False),
         # Allow list with subdomain
-        ("https://sub.example.com", ["sub.example.com"], True),
-        ("https://sub.example.com", ["example.com"], True),
+        ("https://sub.example.com", "", ["sub.example.com"], True),
+        ("https://sub.example.com", "", ["example.com"], True),
         # Allow list with path
-        ("https://example.com/page.html", ["example.com"], True),
-        ("https://other.com/page.html", ["example.com"], False),
-        ("https://sub.example.com/page.html", ["example.com"], True),
+        ("https://example.com/page.html", "", ["example.com"], True),
+        ("https://other.com/page.html", "", ["example.com"], False),
+        ("https://sub.example.com/page.html", "", ["example.com"], True),
         # Mixed allow_list
-        ("https://foo.example.com", ["example.com", "https://abc.com/path.txt"], True),
-        ("https://bar.other.com", ["example.com", "https://abc.com/path.txt"], False),
+        ("https://foo.example.com", "", ["example.com", "https://abc.com/path.txt"], True),
+        ("https://bar.other.com", "", ["example.com", "https://abc.com/path.txt"], False),
+        # extract_url should be used if available
+        ("https://unindexablepage.com", "https://example.com/something", ["example.com"], True),
     ]
 )
-def test_should_ignore_robots_txt(url, allow_list, expected):
+def test_should_ignore_robots_txt(url, extract_url, allow_list, expected):
     def resource():
         return None
     resource.url = url
+    resource.extract_url = extract_url
 
     assert _should_ignore_robots_txt(resource, allow_list) == expected

--- a/solution/backend/resources/utils/aws_utils.py
+++ b/solution/backend/resources/utils/aws_utils.py
@@ -155,7 +155,7 @@ def _should_ignore_robots_txt(resource, allow_list):
     if isinstance(resource, FederalRegisterLink):
         return True
 
-    url = resource.url.strip().lower()
+    url = (resource.extract_url or resource.url).strip().lower()
     resource_domain = urlparse(url).hostname or ""
 
     for pattern in allow_list:


### PR DESCRIPTION
Resolves #n/a

**Description-**

We have had a field on the resource model, `extract_url`, for a long time. It's purpose so far has been limited to Federal Register links where the user-visible page doesn't extract as well as a non-user-friendly link. However, we can apply this to other resources as well. For example: show a user a friendly web page but index a large PDF that is linked to from that page.

**This pull request changes...**

- `extract_url` visible and editable on the admin panel.
- If `extract_url` field changes, it will trigger extraction if auto extract is enabled.

**Steps to manually verify this change...**

1. Go to a public link and expand the "Search indexing" fieldset.
2. Enter a new URL in to the "Text extraction URL" field and save.
3. After some time, the indexed text should change to reflect the new URL.

