### PR TITLE
EREGCSC-3195-B Increase memory limit to attempt to fix s3 sync step

### DIFF
--- a/.github/workflows/deploy-to-env.yml
+++ b/.github/workflows/deploy-to-env.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy Static Assets
         env:
@@ -147,6 +148,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy ZIP-based Lambdas
         env:
@@ -191,6 +193,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy Text Extractor
         env:
@@ -234,6 +237,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy FR Parser
         env:
@@ -277,6 +281,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy ECFR Parser
         env:
@@ -320,6 +325,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy Parser Launcher
         env:
@@ -363,6 +369,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy MCP Server
         env:
@@ -408,6 +415,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       - name: Deploy Site-Lambda
         env:
@@ -501,6 +509,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws_default_region }}
+          role-duration-seconds: 7200
 
       # Get test user credentials from AWS Secret Manager
       - name: Get test user credentials

--- a/cdk-eregs/lib/stacks/static-assets-stack.ts
+++ b/cdk-eregs/lib/stacks/static-assets-stack.ts
@@ -174,8 +174,6 @@ export class StaticAssetsStack extends cdk.Stack {
                 s3deploy.Source.asset(path.join(__dirname, '../../../solution/static-assets/regulations')),
             ],
             destinationBucket: assetsBucket,
-            distribution: distribution,
-            distributionPaths: ['/*'],
         });
 
         // =========================

--- a/cdk-eregs/lib/stacks/static-assets-stack.ts
+++ b/cdk-eregs/lib/stacks/static-assets-stack.ts
@@ -174,6 +174,8 @@ export class StaticAssetsStack extends cdk.Stack {
                 s3deploy.Source.asset(path.join(__dirname, '../../../solution/static-assets/regulations')),
             ],
             destinationBucket: assetsBucket,
+            memoryLimit: 1769,
+            waitForDistributionInvalidation: false,
         });
 
         // =========================


### PR DESCRIPTION
Resolves [EREGCSC-3195](https://jiraent.cms.gov/browse/EREGCSC-3195)

**Description:**

Deploy to prod still failing. S3 sync lambda log indicates a 15 minute timeout and 126/128MB of available memory used. This attempts to increase the memory so we have the eqivalent of 1 vCPU and over 1GB of memory available.

**This pull request changes:**

- Increase memory available to S3 sync Lambda.

**Steps to manually verify this change:**

1. Green check marks
2. Deploy through to prod and see what happens during static-assets deploy step.

