### PR TITLE
[HOTFIX] Following link to regs with highlighted text can break Vue

### DIFF
--- a/solution/ui/regulations/utilities/utils.js
+++ b/solution/ui/regulations/utilities/utils.js
@@ -594,7 +594,7 @@ function addMarks(element, highlightString) {
 
             if (element?.parentNode?.nodeName === "A") {
                 const closestParagraph = element.parentNode.closest("p");
-                if (closestParagraph.className === "citation-node") {
+                if (closestParagraph?.className === "citation-node") {
                     return;
                 }
             }


### PR DESCRIPTION
Resolves `prod` bug

**Description**

When loading the reader view with the `highlight` query parameter in the URL, certain links would render the reader view without the header or right sidebar.  Those missing elements are a symptom of the main problem, which is that something was causing the Javascript code for the reader view to crash.  

Example: `<prod_url>/42/442/Subpart-A/2024-07-05/?highlight=section%201902,sections,Section,1902#442-1`

**This pull request changes:**

- Adds an optional chaining `?` character to the [`HTMLElement` `closest()` method](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest) invocation to guard against an HTML element being `null`.

**Steps to manually verify this change:**

1. Green check marks
2. Visit [ephemeral deployment with same title/section/highlight query param as above](https://4qda0qx7xi.execute-api.us-east-1.amazonaws.com/eph-1762/42/442/Subpart-A/2024-07-05/?highlight=section%201902,sections,Section,1902#442-1)
3. Ensure header and right sidebar load and work as expected
4. Try to other searches with the Regulations checkbox checked for light smoke testing

