### PR TITLE
Update securitysync.yml to use new version of action

### DIFF
--- a/.github/workflows/securitysync.yml
+++ b/.github/workflows/securitysync.yml
@@ -29,7 +29,7 @@ jobs:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
       - name: Sync Security Hub and Jira
-        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v2.2
+        uses: Enterprise-CMCS/mac-fc-security-hub-visibility@v2.2.3
         with:
           jira-token: ${{ secrets.JIRA_TOKEN }}
           jira-username: noVal # required variable for package but not for Enterprise Jira


### PR DESCRIPTION
[Edited by Britta to add: this is a routine update to a utility we use. For context about this change, see [https://github.com/Enterprise-CMCS/mac-fc-security-hub-visibility/releases/tag/v2.2.3](https://github.com/Enterprise-CMCS/mac-fc-security-hub-visibility/releases/tag/v2.2.3). ]