### PR TITLE
2094-B Fix for "part"."section" format registering "part" as a section

### DIFF
--- a/solution/backend/regulations/tests/fixtures/section_link_tests.json
+++ b/solution/backend/regulations/tests/fixtures/section_link_tests.json
@@ -105,6 +105,11 @@
         "expected": "§ <a target=\"_blank\" rel=\"noopener noreferrer\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the Act. §. <a target=\"_blank\" rel=\"noopener noreferrer\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the Act. &#xA7; <a target=\"_blank\" rel=\"noopener noreferrer\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the act. &#xA7;. <a target=\"_blank\" rel=\"noopener noreferrer\" class=\"external\" href=\"https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title42-sectionabc&num=0&edition=prelim#substructure-location_a\">123(a)</a> of the act."
     },
     {
+        "testing": "part.section format not matching section pattern",
+        "input": "§ 123.456 of the Act.",
+        "expected": "§ 123.456 of the Act."
+    },
+    {
         "testing": "proper word boundaries",
         "input": "intersection 123(a) of the act. intersects 123(a). intersect 123(a). And it intersects. 123(a) of the act states that.",
         "expected": "intersection 123(a) of the act. intersects 123(a). intersect 123(a). And it intersects. 123(a) of the act states that."

--- a/solution/backend/regulations/utils/link_statutes.py
+++ b/solution/backend/regulations/utils/link_statutes.py
@@ -26,7 +26,9 @@ NUMBER_PATTERN = r"[0-9]+"
 SECTION_ID_PATTERN = rf"\d+[a-z]*(?:(?:{DASH_PATTERN})+[a-z0-9]+)?"
 
 # Matches individual sections, for example "1902(a)(2) and (b)(1)" and its variations.
-SECTION_PATTERN = rf"{SECTION_ID_PATTERN}(?:{AND_OR_PATTERN}{PARAGRAPH_PATTERN})*"
+# Negative lookahead ensures that "§ 1234.5678" does not register as a link to section 1234.
+# Another pattern is used to properly link to part 1234 section 5678.
+SECTION_PATTERN = rf"(?!{SECTION_ID_PATTERN}\.{SECTION_ID_PATTERN}){SECTION_ID_PATTERN}(?:{AND_OR_PATTERN}{PARAGRAPH_PATTERN})*"
 
 # Matches entire statute references, including one or more sections and an optional Act.
 # For example, "Sections 1902(a)(2) and (b)(1) and 1903(b) of the Social Security Act" and its variations.


### PR DESCRIPTION
Resolves #2094

**Description-**

Existing regex does not consider `123.456` to be a "part" and a "section", it only looks for the section e.g.  `§ 123`, so the period being there splits the reference and the site will link to section "123" if a link conversion exists for it.

Instead, we have to use negative lookahead to ensure that a reference that looks "§ 123.456" is ignored entirely. These refs will be handled by an entirely separate regex in another PR.

**This pull request changes...**

- Negative lookahead discards matches if they are of the form "§ 123.456" and similar variations.
- Unit test updated.

**Steps to manually verify this change...**

1. On the experimental deployment's admin panel, verify that the link conversions for Title IV are loaded in.
2. From the homepage, navigate to title 42 part 435 section 139.
3. Observe that the text of this section contains no links.
4. Observe that other links on the page continue to work as expected.

