### PR TITLE
[Dependabot] Allow `cdk` updates on different schedule than other `npm` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     - package-ecosystem: "npm"
       # Look for `package.json` and `lock` files
       directories:
-        - "/cdk-eregs" # CDK project
         - "/solution/ui/e2e" # Cypress tests
         - "/solution/ui/regulations" # Vitest, bundling
         - "/solution/ui/regulations/eregs-component-lib" # Django template components
@@ -34,6 +33,20 @@ updates:
           vitest:
             patterns:
               - "vitest*"
+
+    # CDK specific updates
+    - package-ecosystem: "npm"
+      # Look for `package.json` and `lock` files
+      directories:
+        - "/cdk-eregs" # CDK project
+      # Check the npm registry for updates every day (weekdays)
+      schedule:
+          interval: "weekly"
+      # Limit the number of open pull requests to 1
+      open-pull-requests-limit: 1
+      # Increase the minimum version for all npm dependencies
+      versioning-strategy: "increase"
+      groups:
           cdk:
             patterns:
               - "*aws*"


### PR DESCRIPTION
Updated dependabot configuration

**Description**

We previously added `*aws*` to our list of directories and patterns in the `package-ecosystem: "npm"` entry of our dependabot config specifically to target AWS CDK updates and allow dependabot to manage updating these libraries.  This worked as expected: pull requests are being created to update AWS CDK libraries and dependencies.

However, AWS CDK dependencies and libraries are updated at a much higher frequency than we anticipated; sometimes multiple times per day.  Since we have a limit of one dependabot PR created per day, the AWS CDK dependencies have been blocking other `npm` updates.  Before adding `*aws*` to our dependabot config, we'd gotten into a successful rhythm of one pull request being created per day; adding `*aws*` has disrupted this.

This pull request will break out the AWS CDK directory (`/cdk-eregs`) into its own config entry and set its update interval to `weekly`.  We don't need to be on the bleeding edge of the AWS CDK updates; we don't need to patch things daily.  We simply need dependabot to help us stay relatively current with AWS CDK dependency versions so that we're not falling months (or years) behind the current version.  Checking weekly will accomplish this while also unblocking the rest of our `npm` dependencies having daily pull requests created for them.

We used [this discussion](https://github.com/dependabot/dependabot-core/issues/1778) as a guide on how to implement these changes.

**This pull request changes:**

- Adds second `package-ecosystem: "npm"` entry to dependabot config
- Adds all AWS CDK configuration to this new `package-ecosystem` entry
- Sets this new entry to a `weekly` schedule
- Removes AWS CDK configuration from existing `package-ecosystem: "npm"` entry that checks daily


**Steps to manually verify this change:**

1. Merge into `main` and ensure that dependabot pull requests are once again being created daily for `npm` dependencies that are not AWS CDK related
2. Ensure that AWS CDK pull requests have been slowed to a weekly cadence

