### PR TITLE
EREGCSC-3012 — Standardize h1 header top padding/margin

### DIFF
--- a/solution/ui/regulations/css/scss/_layout.scss
+++ b/solution/ui/regulations/css/scss/_layout.scss
@@ -23,11 +23,10 @@ body {
     margin: 0 auto;
     position: relative;
 
-    @include eds-gutters(var(--spacer-3));
+    @include eds-standard-layout;
 
     @include screen-xl {
         max-width: var(--media-width-xl);
-        padding: var(--spacer-4);
     }
 
     @include screen-xxl {


### PR DESCRIPTION
Resolves [EREGCSC-3012](https://jiraent.cms.gov/browse/EREGCSC-3012)

**Description:**

Ensures that `eds-standard-layout` mixin is used for top and gutter spacing for all center column pages of eRegs.

**This pull request changes:**

- Removes explicit padding from `.site-container` class
- Replaces explicit padding with `eds-standard-layout` mixin that contains standardized padding styles meant to be used in all center column pages

**Steps to manually verify this change:**

1. Green check marks
2. Visit [ephemeral deployment](https://2em8h7p6y4.execute-api.us-east-1.amazonaws.com/eph-1828/)
3. Ensure that `h1` header on all main center column pages (OBBA, SSA State Medicaid Manual, Sign In, Get Account Access, Search) stays in the same position as you navigate between these pages
4. Ensure that space above `h1` on above pages matches space above `h1` on Subjects page

