### PR TITLE
EREGCSC-3211-B Prune unit tests

### DIFF
--- a/solution/parsers/tests/test_common_auth.py
+++ b/solution/parsers/tests/test_common_auth.py
@@ -1,10 +1,10 @@
-import unittest
 import base64
+import unittest
 from unittest.mock import patch
 
-from common.auth import build_auth_headers, resolve_backend_credentials
 from common.config import ConfigParseError
-from common.auth import BackendCredentials
+
+from common.auth import BackendCredentials, build_auth_headers, resolve_backend_credentials
 
 
 class CommonAuthTests(unittest.TestCase):
@@ -24,21 +24,6 @@ class CommonAuthTests(unittest.TestCase):
             build_auth_headers(BackendCredentials(auth_type="basic", username="", password=""))
 
     def test_resolve_from_env_when_credentials_present(self):
-        with patch.dict(
-            "os.environ",
-            {
-                "EREGS_USERNAME": "env-user",
-                "EREGS_PASSWORD": "env-pass",
-            },
-            clear=True,
-        ):
-            creds = resolve_backend_credentials()
-
-        self.assertEqual(creds.auth_type, "basic")
-        self.assertEqual(creds.username, "env-user")
-        self.assertEqual(creds.password, "env-pass")
-
-    def test_resolve_from_env_without_message_credentials(self):
         with patch.dict(
             "os.environ",
             {

--- a/solution/parsers/tests/test_common_ecfr.py
+++ b/solution/parsers/tests/test_common_ecfr.py
@@ -1,7 +1,6 @@
 import unittest
 
 from common.ecfr import (
-    ECFR_V1_BASE_URL,
     extract_part_numbers,
     identifier_to_part_number,
     parse_part_number,
@@ -11,9 +10,6 @@ from common.eregs_config import EregsConfigError
 
 
 class CommonEcfrTests(unittest.TestCase):
-    def test_base_url_default(self):
-        self.assertEqual(ECFR_V1_BASE_URL, "https://www.ecfr.gov/api/versioner/v1/")
-
     def test_extract_part_numbers_collects_unique_sorted(self):
         payload = {
             "type": "chapter",

--- a/solution/parsers/tests/test_common_launcher.py
+++ b/solution/parsers/tests/test_common_launcher.py
@@ -1,11 +1,8 @@
 import json
 import unittest
-from unittest.mock import Mock
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import boto3
-from moto import mock_aws
-
 from common.launcher import (
     build_launcher_response,
     dispatch_work_units,
@@ -13,6 +10,7 @@ from common.launcher import (
     send_work_units,
     send_work_units_via_http,
 )
+from moto import mock_aws
 
 
 class CommonLauncherTests(unittest.TestCase):
@@ -81,47 +79,46 @@ class CommonLauncherTests(unittest.TestCase):
         self.assertEqual(failures[0]["index"], "0")
         self.assertIn("timed out", failures[0]["reason"])
 
-    @patch("common.launcher.send_work_units_via_http")
-    def test_dispatch_work_units_local_mode(self, mock_send_http):
-        mock_send_http.return_value = (1, [])
-        work_units = [{"config": {"title_number": 42}}]
-
-        with patch.dict(
-            "os.environ",
-            {
-                "PARSER_LOCAL_MODE": "true",
-                "PARSER_WORKER_URL": "http://example.local",
-            },
-            clear=True,
-        ):
-            local_mode, succeeded, failures = dispatch_work_units(work_units)
-
-        self.assertTrue(local_mode)
-        self.assertEqual(succeeded, 1)
-        self.assertEqual(failures, [])
-        mock_send_http.assert_called_once_with("http://example.local", work_units)
-
     @patch("common.launcher.send_work_units")
-    def test_dispatch_work_units_queue_mode(self, mock_send_queue):
+    @patch("common.launcher.send_work_units_via_http")
+    def test_dispatch_work_units_mode_branches(self, mock_send_http, mock_send_queue):
         work_units = [{"config": {"title_number": 42}}]
+        mock_send_http.return_value = (1, [])
 
-        with patch.dict(
-            "os.environ",
-            {
-                "PARSER_LOCAL_MODE": "false",
-                "PARSER_QUEUE_URL": "https://sqs.us-east-1.amazonaws.com/123/parser-queue",
-            },
-            clear=True,
-        ):
-            local_mode, succeeded, failures = dispatch_work_units(work_units)
+        cases = [
+            (
+                "local",
+                {
+                    "PARSER_LOCAL_MODE": "true",
+                    "PARSER_WORKER_URL": "http://example.local",
+                },
+                True,
+                mock_send_http,
+                ("http://example.local", work_units),
+            ),
+            (
+                "queue",
+                {
+                    "PARSER_LOCAL_MODE": "false",
+                    "PARSER_QUEUE_URL": "https://sqs.us-east-1.amazonaws.com/123/parser-queue",
+                },
+                False,
+                mock_send_queue,
+                ("https://sqs.us-east-1.amazonaws.com/123/parser-queue", work_units),
+            ),
+        ]
 
-        self.assertFalse(local_mode)
-        self.assertEqual(succeeded, 1)
-        self.assertEqual(failures, [])
-        mock_send_queue.assert_called_once_with(
-            "https://sqs.us-east-1.amazonaws.com/123/parser-queue",
-            work_units,
-        )
+        for case_name, env, expected_local_mode, expected_mock, expected_args in cases:
+            with self.subTest(case=case_name):
+                mock_send_http.reset_mock()
+                mock_send_queue.reset_mock()
+                with patch.dict("os.environ", env, clear=True):
+                    local_mode, succeeded, failures = dispatch_work_units(work_units)
+
+                self.assertEqual(local_mode, expected_local_mode)
+                self.assertEqual(succeeded, 1)
+                self.assertEqual(failures, [])
+                expected_mock.assert_called_once_with(*expected_args)
 
 
 if __name__ == "__main__":

--- a/solution/parsers/tests/test_ecfr_launcher_client.py
+++ b/solution/parsers/tests/test_ecfr_launcher_client.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock, patch
 import requests
 from common.eregs_client import EregsClientError
 
-from common import eregs_client as _cregs
 from common.auth import BackendCredentials
 
 
@@ -83,41 +82,6 @@ class EcfrLauncherClientTests(unittest.TestCase):
                 credentials=BackendCredentials(auth_type="basic", username="u", password="p"),
                 payload={"success": True, "log": "queued=2 skipped=1"},
             )
-
-    @patch("requests.post")
-    def test_create_ecfr_result_success(self, mock_post):
-        response = Mock()
-        response.raise_for_status.return_value = None
-        response.text = '{"id": 9, "status": "queued"}'
-        response.json.return_value = {"id": 9, "status": "queued"}
-        mock_post.return_value = response
-
-        result = _cregs.create_ecfr_result(
-            api_base_url="https://example.local/v3/",
-            credentials=BackendCredentials(auth_type="basic", username="u", password="p"),
-            payload={"title": 42, "part": 400, "status": "queued", "success": False, "log": ""},
-        )
-
-        self.assertEqual(result["status"], "queued")
-        self.assertTrue(mock_post.call_args.args[0].endswith("/parsers/ecfr/results"))
-
-    @patch("requests.patch")
-    def test_update_ecfr_result_success(self, mock_patch):
-        response = Mock()
-        response.raise_for_status.return_value = None
-        response.text = '{"id": 9, "status": "succeeded"}'
-        response.json.return_value = {"id": 9, "status": "succeeded"}
-        mock_patch.return_value = response
-
-        result = _cregs.update_ecfr_result(
-            api_base_url="https://example.local/v3/",
-            credentials=BackendCredentials(auth_type="basic", username="u", password="p"),
-            result_id=9,
-            payload={"status": "succeeded", "log": ""},
-        )
-
-        self.assertEqual(result["status"], "succeeded")
-        self.assertTrue(mock_patch.call_args.args[0].endswith("/parsers/ecfr/results/9"))
 
 
 if __name__ == "__main__":

--- a/solution/parsers/tests/test_ecfr_worker_app.py
+++ b/solution/parsers/tests/test_ecfr_worker_app.py
@@ -5,7 +5,10 @@ import types
 import unittest
 from importlib import util
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
+
+from common.auth import BackendCredentials
 
 
 def _load_module():
@@ -27,33 +30,20 @@ def _load_module():
 
 
 _module = _load_module()
-config_spec = util.spec_from_file_location(
-    "ecfr_worker_pkg.config",
-    Path(__file__).resolve().parent.parent / "ecfr-worker" / "config.py",
-)
-if config_spec is None or config_spec.loader is None:
-    raise RuntimeError("Unable to load ecfr worker config module")
-_config_module = util.module_from_spec(config_spec)
-sys.modules["ecfr_worker_pkg.config"] = _config_module
-config_spec.loader.exec_module(_config_module)
 
 
 class EcfrWorkerAppTests(unittest.TestCase):
     def _build_parsed_config(self, *, upload_reg_text: bool, upload_locations: bool):
-        with patch.dict(os.environ, {"EREGS_USERNAME": "env-user", "EREGS_PASSWORD": "env-pass"}, clear=True):
-            return _config_module.parse_config(
-                {
-                    "config": {
-                        "parser_result_id": 7,
-                        "title_number": 42,
-                        "part_number": 400,
-                        "effective_date": "2025-01-01",
-                        "upload_reg_text": upload_reg_text,
-                        "upload_locations": upload_locations,
-                        "log_level": "info",
-                    }
-                }
-            )
+        return SimpleNamespace(
+            parser_result_id=7,
+            title_number=42,
+            part_number=400,
+            effective_date="2025-01-01",
+            upload_reg_text=upload_reg_text,
+            upload_locations=upload_locations,
+            log_level="INFO",
+            credentials=BackendCredentials(auth_type="basic", username="u", password="p"),
+        )
 
     def test_handler_updates_result_to_succeeded(self):
         parsed_config = self._build_parsed_config(upload_reg_text=True, upload_locations=True)

--- a/solution/parsers/tests/test_fr_launcher_app.py
+++ b/solution/parsers/tests/test_fr_launcher_app.py
@@ -56,7 +56,7 @@ class FrLauncherAppTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "loglevel must be one of"):
             _module.resolve_parser_log_level({"loglevel": "verbose"})
 
-    def test_build_work_units_dispatches_one_work_unit_per_doc(self):
+    def test_build_work_units_skip_disabled_queues_all_docs(self):
         targets = [_module.FrTarget(title_number=42, part_number=400)]
         docs = [_doc("2026-0001"), _doc("2026-0002")]
 
@@ -74,10 +74,9 @@ class FrLauncherAppTests(unittest.TestCase):
                 fr_api_base_url="https://www.federalregister.gov",
             )
 
-        self.assertEqual(len(work_units), 2)
+        self.assertEqual([w["config"]["document_number"] for w in work_units], ["2026-0001", "2026-0002"])
         self.assertEqual(skipped_count, 0)
         cfg = work_units[0]["config"]
-        self.assertEqual(cfg["document_number"], "2026-0001")
         self.assertEqual(cfg["title"], 42)
         self.assertEqual(cfg["part"], "400")
         self.assertEqual(cfg["log_level"], "INFO")
@@ -104,26 +103,6 @@ class FrLauncherAppTests(unittest.TestCase):
 
         self.assertEqual([w["config"]["document_number"] for w in work_units], ["2026-0001", "2026-0003"])
         self.assertEqual(skipped_count, 1)
-
-    def test_build_work_units_processes_all_docs_when_skip_disabled(self):
-        targets = [_module.FrTarget(title_number=42, part_number=400)]
-        docs = [_doc("2026-0001"), _doc("2026-0002")]
-
-        with patch.object(_module, "expand_fr_targets", return_value=targets), patch.object(
-            _module, "_resolve_skip_fr_documents", return_value=False
-        ), patch.object(
-            _module, "fetch_documents", return_value=docs
-        ):
-            work_units, _ = _module._build_work_units(
-                parser_config={},
-                api_base_url="https://example.local/v3/",
-                credentials=BackendCredentials(auth_type="basic", username="u", password="p"),
-                parser_log_level="INFO",
-                ecfr_api_base_url="https://ecfr.example/api/versioner/v1/",
-                fr_api_base_url="https://www.federalregister.gov",
-            )
-
-        self.assertEqual(len(work_units), 2)
 
     def test_handler_dispatches_and_records_launcher_result(self):
         with patch.dict(

--- a/solution/parsers/tests/test_fr_worker_app.py
+++ b/solution/parsers/tests/test_fr_worker_app.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 from importlib import util
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from common.auth import BackendCredentials
@@ -39,30 +40,23 @@ _module = _load_module("app", "fr_worker_pkg", WORKER_DIR, "app.py")
 
 
 def _config(**overrides):
-    base = dict(
-        document_number="2026-12345",
-        title=42,
-        part="400",
-        description="A document title",
-        name="90 FR 1",
-        doc_type="Rule",
-        url="https://example/x",
-        date="2026-01-01",
-        docket_numbers=["ABC-1"],
-        raw_text_url="https://example/x.txt",
-        full_text_xml_url="https://example/x.xml",
-        log_level="DEBUG",
-        credentials=BackendCredentials(auth_type="basic", username="u", password="p"),
-    )
+    base = {
+        "document_number": "2026-12345",
+        "title": 42,
+        "part": "400",
+        "description": "A document title",
+        "name": "90 FR 1",
+        "doc_type": "Rule",
+        "url": "https://example/x",
+        "date": "2026-01-01",
+        "docket_numbers": ["ABC-1"],
+        "raw_text_url": "https://example/x.txt",
+        "full_text_xml_url": "https://example/x.xml",
+        "log_level": "DEBUG",
+        "credentials": BackendCredentials(auth_type="basic", username="u", password="p"),
+    }
     base.update({k: v for k, v in overrides.items() if v is not None})
-    spec = util.spec_from_file_location(
-        "fr_worker_pkg.config",
-        WORKER_DIR / "config.py",
-    )
-    cfg_mod = util.module_from_spec(spec)
-    sys.modules["fr_worker_pkg.config"] = cfg_mod
-    spec.loader.exec_module(cfg_mod)
-    return cfg_mod.FrDocumentConfig(**base)
+    return SimpleNamespace(**base)
 
 
 class FrWorkerAppTests(unittest.TestCase):

--- a/solution/parsers/tests/test_fr_worker_config.py
+++ b/solution/parsers/tests/test_fr_worker_config.py
@@ -62,13 +62,6 @@ class FrWorkerConfigTests(unittest.TestCase):
         self.assertEqual(parsed.log_level, "WARNING")
         self.assertEqual(parsed.credentials, BackendCredentials("basic", "env-user", "env-pass", None))
 
-    def test_parse_config_requires_document_number_and_log_level(self):
-        with patch.dict("os.environ", {"EREGS_USERNAME": "env-user", "EREGS_PASSWORD": "env-pass"}, clear=True):
-            parsed = parse_config(_payload())
-
-        self.assertEqual(parsed.document_number, "2026-12345")
-        self.assertEqual(parsed.log_level, "WARNING")
-
     def test_parse_config_rejects_invalid_log_level(self):
         with patch.dict("os.environ", {"EREGS_USERNAME": "env-user", "EREGS_PASSWORD": "env-pass"}, clear=True):
             with self.assertRaisesRegex(ConfigParseError, "loglevel must be one of"):

--- a/solution/parsers/tests/test_fr_worker_sections.py
+++ b/solution/parsers/tests/test_fr_worker_sections.py
@@ -54,48 +54,51 @@ class FetchFullTextSectionsTests(unittest.TestCase):
             {"438": "42", "440": "42", "457": "42", "460": "42", "41": "45"},
         )
 
-    def test_valid_section_range(self):
-        xml = """
-            <PRORULE>
-                <PREAMB>
-                    <CFR>42 CFR Parts 438, 440, 457, and 460</CFR>
-                    <CFR>45 CFR Parts 41.</CFR>
-                    <CFR>47 CFR Parts 123</CFR>
-                </PREAMB>
+    def test_section_and_range_variants(self):
+        cases = [
+            (
+                "single-range",
+                """
                 <SUPLINF>
                     <SECTION><SECTNO>§\u2009438.502-438.700 </SECTNO><SUBJECT>Definitions.</SUBJECT></SECTION>
                 </SUPLINF>
-            </PRORULE>
-        """
-        with patch.object(_module, "requests") as mock_requests:
-            mock_requests.get.return_value = self._response(xml)
-            sections, ranges, part_map = _module.fetch_full_text_sections("https://example/x.xml", {"42", "45"})
-
-        self.assertEqual(sections, [])
-        self.assertEqual(ranges, ["438.502-438.700"])
-        self.assertEqual(part_map["438"], "42")
-
-    def test_sections_and_range(self):
-        xml = """
-            <PRORULE>
-                <PREAMB>
-                    <CFR>42 CFR Parts 438, 440, 457, and 460</CFR>
-                    <CFR>45 CFR Parts 41.</CFR>
-                    <CFR>47 CFR Parts 123</CFR>
-                </PREAMB>
+                """,
+                [],
+                ["438.502-438.700"],
+            ),
+            (
+                "mixed-sections-and-range",
+                """
                 <SUPLINF>
                     <SECTION><SECTNO>§\u2009438.502 </SECTNO></SECTION>
                     <SECTION><SECTNO>§\u200941.118 </SECTNO></SECTION>
                     <SECTION><SECTNO>§\u2009438.502-438.700 </SECTNO></SECTION>
                 </SUPLINF>
-            </PRORULE>
-        """
-        with patch.object(_module, "requests") as mock_requests:
-            mock_requests.get.return_value = self._response(xml)
-            sections, ranges, _ = _module.fetch_full_text_sections("https://example/x.xml", {"42", "45"})
+                """,
+                ["438.502", "41.118"],
+                ["438.502-438.700"],
+            ),
+        ]
 
-        self.assertEqual(sections, ["438.502", "41.118"])
-        self.assertEqual(ranges, ["438.502-438.700"])
+        for case_name, suplinf_body, expected_sections, expected_ranges in cases:
+            with self.subTest(case=case_name):
+                xml = f"""
+                    <PRORULE>
+                        <PREAMB>
+                            <CFR>42 CFR Parts 438, 440, 457, and 460</CFR>
+                            <CFR>45 CFR Parts 41.</CFR>
+                            <CFR>47 CFR Parts 123</CFR>
+                        </PREAMB>
+                        {suplinf_body}
+                    </PRORULE>
+                """
+                with patch.object(_module, "requests") as mock_requests:
+                    mock_requests.get.return_value = self._response(xml)
+                    sections, ranges, part_map = _module.fetch_full_text_sections("https://example/x.xml", {"42", "45"})
+
+                self.assertEqual(sections, expected_sections)
+                self.assertEqual(ranges, expected_ranges)
+                self.assertEqual(part_map["438"], "42")
 
     def test_bad_xml_raises(self):
         xml = """


### PR DESCRIPTION
Resolves [EREGCSC-3211](https://jiraent.cms.gov/browse/EREGCSC-3211)

**Description:**

Now that the bulk of parser work is done, this PR revisits the existing unit tests and prunes away ones that have redundant coverage, consolidates overlapping scenarios, and reducing coupling to implementation details in worker handler tests. The goal is to keep high-signal contract/parity checks while reducing churn from future minor refactors and fixes.

**This pull request changes:**

- Removed duplicate/low-value tests:
    - solution/parsers/tests/test_common_auth.py
    - solution/parsers/tests/test_common_ecfr.py
    - solution/parsers/tests/test_fr_worker_config.py
- Consolidated overlapping launcher behavior checks:
    - solution/parsers/tests/test_fr_launcher_app.py
- Parametrized overlapping section/range extraction scenarios:
    - solution/parsers/tests/test_fr_worker_sections.py
- Removed duplicated shared-client assertions already covered elsewhere:
    - solution/parsers/tests/test_ecfr_launcher_client.py
- Merged dispatch mode branch tests into one clearer test:
    - solution/parsers/tests/test_common_launcher.py
- Refactored worker handler tests to use minimal fixtures (SimpleNamespace) instead of config module loading/parse paths:
    - solution/parsers/tests/test_ecfr_worker_app.py
    - solution/parsers/tests/test_fr_worker_app.py

**Steps to manually verify this change:**

1. Green check marks
2. Run parser unit tests: `cd solution && make parsers.test`.

