### PR TITLE
EREGCSC-2992 — Upgrade Node to latest LTS

### DIFF
--- a/.github/workflows/deploy-to-env.yml
+++ b/.github/workflows/deploy-to-env.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - uses: actions/setup-python@v5
         with:
@@ -390,7 +390,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       # Run the cypress tests
       - name: end-to-end tests

--- a/.github/workflows/lint-js-ts.yml
+++ b/.github/workflows/lint-js-ts.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       # Execute linting
       - name: Run ESLint on project
         if: success()

--- a/.github/workflows/remove-experimental.yml
+++ b/.github/workflows/remove-experimental.yml
@@ -30,7 +30,7 @@ jobs:
       # Setup Node
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       # Setup Python
       - uses: actions/setup-python@v5
@@ -43,7 +43,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: us-east-1
-      
+
       - name: Destroy PR-Specific Redirect Stack
         env:
           PR_NUMBER: ${{ github.event.number }}
@@ -52,16 +52,16 @@ jobs:
         run: |
           pushd cdk-eregs
           npm install
-          
+
           # Generate the exact stack name for this PR
           STACK_NAME="cms-eregs-eph-${PR_NUMBER}-redirect-api"
-          
+
           echo "Destroying PR-specific stack: ${STACK_NAME}"
           npx cdk destroy "${STACK_NAME}" \
           -c environment=${{ env.ENVIRONMENT_NAME }} \
           --force \
           --app "npx ts-node bin/zip-lambdas.ts"
-          
+
           echo "Cleanup completed for stack: ${STACK_NAME}"
           popd
 
@@ -73,16 +73,16 @@ jobs:
         run: |
           pushd cdk-eregs
           npm install
-          
+
           # Generate the exact stack name for this PR
           STACK_NAME="cms-eregs-eph-${PR_NUMBER}-maintenance-api"
-          
+
           echo "Destroying PR-specific stack: ${STACK_NAME}"
           npx cdk destroy "${STACK_NAME}" \
           -c environment=${{ env.ENVIRONMENT_NAME }} \
           --force \
           --app "npx ts-node bin/zip-lambdas.ts"
-          
+
           echo "Cleanup completed for stack: ${STACK_NAME}"
           popd
 
@@ -100,7 +100,7 @@ jobs:
           aws lambda invoke --function-name cms-eregs-eph-$PR_NUMBER-dropdb /dev/stdout | tee -a aws.log
           # Check for invocation errors
           ! grep -q FunctionError aws.log
-          
+
           # Generate the stack names for this PR
           PARSER_LAUNCHER_STACK="cms-eregs-eph-${PR_NUMBER}-parser-launcher"
           TEXT_EXTRACTOR_STACK="cms-eregs-eph-${PR_NUMBER}-text-extractor"
@@ -114,21 +114,21 @@ jobs:
           -c environment=${{ env.ENVIRONMENT_NAME }} \
           --force \
           --app "npx ts-node bin/docker-lambdas.ts"
-          
+
           # Destroy fr-parser stack
           echo "Destroying PR-specific stack: ${FR_PARSER_STACK}"
           npx cdk destroy "${FR_PARSER_STACK}" \
           -c environment=${{ env.ENVIRONMENT_NAME }} \
           --force \
           --app "npx ts-node bin/docker-lambdas.ts"
-          
+
           # Destroy ecfr-parser stack
           echo "Destroying PR-specific stack: ${ECFR_PARSER_STACK}"
           npx cdk destroy "${ECFR_PARSER_STACK}" \
           -c environment=${{ env.ENVIRONMENT_NAME }} \
           --force \
           --app "npx ts-node bin/docker-lambdas.ts"
-          
+
           # Destroy api-stack stack
           echo "Destroying PR-specific stack: ${API_STACK}"
           npx cdk destroy "${API_STACK}" \
@@ -154,39 +154,39 @@ jobs:
           npm install
           npm install fs-extra
           npm install --save-dev @types/fs-extra
-          
+
           # Disable the CloudFront distribution first
           STATIC_STACK="cms-eregs-eph-$PR_NUMBER-static-assets"
-          
+
           # Get distribution ID
           DIST_ID=$(aws cloudformation describe-stacks --stack-name $STATIC_STACK --query "Stacks[0].Outputs[?OutputKey=='CloudFrontDistributionId'].OutputValue" --output text)
-          
+
           if [ ! -z "$DIST_ID" ]; then
             echo "Disabling CloudFront distribution $DIST_ID"
             # Get current distribution config
             aws cloudfront get-distribution-config --id $DIST_ID > dist-config.json
             ETAG=$(cat dist-config.json | jq -r '.ETag')
-            
+
             # Disable the distribution
             cat dist-config.json | jq '.DistributionConfig.Enabled = false' | jq .DistributionConfig > dist-config-disabled.json
             aws cloudfront update-distribution --id $DIST_ID --distribution-config file://dist-config-disabled.json --if-match $ETAG
-            
+
             # Wait for distribution to be disabled
             echo "Waiting for distribution to be disabled..."
             aws cloudfront wait distribution-deployed --id $DIST_ID
           fi
-          
+
           # Now destroy the stack with force
           npx cdk destroy $STATIC_STACK \
           -c environment=${{ env.ENVIRONMENT_NAME }} \
           --force \
           --exclusively \
           --app "npx ts-node bin/static-assets.ts"
-          
+
           # Manually empty and delete buckets if they still exist
           ASSETS_BUCKET="eregs-eph-$PR_NUMBER-site-assets"
           LOGS_BUCKET="eregs-eph-$PR_NUMBER-cloudfront-logs"
-          
+
           for BUCKET in $ASSETS_BUCKET $LOGS_BUCKET; do
             if aws s3api head-bucket --bucket $BUCKET 2>/dev/null; then
               echo "Emptying and deleting bucket: $BUCKET"
@@ -194,5 +194,5 @@ jobs:
               aws s3api delete-bucket --bucket $BUCKET
             fi
           done
-          
+
           popd

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       # Install Front End dependencies
       - name: Install Front End dependencies
         if: success()

--- a/.github/workflows/update-cdk-bootstrap.yml
+++ b/.github/workflows/update-cdk-bootstrap.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install AWS CDK
         run: npm install -g aws-cdk

--- a/.github/workflows/update-code-json.yml
+++ b/.github/workflows/update-code-json.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4.3.0
         with:
-          node-version: "20"
+          node-version: 22
 
       - name: Setup Go
         uses: actions/setup-go@v5.4.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You need these to get started:
 -   git
 -   Docker, including Docker Compose (install [Docker Desktop](https://docs.docker.com/desktop/))
 -   Python 3.12 (consider using [Homebrew](https://docs.brew.sh/Homebrew-and-Python))
--   [Node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) >= v20, which includes npm (we suggest using [nvm](https://github.com/nvm-sh/nvm))
+-   [Node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) >= v22, which includes npm (we suggest using [nvm](https://github.com/nvm-sh/nvm))
 -   [go](https://go.dev/dl/) version 1.16
 -   **Prevent security incidents:** To stop yourself from accidentally pushing secrets to GitHub, you must set up pre-commit hooks in your local environment: [SECRETSCANNING.md](SECRETSCANNING.md#quick-start).
 


### PR DESCRIPTION
Resolves [EREGCSC-2992](https://jiraent.cms.gov/browse/EREGCSC-2992)

**Description**

eRegs is using Node 20 wherever Node is required.  Node 20 is currently in "Maintenance LTS (Long Term Support)" mode and will be [supported through May 2026](https://nodejs.org/en/about/previous-releases).  We should upgrade to a newer version of Node before that time.

**This pull request changes:**

- Updates node versions to the latest current LTS version, which is Node 22.  This will be supported through May 2027.

**Steps to manually verify this change:**

1. Green check marks
2. All team members install and use Node 22 LTS ([Jod](https://nodejs.org/en/blog/release/v22.11.0)) locally
   - If using Node Version Manager ([nvm](https://github.com/nvm-sh/nvm)), this command will install and use Node 22: `nvm install 22`
   - User may also desire to set nvm's default version to 22: `nvm alias default 22`
4. No issues with local development, Github Actions runs, or deployments to hosted environments using Node 22

