### PR TITLE
EREGCSC-3195 Remove redundant cache invalidation; extend role expiry time

### DIFF
--- a/.github/workflows/deploy-to-env.yml
+++ b/.github/workflows/deploy-to-env.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy Static Assets
         env:
@@ -147,6 +148,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy ZIP-based Lambdas
         env:
@@ -191,6 +193,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy Text Extractor
         env:
@@ -234,6 +237,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy FR Parser
         env:
@@ -277,6 +281,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy ECFR Parser
         env:
@@ -320,6 +325,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy Parser Launcher
         env:
@@ -363,6 +369,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy MCP Server
         env:
@@ -408,6 +415,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy Site-Lambda
         env:
@@ -501,6 +509,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       # Get test user credentials from AWS Secret Manager
       - name: Get test user credentials

--- a/cdk-eregs/lib/stacks/static-assets-stack.ts
+++ b/cdk-eregs/lib/stacks/static-assets-stack.ts
@@ -174,8 +174,6 @@ export class StaticAssetsStack extends cdk.Stack {
                 s3deploy.Source.asset(path.join(__dirname, '../../../solution/static-assets/regulations')),
             ],
             destinationBucket: assetsBucket,
-            distribution: distribution,
-            distributionPaths: ['/*'],
         });
 
         // =========================


### PR DESCRIPTION
Resolves [EREGCSC-3195](https://jiraent.cms.gov/browse/EREGCSC-3195)

**Description:**

Prod deployments have been intermittently failing on the `deploy-static-assets` step with `ExpiredToken` errors after the CDK was bumped from 2.253.1 to 2.260.0. The root cause may be that the `s3deploy.BucketDeployment` construct was configured with `distributionPaths: ['/*']`, which creates a full CloudFront invalidation inside the CDK deploy's CloudFormation stack update. CloudFront /* invalidations take variable time (2-30+ min), and when slow the OIDC-assumed role credentials expired before the stack update completed.

The CDK version bump (specifically v2.259.0's custom resource Lambda runtime change from nodejs22.x to nodejs24.x) likely changed the bundled AWS SDK version in the BucketDeployment's handler code, making invalidation timing more variable.

**This pull request changes:**

- Removed `distribution` and `distributionPaths: ['/*']` from the BucketDeployment in `cdk-eregs/lib/stacks/static-assets-stack.ts`, so CDK deploy only syncs files to S3 without blocking on CloudFront.
- Added `role-duration-seconds: 7200` to all `configure-aws-credentials` steps.
- Cache invalidation still happens via the existing `Create CloudFront invalidation` workflow step (which uses fresh credentials and doesn't wait for completion), so there's no gap in coverage.

**Steps to manually verify this change:**

1. Green check marks
2. Confirm the deploy-static-assets step completes in ~1-5 minutes (not 20-60+).
3. Verify static assets are served after deployment (cache is invalidated by the workflow step).

