### PR TITLE
EREGCSC-3020 Fix invalidate on static assets deploy

### DIFF
--- a/.github/workflows/deploy-to-env.yml
+++ b/.github/workflows/deploy-to-env.yml
@@ -104,6 +104,13 @@ jobs:
           --app "npx ts-node bin/static-assets.ts"
           popd
 
+      - name: Create CloudFront invalidation
+        env:
+          STAGE_NAME: ${{ inputs.stage_name }}
+        run: |
+          DISTRIBUTION_ID=$(aws cloudformation list-stack-resources --stack-name cms-eregs-${STAGE_NAME}-static-assets | jq -r '.StackResourceSummaries[] | select(.ResourceType == "AWS::CloudFront::Distribution") | .PhysicalResourceId')
+          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"
+
   deploy-alternate-sites:
     runs-on: ubuntu-22.04
     environment: ${{ inputs.environment }}


### PR DESCRIPTION
Resolves [EREGCSC-3020](https://jiraent.cms.gov/browse/EREGCSC-3020)

**Description:**

After deploying, there are sometimes CORS failures for fonts that prevents the font from loading.

**This pull request changes:**

- Modified deploy action to invalidate CloudFront cache on every deploy.

**Steps to manually verify this change:**

1. Green check marks
2. Go to AWS -> CloudFront -> Distributions
3. Select distribution for 3020, click "Invalidations"
4. Verify invalidation exists.

